### PR TITLE
Fix dark mode snippet

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -112,7 +112,7 @@ Here's a simple example of how you can support light mode, dark mode, as well as
 
 ```js
 // On page load or when changing themes, best to add inline in `head` to avoid FOUC
-if (localStorage.theme === 'dark' || (!'theme' in localStorage && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
   document.querySelector('html').classList.add('dark')
 } else {
   document.querySelector('html').classList.remove('dark')


### PR DESCRIPTION
Correctly check that 'theme' is not present in localStorage.

I think it could be further simplified by saying `!localStorage.theme` as in 
```js
if (localStorage.theme === 'dark' || (!localStorage.theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
    ...
}
```