### PR TITLE
Fix closing div tag in grid-row docs

### DIFF
--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -28,7 +28,7 @@ Use the `row-span-{n}` utilities to make an element span _n_ rows.
 <div class="grid grid-rows-3 grid-flow-col gap-4">
   <div class="**row-span-3** ...">1</div>
   <div class="col-span-2 ...">2</div>
-  <div class="**row-span-2** col-span-2 ...">3<div>
+  <div class="**row-span-2** col-span-2 ...">3</div>
 </div>
 ```
 


### PR DESCRIPTION
Just missing end tag for div in grid-row docs