### PR TITLE
Rename 'cols' to 'rows' in Row - Responsive

### DIFF
--- a/source/docs/grid-template-rows.blade.md
+++ b/source/docs/grid-template-rows.blade.md
@@ -41,7 +41,7 @@ Use the `grid-rows-{n}` utilities to create grids with _n_ equally sized rows.
 
 ## Responsive
 
-To control the columns of a grid at a specific breakpoint, add a `{screen}:` prefix to any existing grid-template-columns utility. For example, use `md:grid-cols-6` to apply the `grid-cols-6` utility at only medium screen sizes and above.
+To control the rows of a grid at a specific breakpoint, add a `{screen}:` prefix to any existing grid-template-rows utility. For example, use `md:grid-rows-6` to apply the `grid-rows-6` utility at only medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 


### PR DESCRIPTION
The `Responsive` section, in the Grid Template Rows docs, was talking about columns when it should be talking about rows.