### PR TITLE
Modify scroll margin snap rule to better support future Safari

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,7 +66,7 @@ module.exports = {
               letterSpacing: '-0.025em',
             },
             'h2, h3': {
-              'scroll-margin-top': `${(70 + 40) / 16}rem`
+              'scroll-margin-top': `${(70 + 40) / 16}rem`,
             },
             'ul > li': {
               paddingLeft: '1.5em',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,7 +66,7 @@ module.exports = {
               letterSpacing: '-0.025em',
             },
             'h2, h3': {
-              'scroll-margin-block': `${(70 + 40) / 16}rem`,
+              'scroll-margin-top': `${(70 + 40) / 16}rem`
             },
             'ul > li': {
               paddingLeft: '1.5em',


### PR DESCRIPTION
Currently the docs scroll to fragment targets such as https://tailwindcss.com/docs/overflow#visible using the `scroll-margin-block` property to avoid the fixed top search bar. This is not supported in Safari.

The `scroll-margin-top` property is supported in Safari TP (and other browsers), so will likely be in the next release of Safari (https://bugs.webkit.org/show_bug.cgi?id=189265#c12).

This change switches to using `scroll-margin-top` to support future Safari and continue supporting Chrome/Edge/Firefox.