### PR TITLE
Add comma in example of addComponents multi-rule

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -751,7 +751,7 @@ addComponents({
     boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
     '&:hover': {
       boxShadow: '0 10px 15px rgba(0,0,0,0.2)',
-    }
+    },
     '@media (min-width: 500px)': {
       borderRadius: '.5rem',
     }


### PR DESCRIPTION
Example was missing a comma, which led to a slight hiccup when attempting to copy and paste the example onto a project.