### PR TITLE
Fix broken link

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -15,7 +15,7 @@ For most real-world projects, we recommend installing Tailwind as a PostCSS plug
 
 If you've never heard of PostCSS or are wondering how it's different from tools like Sass, read our guide on [using PostCSS as your preprocessor](/docs/using-with-preprocessors#using-post-css-as-your-preprocessor) for an introduction.
 
-If this is a bit over your head and you'd like to try Tailwind without configuring PostCSS, read our instructions on [using Tailwind without PostCSS](#using-tailwind-without-postcss) instead.
+If this is a bit over your head and you'd like to try Tailwind without configuring PostCSS, read our instructions on [using Tailwind without PostCSS](#using-tailwind-without-post-css) instead.
 
 ### Install Tailwind via npm
 


### PR DESCRIPTION
Camel Case in the headers are changed to kebab case anchor links. This link needs the extra dash to work.