### PR TITLE
Replace unit of measurement K with KiB (kibibyte)

### DIFF
--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -9,7 +9,7 @@ const brotliSize = require('brotli-size')
 const CleanCSS = require('clean-css')
 const { loopWhile } = require('deasync')
 
-const convertToKB = (bytes) => (bytes / 1024).toFixed(1) + 'K'
+const convertToKB = (bytes) => (bytes / 1024).toFixed(1) + 'KiB'
 
 module.exports = () => {
   const stats = {}


### PR DESCRIPTION
## Changes:

- Replace user facing unit of measurement K with KiB (kibibyte)

## Context:

I think we should use kibibytes here, as we're talking about multiples of 1024 bits, we even do a conversion in the utility that is explicit about the unit used: ``const convertToKB = (bytes) => (bytes / 1024).toFixed(1) + 'K'``

Using the standard kibibyte unit removes the the ambiguity of the K unit. Because is K = 1000 bytes, or is K = 1024 bytes?
Using kilobytes instead of kibibytes is still ambiguous, as a kilobyte has historically been 1000 bytes or 1024 bytes.

[Wikipedia page on the Kibibyte](https://en.wikipedia.org/wiki/Kibibyte)