### PR TITLE
Use correct casing for boxShadows default key

### DIFF
--- a/src/components/home/ConstraintBased.js
+++ b/src/components/home/ConstraintBased.js
@@ -349,14 +349,14 @@ export function ConstraintBased() {
                       animate={{ opacity: 1 }}
                     />
                     <ul className="relative z-20 w-full flex-none grid grid-cols-2 gap-4">
-                      {['sm', 'default', 'md', 'lg', 'xl', '2xl'].map((shadow, i) => (
+                      {['sm', 'DEFAULT', 'md', 'lg', 'xl', '2xl'].map((shadow, i) => (
                         <motion.li
                           key={shadow}
                           initial={{ opacity: 0 }}
                           animate={{ opacity: 1 }}
                           transition={{ delay: [0.1, 0.1, 0.2, 0.2, 0.3, 0.3][i] }}
                         >
-                          <div>{`shadow${shadow === 'default' ? '' : `-${shadow}`}`}</div>
+                          <div>{`shadow${shadow === 'DEFAULT' ? '' : `-${shadow}`}`}</div>
                           <div
                             className="bg-white rounded-lg h-18 mt-1"
                             style={{ boxShadow: defaultConfig.theme.boxShadow[shadow] }}


### PR DESCRIPTION
Changed the key for default boxShadow to be uppercased in the shadow example so it uses the correct key from the default config.

**Before**
<img width="666" alt="before" src="https://user-images.githubusercontent.com/6917854/99639305-be60ed80-2a47-11eb-86ed-167469699888.png">

**After**
<img width="675" alt="after" src="https://user-images.githubusercontent.com/6917854/99639316-c1f47480-2a47-11eb-8063-1e174d873af1.png">
