### PR TITLE
Replaced focus:outline-0 with focus:outline-none on the search bar

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -66,7 +66,7 @@
             {{-- Search section --}}
             <div class="w-full lg:px-6 xl:w-3/4 xl:px-12">
               <div class="relative">
-                <input id="docsearch" class="transition-colors duration-100 ease-in-out focus:outline-0 border border-transparent focus:bg-white focus:border-gray-300 placeholder-gray-600 rounded-lg bg-gray-200 py-2 pr-4 pl-10 block w-full appearance-none leading-normal" type="text" placeholder="Search the docs (Press &quot;/&quot; to focus)">
+                <input id="docsearch" class="transition-colors duration-100 ease-in-out focus:outline-none border border-transparent focus:bg-white focus:border-gray-300 placeholder-gray-600 rounded-lg bg-gray-200 py-2 pr-4 pl-10 block w-full appearance-none leading-normal" type="text" placeholder="Search the docs (Press &quot;/&quot; to focus)">
                 <div class="pointer-events-none absolute inset-y-0 left-0 pl-4 flex items-center">
                   <svg class="fill-current pointer-events-none text-gray-600 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"/></svg>
                 </div>


### PR DESCRIPTION
Replaced `focus:outline-0` with `focus:outline-none` — `focus:outline-0` doesn’t actually do anything (nor is it a standard Tailwind CSS class). 👍