### PR TITLE
fix: mention place-items-end in the correct location

### DIFF
--- a/src/pages/docs/place-items.mdx
+++ b/src/pages/docs/place-items.mdx
@@ -47,7 +47,7 @@ Use `place-items-start` to place grid items on the start of their grid areas on 
 
 ## End
 
-Use `place-items-start` to place grid items on the end of their grid areas on both axis:
+Use `place-items-end` to place grid items on the end of their grid areas on both axis:
 
 ```html
 <template preview>


### PR DESCRIPTION
While reading through the documentation of [place-items](https://tailwindcss.com/docs/place-items#end) I noticed that `place-items-start` was mentioned under the headline "End". It should be `place-items-end`.

The code sample is correct.
