### PR TITLE
Ordering Default color palette to mirror Tailwind UI

### DIFF
--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -319,6 +319,12 @@ Tailwind includes a generous palette of great-looking, well-balanced colors that
 ])
 
 @include('_partials.color-palette', [
+  'colorName' => 'Pink',
+  'color' => 'pink',
+  'breakpoint' => '400',
+])
+
+@include('_partials.color-palette', [
   'colorName' => 'Red',
   'color' => 'red',
   'breakpoint' => '500',
@@ -363,12 +369,6 @@ Tailwind includes a generous palette of great-looking, well-balanced colors that
 @include('_partials.color-palette', [
   'colorName' => 'Purple',
   'color' => 'purple',
-  'breakpoint' => '400',
-])
-
-@include('_partials.color-palette', [
-  'colorName' => 'Pink',
-  'color' => 'pink',
   'breakpoint' => '400',
 ])
 </div>


### PR DESCRIPTION
This will be helpful for people who may want to compare the palettes or find overrides. I wasted some time figuring out why my overrides weren't working correctly between TailwindCSS and Tailwind UI — when I realized both documentations did not present the colors in the same order!