### PR TITLE
Divide by 1000 and use kB as unit of measurement

### DIFF
--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -9,7 +9,7 @@ const brotliSize = require('brotli-size')
 const CleanCSS = require('clean-css')
 const { loopWhile } = require('deasync')
 
-const convertToKB = (bytes) => (bytes / 1024).toFixed(1) + 'K'
+const convertToKB = (bytes) => (bytes / 1000).toFixed(1) + 'kB'
 
 module.exports = () => {
   const stats = {}


### PR DESCRIPTION
## Changes:

- Replace user facing unit of measurement K with kB (1000 bytes = 1 kB)
- Use 1000 bytes to a kilobyte for the `convertToKB` function

## Context:

Implements the change that @adamwathan wanted at the end of the discussion at #509.

Supersedes #509