### PR TITLE
Fix invalid Javascript in the variant defaults snippet

### DIFF
--- a/src/utils/defaultVariantsConfig.js
+++ b/src/utils/defaultVariantsConfig.js
@@ -15,7 +15,7 @@ module.exports = {
             inlineCharacterLimit: Infinity,
           })}`
       )
-      .join('\n    ')}
+      .join(',\n    ')}
   }
 }`,
   Prism.languages.js,


### PR DESCRIPTION
The [default variants section of the documentation](https://tailwindcss.com/docs/configuring-variants#default-variants-reference) is invalid JS since the object members don't have commas between them. It adds an extra step when copying defaults into your own config to customize them. This PR adds the commas.

Thanks for Tailwind 🙌 