### PR TITLE
Wrap object keys starting with number in quotes

### DIFF
--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -149,11 +149,11 @@ If you also want to provide a default letter-spacing value for a font size, you 
 module.exports = {
   theme: {
     fontSize: {
-      2xl: ['24px', {
+      '2xl': ['24px', {
         letterSpacing: '-0.01em',
       }],
       // Or with a default line-height as well
-      3xl: ['32px', {
+      '3xl': ['32px', {
         letterSpacing: '-0.02em',
         lineHeight: '40px',
       }],


### PR DESCRIPTION
[very minor]

JS needs object keys starting with numbers to be wrapped in quotes. You can see that the syntax highlighting marks it in red on the site:

https://i.imgur.com/FSjQxva.png