### PR TITLE
fix the typo in the code section

### DIFF
--- a/source/docs/pseudo-class-variants.blade.md
+++ b/source/docs/pseudo-class-variants.blade.md
@@ -301,7 +301,7 @@ You can control whether `odd` variants are enabled for a utility in the `variant
 module.exports = {
   // ...
   variants: {
-    borderWidth: ['responsive', 'odd', 'hover', 'focus'],
+    backgroundColor: ['responsive', 'odd', 'hover', 'focus'],
   },
 }
 ```
@@ -340,7 +340,7 @@ You can control whether `even` variants are enabled for a utility in the `varian
 module.exports = {
   // ...
   variants: {
-    borderWidth: ['responsive', 'even', 'hover', 'focus'],
+    backgroundColor: ['responsive', 'even', 'hover', 'focus'],
   },
 }
 ```


### PR DESCRIPTION
There is a typo in the `odd` and `even` js code
I changed `borderWidth` to `backgroundColor`