### PR TITLE
Fix `2xl` & `3xl` quotes and update other `boxShadow` values

### DIFF
--- a/source/docs/box-shadow.blade.md
+++ b/source/docs/box-shadow.blade.md
@@ -142,16 +142,18 @@ By default Tailwind provides three drop shadow utilities, one inner shadow utili
 If a `default` shadow is provided, it will be used for the non-suffixed `.shadow` utility. Any other keys will be used as suffixes, for example the key `'2'` will create a corresponding `.shadow-2` utility.
 
 @component('_partials.customized-config', ['key' => 'theme.boxShadow'])
-  default: '0 1px 3px 0 rgba(0, 0, 0, .1), 0 1px 2px 0 rgba(0, 0, 0, .06)',
-  md: '0 4px 6px -1px rgba(0, 0, 0, .1), 0 2px 4px -1px rgba(0, 0, 0, .06)',
-  lg: '0 10px 15px -3px rgba(0, 0, 0, .1), 0 4px 6px -2px rgba(0, 0, 0, .05)',
-  xl: '0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04)',
-  2xl: '0 25px 50px -12px rgba(0, 0, 0, .25)',
-+ 3xl: '0 35px 60px -15px rgba(0, 0, 0, .3)',
+  xs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
+  sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+  default: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+  md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+  lg: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+  xl: '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+  '2xl': '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
++ '3xl': '0 35px 60px -15px rgba(0, 0, 0, 0.3)',
   inner: 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
 - outline: '0 0 0 3px rgba(66, 153, 225, 0.5)',
 + focus: '0 0 0 3px rgba(66, 153, 225, 0.5)',
-  'none': 'none',
+  none: 'none',
 @endcomponent
 
 @include('_partials.variants-and-disabling', [


### PR DESCRIPTION
The `2xl` and `3xl` keys are invalid. I've also updated the values to the latest values in Tailwind: https://github.com/tailwindcss/tailwindcss/blob/a05233281623739af7ad1ceaede6b0bf82a900db/stubs/defaultConfig.stub.js#L191-L202