### PR TITLE
Add link to PurgeCSS options reference in docs

### DIFF
--- a/src/pages/docs/controlling-file-size.mdx
+++ b/src/pages/docs/controlling-file-size.mdx
@@ -172,6 +172,8 @@ module.exports = {
 }
 ```
 
+A list of available options can be found in the [PurgeCSS documentation](https://purgecss.com/configuration.html#options).
+
 ## Setting up PurgeCSS manually
 
 Under the hood, Tailwind's `purge` feature is powered by a fantastic library called [PurgeCSS](https://purgecss.com/).


### PR DESCRIPTION
Links to the specific options which can be passed through to purgeCSS. Just saves a couple of minutes finding the right page in the docs.