### PR TITLE
Deleting extra class

### DIFF
--- a/source/components/forms.blade.md
+++ b/source/components/forms.blade.md
@@ -150,7 +150,7 @@ Here are a few examples to help you get an idea of how to build components like 
 
 @component('_partials.code-sample', ['class' => 'flex justify-center p-8'])
 <form class="w-full max-w-sm">
-  <div class="flex items-center border-b border-b-2 border-teal-500 py-2">
+  <div class="flex items-center border-b border-teal-500 py-2">
     <input class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none" type="text" placeholder="Jane Doe" aria-label="Full name">
     <button class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded" type="button">
       Sign Up


### PR DESCRIPTION
Hi! I noticed an extra class in the forms documentation, this PR removed the extra one.

From this `flex items-center border-b border-b-2 border-teal-500 py-2`

To this `flex items-center border-b border-teal-500 py-2`

