### PR TITLE
Update file size for CDN build

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -340,6 +340,6 @@ To pull in Tailwind for quick demos or just giving the framework a spin, grab th
 <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
 ```
 
-Note that while the CDN build is large *(27kb compressed, 348kb raw)*, **it's not representative of the sizes you see when including Tailwind as part of your build process**.
+Note that while the CDN build is large *(93kb compressed, 1328kb raw)*, **it's not representative of the sizes you see when including Tailwind as part of your build process**.
 
 Sites that follow our [best practices](/docs/controlling-file-size) are almost always under 10kb compressed. For example, [Firefox Send](https://send.firefox.com/) is built with Tailwind and their CSS is under 4kb compressed and minified.


### PR DESCRIPTION
Fixes #456

The commit contains the exact filesize that the Firefox dev tools give me when I create a basic `index.html` file and include the official TailwindCSS CDN link, and check the filesize with the developer tools.

Steps to reproduce my numbers:
1. Make a basic `index.html` file with standard HTML boilerplate.
2. Add TailwindCSS CDN link in the `<head>` section.
3. Open `index.html` file in Firefox.
4. Open developer tools in Firefox, go to the Network tab.
5. Force reload of assets with CTRL + F5.
6. Check file size for Tailwind CSS.

---

There's also a somewhat related pull-request, that one wants to update the Brotli file size in the Controlling File Size docs.
#429