### PR TITLE
Add clarity to npx compatibility

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -58,6 +58,10 @@ If you're using `postcss-import` (or a tool that uses it under the hood, such as
   </h2>
 </div>
 
+@component('_partials.tip-bad')
+Won't work if tailwindcss is installed using yarn.
+@endcomponent
+
 If you'd like to customize your Tailwind installation, you can generate a config file for your project using the Tailwind CLI utility included when you install the `tailwindcss` npm package:
 
 ```bash


### PR DESCRIPTION
Tailwind needs to be installed via npm otherwise npx command fails.