### PR TITLE
Add tailwindcss init -p documentation

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -87,7 +87,7 @@ module.exports = {
 }
 ```
 
-#### <Heading badge="v1.7.4+">Generating a basic postcss.config.js</Heading>
+#### <Heading badge="v1.7.4+">Generating a basic PostCSS config file</Heading>
 
 You can also generate a basic `postcss.config.js` file for your project using the Tailwind CLI utility:
 ```bash

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -87,6 +87,13 @@ module.exports = {
 }
 ```
 
+#### <Heading badge="v1.7.4+">Generating a basic postcss.config.js</Heading>
+
+You can also generate a basic `postcss.config.js` file for your project using the Tailwind CLI utility:
+```bash
+npx tailwindcss init -p
+```
+
 We've included more specific instructions for a few popular tools below, but for instructions on getting started with PostCSS in general, see the [PostCSS documentation](https://github.com/postcss/postcss#usage).
 
 ### Using Tailwind CLI


### PR DESCRIPTION
**EDIT:**

I've changed the pull request so that it includes a heading and version badge, I've also rebased this branch so it's fully up to date with current `master`. I've also decreased the heading level from `h3` to a `h4`.

---

## Changes:

- Add text documenting the `npx tailwindcss init -p` option that scaffolds a basic PostCSS config file
- Use heading + badge with Tailwind version

## Context:
[TailwindCSS 1.7.4 ](https://github.com/tailwindlabs/tailwindcss/releases/tag/v1.7.4) has added the `npx tailwindcss init -p` option to scaffold a basic PostCSS config file. This is not yet documented somewhere on the website, the string `init -p` gives no hits on the current `master`.

I'm not sure what the best place for this change is... Should it be in the [Installation.mdx](https://github.com/tailwindlabs/tailwindcss.com/blob/master/src/pages/docs/installation.mdx) where I put it now? Or should it go in the [creating-your-configuration section of configuration.mdx](https://github.com/tailwindlabs/tailwindcss.com/blob/master/src/pages/docs/configuration.mdx#creating-your-configuration-file)?

I'll of course move the section to where the reviewer wants it. :smile: 