### PR TITLE
Add caveat to the use of extend and update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Tailwind uses the [Jigsaw](http://jigsaw.tighten.co/) static site generator for its documentation. Here is how you can generate the documentation locally:
 
-1. Go to your Tailwind folder
+1. Go to your Tailwind docs folder
 
     ```sh
     cd docs
@@ -13,7 +13,7 @@ Tailwind uses the [Jigsaw](http://jigsaw.tighten.co/) static site generator for 
 2. Install JS dependencies
 
     ```sh
-    npm install
+    yarn
     ```
 
 3. Install PHP dependencies for docs (requires Composer: https://getcomposer.org)
@@ -25,7 +25,7 @@ Tailwind uses the [Jigsaw](http://jigsaw.tighten.co/) static site generator for 
 4. Run the build to generate the static site
 
     ```sh
-    npm run dev
+    yarn dev
     ```
 
 5. View the static site at `/build_local`, or you can run the Jigsaw server:

--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -243,6 +243,24 @@ module.exports = {
 }
 ```
 
+There's one important caveat though, `extend` only works one level deep, so something like the example below won't work.
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        blue: {
+          // this won't work, extend only goes one level deep
+          brand: '#0096D6',
+        }
+      }
+    }
+  }
+}
+```
+
 ### Referencing other values
 
 If you need to reference another value in your theme, you can do so by providing a closure instead of a static value. The closure will receive a `theme()` function that you can use to look up other values in your theme using dot notation.


### PR DESCRIPTION
### This PR:

1. **Adds a caveat and an example of what won't work when using `extend`, in the theme page**
**Reasoning:**  while helping people in the discord I noticed some developers running into this issue, explaining it in the docs would help a lot.

2. **Updates README to reference `yarn` instead of `npm`.**
**Reasoning:** when setting up the docs project to make this PR I followed the instructions in the README and the console was complaining about a generated `package-lock.json` since the project already has a `yarn.lock` file.