### PR TITLE
Change whitelist to safelist for PurgeCSS 3 options

### DIFF
--- a/src/pages/docs/controlling-file-size.mdx
+++ b/src/pages/docs/controlling-file-size.mdx
@@ -178,7 +178,7 @@ module.exports = {
 
     // These options are passed through directly to PurgeCSS
     options: {
-      whitelist: ['bg-red-500', 'px-4'],
+      safelist: ['bg-red-500', 'px-4'],
     }
   },
   // ...
@@ -240,7 +240,7 @@ module.exports = {
 
 Note that in this example, **we're only enabling PurgeCSS in production**. We recommend configuring PurgeCSS this way because it can be slow to run, and during development it's nice to have every class available so you don't need to wait for a rebuild every time you change some HTML.
 
-Finally, we recommend only applying PurgeCSS to Tailwind's utility classes, and not to [base styles](/docs/adding-base-styles) or [component classes](/docs/extracting-components#extracting-css-components-with-apply). The easiest way to do this is to use PurgeCSS's [whitelisting](https://purgecss.com/whitelisting.html) feature to disable PurgeCSS for non-utility classes:
+Finally, we recommend only applying PurgeCSS to Tailwind's utility classes, and not to [base styles](/docs/adding-base-styles) or [component classes](/docs/extracting-components#extracting-css-components-with-apply). The easiest way to do this is to use PurgeCSS's [safelisting](https://purgecss.com/safelisting.html) feature to disable PurgeCSS for non-utility classes:
 
 ```css
 /* purgecss start ignore */


### PR DESCRIPTION
Prompted by https://github.com/tailwindlabs/tailwindcss/discussions/2708 which lead to realising we upgraded to PurgeCSS 3 but didn't update the docs - this PR makes that update.