### PR TITLE
Change PurgeCSS Documentation URL

### DIFF
--- a/src/pages/docs/controlling-file-size.mdx
+++ b/src/pages/docs/controlling-file-size.mdx
@@ -185,7 +185,7 @@ module.exports = {
 }
 ```
 
-A list of available options can be found in the [PurgeCSS documentation](https://purgecss.com/configuration.html#options).
+A list of available options can be found in the [PurgeCSS 2.x documentation](https://github.com/FullHuman/purgecss/blob/5314e41edf328e2ad2639549e1587b82a964a42e/docs/configuration.md).
 
 ## Setting up PurgeCSS manually
 


### PR DESCRIPTION
_PurgeCSS 3.x_ has been released. Some _PurgeCSS_ options used by _Tailwind 1.8.x_ has been removed since _version 3.x_. I changed the documentation link to _version 2.x_ to avoid user confusion.