### PR TITLE
Fix spelling in Place Items docs

### DIFF
--- a/src/pages/docs/place-items.mdx
+++ b/src/pages/docs/place-items.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Place Items"
-description: "Utilities for controlling how items are justifed and aligned at the same time."
+description: "Utilities for controlling how items are justified and aligned at the same time."
 featureVersion: "v1.8.0+"
 ---
 


### PR DESCRIPTION
Fix minor spelling error in `Place Items` docs

<img width="596" alt="Screenshot 2020-09-26 at 8 49 20 PM" src="https://user-images.githubusercontent.com/1921183/94341157-e0d31d80-0039-11eb-9448-76dbda4b4e61.png">

Changed to:

<img width="608" alt="Screenshot 2020-09-26 at 8 52 28 PM" src="https://user-images.githubusercontent.com/1921183/94341222-3dced380-003a-11eb-9e62-aa03877d4948.png">

