### PR TITLE
Suggest fragment anchor right on xs breakpoint

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -42,8 +42,8 @@ export function Heading({
         // eslint-disable-next-line
         <a
           href={`#${id}`}
-          className="absolute after:hash opacity-0 group-hover:opacity-100"
-          style={{ marginLeft: '-1em', paddingRight: '0.5em', boxShadow: 'none', color: '#a1a1aa' }}
+          className="absolute after:hash opacity-0 group-hover:opacity-100 right-0 sm:right-auto sm:-ml-5 mr-2"
+          style={{ boxShadow: 'none', color: '#a1a1aa' }}
           aria-label="Anchor"
         />
       )}


### PR DESCRIPTION
Currently the fragment anchor appears off to the left of the screen when a heading is tapped on mobile:

![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 17 57 47](https://user-images.githubusercontent.com/6286310/100646517-05978a00-3336-11eb-9a07-d3ea12f35c2c.png)

As there isn't really space on the left for it, this PR has it placed on the right hand side.

![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 17 59 15](https://user-images.githubusercontent.com/6286310/100646520-07614d80-3336-11eb-8035-1b8db011462c.png)
