### PR TITLE
box-shadow: Remove mentions of "xs"

### DIFF
--- a/src/pages/docs/box-shadow.mdx
+++ b/src/pages/docs/box-shadow.mdx
@@ -16,7 +16,7 @@ export const classes = { plugin }
 
 ## Outer shadow
 
-Use the `shadow-xs`, `.shadow-sm`, `.shadow`, `.shadow-md`, `.shadow-lg`, `.shadow-xl`, or `.shadow-2xl` utilities to apply different sized outer box shadows to an element.
+Use the `.shadow-sm`, `.shadow`, `.shadow-md`, `.shadow-lg`, `.shadow-xl`, or `.shadow-2xl` utilities to apply different sized outer box shadows to an element.
 
 ```html indigo
 <template preview>
@@ -91,7 +91,6 @@ If a `default` shadow is provided, it will be used for the non-suffixed `.shadow
   module.exports = {
     theme: {
       boxShadow: {
-        xs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
         sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
         DEFAULT: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
         md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',


### PR DESCRIPTION
Removed in Tailwind 2: https://tailwindcss.com/docs/upgrading-to-v2#replace-shadow-outline-and-shadow-xs-with-ring-utilities

Did not mention the ring utilities in this PR, though perhaps that could be a good idea as well.