### PR TITLE
fix: :pencil2: Add missing dot in snippet

### DIFF
--- a/src/pages/docs/adding-new-utilities.mdx
+++ b/src/pages/docs/adding-new-utilities.mdx
@@ -157,7 +157,7 @@ module.exports = {
         '.filter-none': {
           filter: 'none',
         },
-        'filter-grayscale': {
+        '.filter-grayscale': {
           filter: 'grayscale(100%)',
         },
       }


### PR DESCRIPTION
The example in [Using a plugin](https://tailwindcss.com/docs/adding-new-utilities#using-a-plugin) is missing a dot, resulting in an error:

```sh
(9:0) Variant cannot be generated because selector contains no classes.
```