### PR TITLE
Use green instead of (non default) teal colour in text gradient example

### DIFF
--- a/src/pages/docs/background-clip.mdx
+++ b/src/pages/docs/background-clip.mdx
@@ -41,14 +41,14 @@ Use `bg-clip-text` to crop an element's background to match the shape of the tex
 ```html emerald
 <template preview>
   <div class="text-center text-5xl font-extrabold leading-none tracking-tight">
-    <span class="bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500">
+    <span class="bg-clip-text text-transparent bg-gradient-to-r from-green-400 to-blue-500">
       Hello world
     </span>
   </div>
 </template>
 
 <div class="text-5xl font-extrabold ...">
-  <span class="**bg-clip-text** text-transparent bg-gradient-to-r from-teal-400 to-blue-500">
+  <span class="**bg-clip-text** text-transparent bg-gradient-to-r from-green-400 to-blue-500">
     Hello world
   </span>
 </div>


### PR DESCRIPTION
Spend around 20 minutes figuring out why the snippet [here](https://tailwindcss.com/docs/background-clip#cropping-to-text) didn't work on my project until I realised that `teal` isn't a default colour anymore. IMO it makes more sense to use the default colours in the examples to avoid such confusion.