### PR TITLE
Update Justify Items example to remove duplicate lines

### DIFF
--- a/src/pages/docs/justify-items.mdx
+++ b/src/pages/docs/justify-items.mdx
@@ -27,7 +27,6 @@ Use `justify-items-auto` to justify grid items automatically on their inline axi
 
 <div class="grid **justify-items-auto** ...">
   <div>1</div>
-  <div>1</div>
   <div>2</div>
   <div>3</div>
   <div>4</div>
@@ -53,7 +52,6 @@ Use `justify-items-start` to justify grid items against the start of their inlin
 </template>
 
 <div class="grid **justify-items-start** ...">
-  <div>1</div>
   <div>1</div>
   <div>2</div>
   <div>3</div>
@@ -81,7 +79,6 @@ Use `justify-items-end` to justify grid items against the end of their inline ax
 
 <div class="grid **justify-items-end** ...">
   <div>1</div>
-  <div>1</div>
   <div>2</div>
   <div>3</div>
   <div>4</div>
@@ -108,7 +105,6 @@ Use `justify-items-center` to justify grid items along their inline axis:
 
 <div class="grid **justify-items-center** ...">
   <div>1</div>
-  <div>1</div>
   <div>2</div>
   <div>3</div>
   <div>4</div>
@@ -134,7 +130,6 @@ Use `justify-items-stretch` to stretch items along their inline axis:
 </template>
 
 <div class="grid **justify-items-stretch** ...">
-  <div>1</div>
   <div>1</div>
   <div>2</div>
   <div>3</div>


### PR DESCRIPTION
This docs page has a few duplicate `<div>` tags that don't need to be there.