### PR TITLE
Add note for default key when using theme function

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -48,7 +48,7 @@ module.exports = {
 
 Like many other places in Tailwind, the `default` key is special and means "no modifier", so this configuration would generate classes like `.text-indigo-lighter`, `.text-indigo`, and `.text-indigo-dark`.
 
-Note that you need to use dot notation to access nested colors when using the `theme()` function — the colors are only converted to dash-case for the actual CSS class names.
+Note that you need to use dot notation to access nested colors when using the `theme()` function — the colors are only converted to dash-case for the actual CSS class names. The `default` key also needs to be specified when accessed via the `theme()` function: `theme('colors.indigo.default')`.
 
 <TipBad>Don't use the dash syntax to access nested color values with theme()</TipBad>
 


### PR DESCRIPTION
I was a bit confused that the `default` key is special for class generation but not for theme function so I think a small note here could be useful