### PR TITLE
Add focus outline to homepage search variant

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -55,10 +55,10 @@ export function Search() {
         ref={searchButtonRef}
         onClick={onOpen}
         className={clsx(
-          'transition-colors duration-100 ease-in-out text-gray-600 py-2 pr-4 pl-10 block w-full appearance-none leading-normal border border-transparent rounded-lg focus:outline-none text-left select-none truncate',
+          'transition-colors duration-100 ease-in-out text-gray-600 py-2 pr-4 pl-10 block w-full appearance-none leading-normal border border-transparent rounded-lg text-left select-none truncate',
           {
-            'bg-white shadow-md focus:shadow-outline': isHome,
-            'focus:bg-white focus:border-gray-300 bg-gray-200': !isHome,
+            'bg-white shadow-md': isHome,
+            'bg-gray-200': !isHome,
           }
         )}
       >

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -57,7 +57,7 @@ export function Search() {
         className={clsx(
           'transition-colors duration-100 ease-in-out text-gray-600 py-2 pr-4 pl-10 block w-full appearance-none leading-normal border border-transparent rounded-lg focus:outline-none text-left select-none truncate',
           {
-            'bg-white shadow-md': isHome,
+            'bg-white shadow-md focus:shadow-outline': isHome,
             'focus:bg-white focus:border-gray-300 bg-gray-200': !isHome,
           }
         )}


### PR DESCRIPTION
Hello there Tailwind crew. 👋

Noticed that the search bar has no focus indication on the homepage, so I added the `focus:shadow-outline` to the `isHome` version since the over one does have a focus indication with the changing of the background and border color. 🙂

### Before (no focus indication)

![before_no_focus](https://user-images.githubusercontent.com/2221746/96504399-ea286200-1254-11eb-94ad-367d6b33520b.gif)

### After (focus indication)

![after_with_focus](https://user-images.githubusercontent.com/2221746/96504393-e7c60800-1254-11eb-944f-c4649283be68.gif)
