### PR TITLE
Fix `height` key in theme reference

### DIFF
--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -408,7 +408,7 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `gridRow` | Values for the `grid-row` property |
 | `gridRowStart` | Values for the `grid-row-start` property |
 | `gridRowEnd` | Values for the `grid-row-end` property |
-| `height`` | Values for the `height` property |
+| `height` | Values for the `height` property |
 | `inset` | Values for the `top`, `right`, `bottom`, and `left` properties |
 | `letterSpacing` | Values for the `letter-spacing` property |
 | `lineHeight` | Values for the `line-height` property |


### PR DESCRIPTION
An extra "`" go into the `width` row in the configuration reference, which affects the layout, so this removes it.

<img width="714" alt="Screenshot 2020-06-04 at 19 24 18" src="https://user-images.githubusercontent.com/795488/83790772-fdb5a080-a698-11ea-85c3-75b478e6eb88.png">
