### PR TITLE
Fix typo in nuxtjs.mdx

### DIFF
--- a/src/pages/docs/guides/nuxtjs.mdx
+++ b/src/pages/docs/guides/nuxtjs.mdx
@@ -122,6 +122,6 @@ Read our documentation on [adding base styles](/docs/adding-base-styles), [extra
 
 ---
 
-You're finished! Now when you run `npm run dev` to start the Vite development server, Tailwind CSS will be ready to use in your project.
+You're finished! Now when you run `npm run dev` to start the Nuxt.js development server, Tailwind CSS will be ready to use in your project.
 
 [Next learn about the utility-first workflow &rarr;](/docs/utility-first)


### PR DESCRIPTION
Remove reference to Vite instead of Nuxt.js.