### PR TITLE
Correct casing in container padding example

### DIFF
--- a/src/pages/docs/container.mdx
+++ b/src/pages/docs/container.mdx
@@ -127,7 +127,7 @@ module.exports = {
   theme: {
     container: {
       padding: {
-        DEFAULT: '1rem',
+        default: '1rem',
         sm: '2rem',
         lg: '4rem',
         xl: '5rem',


### PR DESCRIPTION
Changed `DEFAULT` to `default`.