### PR TITLE
Add note for loading Inter font

### DIFF
--- a/source/docs/font-family.blade.md
+++ b/source/docs/font-family.blade.md
@@ -32,6 +32,8 @@ Use `.font-sans` to apply a web safe sans-serif font family:
 </p>
 @endcomponent
 
+Note that the [Inter](https://rsms.me/inter/) font files are not included with Tailwind. It is recommended to use the cdn link [here](https://rsms.me/inter/inter.css).
+
 ### Serif
 
 Use `.font-serif` to apply a web safe serif font family:


### PR DESCRIPTION
This PR adds a note about loading `Inter` from the cdn as it will not be included in Tailwind V2 per [#1275](https://github.com/tailwindcss/tailwindcss/pull/1275).

This PR does not load `Inter` as it will not be added to the `sans` font stack until V2. Once V2 is ready to be released, we can add the cdn link to load the font for the example.