### PR TITLE
Fix typo (tailwindcss.com#614)

### DIFF
--- a/src/pages/docs/ring-offset-width.mdx
+++ b/src/pages/docs/ring-offset-width.mdx
@@ -103,8 +103,8 @@ Learn more about customizing the default theme in the [theme customization docum
 
 ### Variants
 
-<Variants plugin="ringWidth" />
+<Variants plugin="ringOffsetWidth" />
 
 ### Disabling
 
-<Disabling plugin="ringWidth" />
+<Disabling plugin="ringOffsetWidth" />


### PR DESCRIPTION
`plugin="ringWidth"` => `plugin="ringOffsetWidth"`

Fix #614 