### PR TITLE
Update order.mdx with grid

### DIFF
--- a/src/pages/docs/order.mdx
+++ b/src/pages/docs/order.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Order"
-description: "Utilities for controlling the order of flex items."
+description: "Utilities for controlling the order of flex and grid items."
 ---
 
 import plugin from 'tailwindcss/lib/plugins/order'


### PR DESCRIPTION
Looks like `order-1`, `order-2` work with the grid ordering. Found this by trial and error so maybe a note in the docs will help?