### PR TITLE
ensure that we include the `@latest` tags

### DIFF
--- a/remark/withPrevalInstructions.js
+++ b/remark/withPrevalInstructions.js
@@ -198,7 +198,7 @@ function createPrevals({ tool: pageTool = error('UNKNOWN') } = {}) {
       version = 'latest',
     }) {
       let knownDependencies = {
-        latest: ['tailwindcss', 'postcss', 'autoprefixer'],
+        latest: ['tailwindcss@latest', 'postcss@latest', 'autoprefixer@latest'],
         'compat-7': [
           'tailwindcss@npm:@tailwindcss/postcss7-compat',
           'postcss@^7',

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -36,7 +36,7 @@ If this is a bit over your head and you'd like to try Tailwind without configuri
 For most projects (and to take advantage of Tailwind's customization features), you'll want to install Tailwind and its peer-dependencies via npm.
 
 ```shell
-npm install tailwindcss postcss autoprefixer
+npm install tailwindcss@latest postcss@latest autoprefixer@latest
 ```
 
 Since Tailwind [does not automatically add vendor prefixes](/docs/browser-support#vendor-prefixes) to the CSS it generates, we recommend installing [autoprefixer](https://github.com/postcss/autoprefixer) to handle this for you like we've shown in the snippet above.


### PR DESCRIPTION
Yarn can correctly use the latest version automatically. For some reason
NPM itself can't, even after running `npm cache clean --force`, which
should clean the cache. It's a bit unfortunate to include this extra
bloat, but what can you do...

Fixes: #675 
