### PR TITLE
Added Font Variant Numeric and Grid Alignment Documentation (v1.8)

### DIFF
--- a/src/layouts/DocumentationLayout.js
+++ b/src/layouts/DocumentationLayout.js
@@ -74,6 +74,8 @@ const nav = {
     pages['grid-row'],
     pages['gap'],
     pages['grid-auto-flow'],
+    pages['justify-items'],
+    pages['justify-self'],
   ],
   Spacing: [pages['padding'], pages['margin'], pages['space']],
   Sizing: [

--- a/src/layouts/DocumentationLayout.js
+++ b/src/layouts/DocumentationLayout.js
@@ -76,6 +76,9 @@ const nav = {
     pages['grid-auto-flow'],
     pages['justify-items'],
     pages['justify-self'],
+    pages['place-content'],
+    pages['place-items'],
+    pages['place-self'],
   ],
   Spacing: [pages['padding'], pages['margin'], pages['space']],
   Sizing: [

--- a/src/layouts/DocumentationLayout.js
+++ b/src/layouts/DocumentationLayout.js
@@ -90,6 +90,7 @@ const nav = {
     pages['font-smoothing'],
     pages['font-style'],
     pages['font-weight'],
+    pages['font-variant-numeric'],
     pages['letter-spacing'],
     pages['line-height'],
     pages['list-style-type'],

--- a/src/pages/docs/font-variant-numeric.mdx
+++ b/src/pages/docs/font-variant-numeric.mdx
@@ -1,0 +1,129 @@
+---
+title: "Font Variant Numeric"
+description: "Utilities for controlling the variant of numbers."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+---
+
+import plugin from 'tailwindcss/lib/plugins/fontVariantNumeric'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+
+export const classes = { plugin }
+
+## Usage
+
+Use the `font-variant-numeric` utilities to enable additional glyphs for numbers, fractions, and ordinal markers.
+
+All properties are composable so you can enable multiple `font-variant-numeric` features by adding multiple classes.
+
+*Attention: Not every font supports each specific numeric font variant.*
+
+## Ordinal
+
+Use the `.ordinal` utility to enable special glyphs for the ordinal markers.
+
+```html
+<p class="ordinal ...">1st</p>
+```
+
+
+## Slashed Zero
+
+Use the `.slashed-zero` utility to force a 0 with a slash; this is useful when a clear distinction between O and 0 is needed.
+```html
+<p class="slashed-zero ...">0</p>
+```
+
+## Lining Nums
+
+Use the `.lining-nums` utility to set all numbers on the baseline.
+
+```html
+<p class="lining-nums ...">12345</p>
+```
+
+## Oldstyle Nums
+
+Use the `.oldstyle-nums` utility to set numbers (e.g. 3, 4, 5, 7 and 9) with descenders.
+
+```html
+<p class="oldstyle-nums ...">123456789</p>
+```
+
+## Proportional Nums
+
+Use the `.proportional-nums` utility to set all numbers proportionally according to space requirements.
+
+```html
+<p class="proportional-nums ...">1234567890</p>
+```
+
+## Tabular Nums
+
+Use the `.tabular-nums` utility to sets all digits to have the same width (non-proportional).
+
+```html
+<p class="tabular-nums ...">1234567890</p>
+```
+
+## Diagonal Fractions
+
+Use the `.diagonal-fractions` utility to enable diagonal fractions where the numerator and denominator are made smaller and separated by a slash.
+```html
+<template preview>
+  <p class="diagonal-fractions text-lg text-gray-800">3/4</p>
+</template>
+
+<p class="diagonal-fractions ...">3/4</p>
+```
+
+## Stacked Fractions
+
+Use the `.stacked-fractions` utility to enable stacked-fractions where the numerator and denominator are made smaller, stacked and separated by a horizontal line.
+
+```html
+<p class="stacked-fractions ...">3/4</p>
+```
+
+
+## Resetting numeric font variants
+
+Use the `.normal-nums` propery to reset numeric font variants. This is usally useful at a particular breakpoint:
+
+```html
+<p class="slashed-zero tabular-nums diagonal-fractions md:normal-nums ...">12345</p>
+```
+
+## Responsive
+
+To control the numeric font variant of an element at a specific breakpoint, add a `{screen}:` prefix to any existing font style utility. For example, use `md:diagonal-fractions` to apply the `diagonal-fractions` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['diagonal-fractions', 'normal-nums', 'diagonal-fractions', 'diagonal-fractions', 'diagonal-fractions']}
+  snippet={(classNames) => `
+    <p class="${classNames} ...">
+      3/4
+    </p>
+  `}
+  preview={(className) => (
+    <p className={`text-lg text-gray-800 ${className}`}>3/4</p>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="fontVariantNumeric" />
+
+### Disabling
+
+<Disabling plugin="fontVariantNumeric" />

--- a/src/pages/docs/justify-items.mdx
+++ b/src/pages/docs/justify-items.mdx
@@ -1,0 +1,120 @@
+---
+title: "Justify Items"
+description: "Utilities for controlling how grid items are aligned along their grid areas on the inline axis."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+
+---
+
+import plugin from 'tailwindcss/lib/plugins/justifyItems'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+
+export const classes = { plugin }
+
+## Auto
+
+Use `.justify-items-auto` to justify grid items automatically on their grid areas on the inline axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 justify-items-auto">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Start
+
+Use `.justify-items-start` to justify grid items against the start of their grid areas on the inline axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 gap-3 bg-gray-200 justify-items-start">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## End
+
+Use `.justify-items-start` to justify grid items against the end of their grid areas on the inline axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 justify-items-end">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Center
+
+Use `.justify-items-center` to justify grid items along their grid areas on the inline axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 justify-items-center">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Stretch
+
+Use `.justify-items-stretch` to stretch items along their grid areas on the inline axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 justify-items-stretch">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Responsive
+
+To justify flex items at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:justify-items-center` to apply the `justify-items-center` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['justify-items-auto', 'justify-items-start', 'justify-items-end', 'justify-items-center', 'justify-items-stretch']}
+  snippet={(classNames) => `
+    <div class="${classNames} ...">
+      <!-- ... -->
+    </div>
+  `}
+  preview={(className) => (
+    <div className={`grid grid-cols-3 bg-gray-200 ${className}`}>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    </div>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="justifyItems" name="justify-items" />
+
+### Disabling
+
+<Disabling plugin="justifyItems" name="justify-items" />

--- a/src/pages/docs/justify-items.mdx
+++ b/src/pages/docs/justify-items.mdx
@@ -23,10 +23,13 @@ Use `.justify-items-auto` to justify grid items automatically on their grid area
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 bg-gray-200 justify-items-auto">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-auto h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -37,25 +40,31 @@ Use `.justify-items-start` to justify grid items against the start of their grid
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 gap-3 bg-gray-200 justify-items-start">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-start h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
 
 ## End
 
-Use `.justify-items-start` to justify grid items against the end of their grid areas on the inline axis:
+Use `.justify-items-end` to justify grid items against the end of their grid areas on the inline axis:
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 bg-gray-200 justify-items-end">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
-  </div>
+  <div class="grid grid-cols-3 gap-4 justify-items-end h-48">
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
+    </div>
 </template>
 ```
 
@@ -65,10 +74,13 @@ Use `.justify-items-center` to justify grid items along their grid areas on the 
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 bg-gray-200 justify-items-center">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-center h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -79,10 +91,13 @@ Use `.justify-items-stretch` to stretch items along their grid areas on the inli
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 bg-gray-200 justify-items-stretch">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -101,10 +116,13 @@ For more information about Tailwind's responsive design features, check out the 
     </div>
   `}
   preview={(className) => (
-    <div className={`grid grid-cols-3 bg-gray-200 ${className}`}>
-      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
-      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div className={`grid grid-cols-3 gap-4 h-48 ${className}`}>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">2</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+      <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
     </div>
   )}
 />

--- a/src/pages/docs/justify-self.mdx
+++ b/src/pages/docs/justify-self.mdx
@@ -22,10 +22,13 @@ Use `.justify-self-auto` to align an item based on the value of the grid's `just
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="justify-self-auto text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="justify-self-auto text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -36,10 +39,13 @@ Use `.justify-self-start` to align a grid item to the start of the grid area on 
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="justify-self-start text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="justify-self-start text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -50,10 +56,13 @@ Use `.justify-self-center` to align a grid item along the center of the grid are
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="justify-self-center text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="justify-self-center text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -64,10 +73,13 @@ Use `.justify-self-end` to align a grid item to the end of the grid area on the 
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="justify-self-end text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="justify-self-end text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -78,10 +90,13 @@ Use `.justify-self-stretch` to stretch a grid item to fill the grid area on its 
 
 ```html
 <template preview>
-  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-    <div class="justify-self-stretch text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
-    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  <div class="grid grid-cols-3 gap-4 justify-items-stretch h-48">
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+    <div class="justify-self-stretch text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2">2</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+    <div class="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
   </div>
 </template>
 ```
@@ -102,10 +117,13 @@ For more information about Tailwind's responsive design features, check out the 
     </div>
   `}
   preview={(className) => (
-    <div className="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
-      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
-      <div className={`text-gray-800 text-center bg-gray-500 px-4 py-2 m-2 ${className}`}>2</div>
-      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div className="grid grid-cols-3 gap-4 h-48">
+      <div className="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">1</div>
+      <div className={`text-gray-800 bg-gray-500 flex justify-center items-center px-4 py-2 ${className}`}>2</div>
+      <div className="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">3</div>
+      <div className="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">4</div>
+      <div className="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">5</div>
+      <div className="text-gray-700 bg-gray-400 flex justify-center items-center px-4 py-2">6</div>
     </div>
   )}
 />

--- a/src/pages/docs/justify-self.mdx
+++ b/src/pages/docs/justify-self.mdx
@@ -1,0 +1,121 @@
+---
+title: "Justify Self"
+description: "Utilities for controlling how an individual grid item is positioned inside its grid area on the inline axis."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+---
+
+import plugin from 'tailwindcss/lib/plugins/justifySelf'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+
+export const classes = { plugin }
+
+## Auto
+
+Use `.justify-self-auto` to align an item based on the value of the grid's `justify-items` property:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="justify-self-auto text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Start
+
+Use `.justify-self-start` to align a grid item to the start of the grid area on the inline axis of the grid, despite the grid's `justify-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="justify-self-start text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Center
+
+Use `.justify-self-center` to align a grid item along the center of the grid area on the inline axis of the grid, despite the grid's `justify-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="justify-self-center text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## End
+
+Use `.justify-self-end` to align a grid item to the end of the grid area on the inline axis of the grid, despite the grid's `justify-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="justify-self-end text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Stretch
+
+Use `.justify-self-stretch` to stretch a grid item to fill the grid area on its inline axis, despite the grid's `justify-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="justify-self-stretch text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+  </div>
+</template>
+```
+
+## Responsive
+
+To control the alignment of a grid item inside its grid area at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:justify-self-end` to apply the `justify-self-end` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['justify-self-auto', 'justify-self-start', 'justify-self-end', 'justify-self-center', 'justify-self-stretch']}
+  snippet={(classNames) => `
+    <div class="justify-items-stretch ...">
+      <!-- ... -->
+      <div class="${classNames} ...">2</div>
+      <!-- ... -->
+    </div>
+  `}
+  preview={(className) => (
+    <div className="grid grid-cols-3 justify-items-stretch bg-gray-200 h-24">
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+      <div className={`text-gray-800 text-center bg-gray-500 px-4 py-2 m-2 ${className}`}>2</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    </div>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="justifySelf" name="justify-self" />
+
+### Disabling
+
+<Disabling plugin="justifySelf" name="justify-self" />

--- a/src/pages/docs/place-content.mdx
+++ b/src/pages/docs/place-content.mdx
@@ -1,0 +1,172 @@
+---
+title: "Place Content"
+description: "Utilities for controlling how the content is placed in the grid."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+
+---
+
+import plugin from 'tailwindcss/lib/plugins/placeContent'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+
+export const classes = { plugin }
+
+## Center
+
+Use `.place-content-center` to pack items in a grid container in the center of the block axis: 
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-center h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Start
+
+Use `.place-content-start` to pack items in a grid container against the start of the block axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-start h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## End
+
+Use `.place-content-end` to to pack items in a grid container against the end of the block axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-end h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Space between
+
+Use `.place-content-between` to distribute grid items along the block axis so that that there is an equal amount of space between each row on the block axis.
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-between h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Space around
+
+Use `.place-content-around` distribute grid items in a grid container such that there is an equal amount of space around each row on the block axis: 
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-around h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Space evenly
+
+Use `.place-content-evenly` to distribute grid items in a grid container such that they are evenly spaced on the block axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-evenly h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Stretch
+
+Use `.place-content-stretch` to stretch grid items along their grid areas on the block axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 bg-gray-200 place-content-stretch h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Responsive
+
+To place grid items at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:place-content-center` to apply the `place-content-centerr` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['place-content-center', 'place-content-start', 'place-content-end', 'place-content-between', 'place-content-around']}
+  snippet={(classNames) => `
+    <div class="${classNames} ...">
+      <!-- ... -->
+    </div>
+  `}
+  preview={(className) => (
+    <div className={`grid grid-cols-3 bg-gray-200 ${className} h-48`}>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+    </div>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="placeContent" name="place-content" />
+
+### Disabling
+
+<Disabling plugin="placeContent" name="place-content" />

--- a/src/pages/docs/place-items.mdx
+++ b/src/pages/docs/place-items.mdx
@@ -1,0 +1,138 @@
+---
+title: "Place Items"
+description: "Utilities for controlling how grid items are placed in their grid areas."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+
+---
+
+import plugin from 'tailwindcss/lib/plugins/placeItems'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+
+export const classes = { plugin }
+
+## Auto
+
+Use `.place-items-auto` to place grid items automatically in their grid areas:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-auto bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Start
+
+Use `.place-items-start` to place grid items on the start of their grid areas on both axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-start bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## End
+
+Use `.place-items-start` to place grid items on the end of their grid areas on both axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-end bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Center
+
+Use `.place-items-center` to place grid items on the center of their grid areas on both axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-center bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Stretch
+
+Use `.place-items-stretch` to stretch items along their grid areas on both axis:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Responsive
+
+To place flex items at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:place-items-center` to apply the `place-items-center` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['place-items-auto', 'place-items-start', 'place-items-end', 'place-items-center', 'place-items-stretch']}
+  snippet={(classNames) => `
+    <div class="${classNames} ...">
+      <!-- ... -->
+    </div>
+  `}
+  preview={(className) => (
+    <div className={`grid grid-cols-3 place-items-stretch bg-gray-200 h-48 ${className}`}>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">2</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+    </div>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="placeItems" name="place-items" />
+
+### Disabling
+
+<Disabling plugin="placeItems" name="place-items" />

--- a/src/pages/docs/place-self.mdx
+++ b/src/pages/docs/place-self.mdx
@@ -1,0 +1,139 @@
+---
+title: "Place Self"
+description: "Utilities for controlling how an individual grid item is positioned inside its grid area."
+featureVersion: "v1.8.0+"
+features:
+  responsive: true
+  customizable: false
+  hover: false
+  focus: false
+---
+
+import plugin from 'tailwindcss/lib/plugins/placeSelf'
+import { ResponsiveCodeSample } from '@/components/ResponsiveCodeSample'
+import { Variants } from '@/components/Variants'
+import { Disabling } from '@/components/Disabling'
+
+export const classes = { plugin }
+
+## Auto
+
+Use `.place-self-auto` to align an item based on the value of the grid's `place-items` property:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="place-self-auto text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Start
+
+Use `.place-self-start` to align a grid item to the start of the grid area on both axis, despite the grid's `place-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="place-self-start text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Center
+
+Use `.place-self-center` to align a grid item at the center of the grid area, despite the grid's `place-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="place-self-center text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## End
+
+Use `.place-self-end` to align a grid item to the end of the grid area on both axis, despite the grid's `place-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="place-self-end text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Stretch
+
+Use `.place-self-stretch` to stretch a grid item to fill the grid area on both axis, despite the grid's `place-items` value:
+
+```html
+<template preview>
+  <div class="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+    <div class="place-self-stretch text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">2</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+    <div class="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+  </div>
+</template>
+```
+
+## Responsive
+
+To control the alignment of a grid item inside its grid area at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:place-self-end` to apply the `place-self-end` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+<ResponsiveCodeSample
+  classNames={['place-self-auto', 'place-self-start', 'place-self-end', 'place-self-center', 'place-self-stretch']}
+  snippet={(classNames) => `
+    <div class="place-items-stretch ...">
+      <!-- ... -->
+      <div class="${classNames} ...">2</div>
+      <!-- ... -->
+    </div>
+  `}
+  preview={(className) => (
+    <div className="grid grid-cols-3 place-items-stretch bg-gray-200 h-48">
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">1</div>
+      <div className={`text-gray-800 text-center bg-gray-500 px-4 py-2 m-2 ${className}`}>2</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">3</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">4</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">5</div>
+      <div className="text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">6</div>
+    </div>
+  )}
+/>
+
+## Customizing
+
+### Responsive and pseudo-class variants
+
+<Variants plugin="placeSelf" name="place-self" />
+
+### Disabling
+
+<Disabling plugin="placeSelf" name="place-self" />


### PR DESCRIPTION
I implemented a basic documentation page for all `font-variant-numeric`.
I also tried to explain what each of them does because the current font stack (setup) does not enable us to provide previews for each variant. 

Furthermore I added 5 more documentation pages showing the new `grid alignment` utilities.
I hope I got everything in place and correct. 

Generally I think the basic structure is in place and this can be improved further.
So please feel free to change stuff and correct things if I made a mistake!

Thanks for all your great work, @adamwathan!