### PR TITLE
Add border variant to checked example

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -536,6 +536,7 @@ module.exports = {
   variants: {
     extend: {
       backgroundColor: ['checked'],
+      borderColor: ['checked'],
     }
   },
 }


### PR DESCRIPTION
In the example for the checkbox background- and border color are used.
However, only the background color variant is extended. So if you copy the example checkbox input and the config, the transparent border won't work.
By adding the border variant the `checked:border-transparent` will work.
There was also a bit confusion in the Discord, that's why I created this pull request.