### PR TITLE
typo "to removing the now"

### DIFF
--- a/src/pages/docs/upcoming-changes.mdx
+++ b/src/pages/docs/upcoming-changes.mdx
@@ -15,7 +15,7 @@ The following breaking changes are currently available in Tailwind behind flags.
 
 Tailwind v1.7.0 introduced new `gap-x-{n}` and `gap-y-{n}` utilities to replace the existing `col-gap-{n}` and `row-gap-{n}` utilities. We currently include both by default, but the old utilities will be removed in v2.0.
 
-To opt-in to removing the now, use the `removeDeprecatedGapUtilities` flag:
+To opt-in to removing them now, use the `removeDeprecatedGapUtilities` flag:
 
 ```js
 // tailwind.config.js


### PR DESCRIPTION
"to removing the now" should be "to removing them now" I think.