### PR TITLE
Update compatible version of node for regex lookbehind assertions

### DIFF
--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -135,7 +135,7 @@ It also uses a negative lookbehind to make sure that if a string ends in `:`, th
 <div :class="{ hidden: !isOpen, ... }"><!-- ... --></div>
 ```
 
-It's important to note that because of the negative lookbehind in this regex, it's only compatible with Node.js 9.11.2 and above. If you need to use an older version of Node.js to build your assets, you can use this regular expression instead:
+It's important to note that because of the negative lookbehind in this regex, it's only compatible with Node.js 8.10.0 and above. If you need to use an older version of Node.js to build your assets, you can use this regular expression instead:
 
 
 ```diff


### PR DESCRIPTION
[node.green](https://node.green/#ES2018-features--RegExp-Lookbehind-Assertions) lists regex lookbehind assertions under 9.11.2 but says that version has identical results going back to 8.10.0.

I wrote a script to confirm the test from node.green and the specific case from the Tailwind docs and ran it with nvm.

```js
function nodeGreenTest (){
  try {
    return /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') && !/(?<=a)b/.test('b');
  } catch (e) {
    return e.message
  }
}

function tailwindTest () {
  try {
    var result = '<div :class="{ hidden: !isOpen, ... }"><!-- ... --></div>'.match(/[\w-/:]+(?<!:)/g)
    return result && result.indexOf('hidden') > -1
  } catch (e) {
    return e.message
  }
}

console.log(process.version)
console.log(nodeGreenTest())
console.log(tailwindTest())
```

**8.9.4**
```
> nvm use 8.9.4 && node index.js
v8.9.4
Invalid regular expression: /(?<=a)b/: Invalid group
Invalid regular expression: /[\w-/:]+(?<!:)/: Invalid group
```

**8.10.0**
```
> nvm use 8.10.0 && node index.js
v8.10.0
true
true
```