### PR TITLE
change compatibility instructions to use tailwindcss@compat

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -294,7 +294,7 @@ If you run into the error mentioned above, uninstall Tailwind and re-install usi
 
 ```shell
 npm uninstall tailwindcss postcss autoprefixer
-npm install tailwindcss@npm:@tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9
+npm install tailwindcss@compat postcss@^7 autoprefixer@^9
 ```
 
 The compatibility build is identical to the main build in every way, so you aren't missing out on any features or anything like that.


### PR DESCRIPTION
I found the PostCSS 7 compatibility instructions did not quite work for me. 

If I used `npm install tailwindcss@npm:@tailwindcss/postcss7-compat` it did not install a tailwindcss script in `node_modules/.bin/` but if I used `npm install tailwindcss@compat` it worked just fine. This PR updates the instructions to match what worked for me.

I ran into this issue using create-react-app 4.0.0 and node 12.16.1 and npm 6.13.4.