### PR TITLE
Remove duplicated disabled attribute

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -446,7 +446,7 @@ Add the `disabled:` prefix to only apply a utility when an element is disabled.
 <button class="**disabled:opacity-50** ...">
   Submit
 </button>
-<button disabled class="**disabled:opacity-50** ..." disabled>
+<button class="**disabled:opacity-50** ..." disabled>
   Submit
 </button>
 ```


### PR DESCRIPTION
A `button` in the docs demonstrating the disabled state has the `disabled` attribute twice.