### PR TITLE
Add autofocus to search input field

### DIFF
--- a/source/_layouts/homepage.blade.php
+++ b/source/_layouts/homepage.blade.php
@@ -72,7 +72,7 @@
                 {{-- Search section --}}
                 <div class="w-full lg:px-6 lg:w-3/4 xl:px-12">
                   <div class="relative">
-                    <input id="docsearch" class="transition bg-white shadow-md focus:outline-0 border border-transparent placeholder-gray-600 rounded-lg py-2 pr-4 pl-10 block w-full appearance-none leading-normal" type="text" placeholder="Search the docs (Press &quot;/&quot; to focus)">
+                    <input id="docsearch" class="transition bg-white shadow-md focus:outline-0 border border-transparent placeholder-gray-600 rounded-lg py-2 pr-4 pl-10 block w-full appearance-none leading-normal" type="text" placeholder="Search the docs (Press &quot;/&quot; to focus)" autofocus>
                     <div class="pointer-events-none absolute inset-y-0 left-0 pl-4 flex items-center">
                       <svg class="fill-current pointer-events-none text-gray-600 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"/></svg>
                     </div>


### PR DESCRIPTION
This PR adds autofocus to the search bar on the main page of tailwindcss (not on subpages). 

I think there might be a high interest in searching the docs when visiting the main page. In addition to that, this change won't bother other users who are not interested in exploring the docs.

The search fields of the subpage (Documentation, Components, ...) won't be autofocused because the user interests on these pages should be slightly different.