### PR TITLE
Fix PostCSS configuration example

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -84,9 +84,9 @@ If you use a custom file name, you will need to specify it when including Tailwi
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: [
+  plugins: {
     tailwindcss: { config: './tailwindcss-config.js' },
-  ],
+  },
 }
 ```
 


### PR DESCRIPTION
Fixes the typo for `postcss.config.js` in [Using a different file name](https://tailwindcss.com/docs/configuration#using-a-different-file-name) section.
