### PR TITLE
Remove duplicated `height` on "Theme Configuration"

### DIFF
--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -397,7 +397,6 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `fontFamily` | Values for the `font-family` property |
 | `fontSize` | Values for the `font-size` property |
 | `fontWeight` | Values for the `font-weight` property |
-| `height` | Values for the `height` property |
 | `inset` | Values for the `inset` property |
 | `gap` | Values for the `gap` property |
 | `gridTemplateColumns` | Values for the `grid-template-columns` property |
@@ -408,7 +407,7 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `gridRow` | Values for the `grid-row` property |
 | `gridRowStart` | Values for the `grid-row-start` property |
 | `gridRowEnd` | Values for the `grid-row-end` property |
-| `height`` | Values for the `height` property |
+| `height` | Values for the `height` property |
 | `inset` | Values for the `top`, `right`, `bottom`, and `left` properties |
 | `letterSpacing` | Values for the `letter-spacing` property |
 | `lineHeight` | Values for the `line-height` property |


### PR DESCRIPTION
`height` is duplicated on [Theme Configuration > Configuration reference](https://tailwindcss.com/docs/theme/#configuration-reference)

![Screen Shot 2020-07-10 at 08 01 45](https://user-images.githubusercontent.com/741969/87147852-bfa53100-c283-11ea-9a21-cd1e8e82283e.png)
