### PR TITLE
Fix the code sample's indexes to match the example

### DIFF
--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -59,42 +59,42 @@ Combined with Tailwind's padding and margin utilities, you'll probably find that
 
 <!-- Span right edge -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-y-0 right-0** w-16 ...">1</div>
+  <div class="absolute **inset-y-0 right-0** w-16 ...">2</div>
 </div>
 
 <!-- Span bottom edge -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-x-0 bottom-0** h-16 w-16 ...">1</div>
+  <div class="absolute **inset-x-0 bottom-0** h-16 w-16 ...">3</div>
 </div>
 
 <!-- Span left edge -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-y-0 left-0** w-16 ...">1</div>
+  <div class="absolute **inset-y-0 left-0** w-16 ...">4</div>
 </div>
 
 <!-- Fill entire parent -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-0** ..."></div>
+  <div class="absolute **inset-0** ...">5</div>
 </div>
 
 <!-- Pin to top left corner -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **left-0 top-0** h-16 w-16 ...">1</div>
+  <div class="absolute **left-0 top-0** h-16 w-16 ...">6</div>
 </div>
 
 <!-- Pin to top right corner -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **top-0 right-0** h-16 w-16 ...">1</div>
+  <div class="absolute **top-0 right-0** h-16 w-16 ...">7</div>
 </div>
 
 <!-- Pin to bottom right corner -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **bottom-0 right-0** h-16 w-16 ...">1</div>
+  <div class="absolute **bottom-0 right-0** h-16 w-16 ...">8</div>
 </div>
 
 <!-- Pin to bottom left corner -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **bottom-0 left-0** h-16 w-16 ...">1</div>
+  <div class="absolute **bottom-0 left-0** h-16 w-16 ...">9</div>
 </div>
 ```
 


### PR DESCRIPTION
It would be easier to understand the examples if the numbers (1 to 9) could match the ones in the code samples (1 or empty)

![image](https://user-images.githubusercontent.com/52666720/99968296-440ed100-2d99-11eb-977b-7e72c03acefc.png)