### PR TITLE
fix typo: update `global.css` to `globals.css`

### DIFF
--- a/src/pages/docs/guides/nextjs.mdx
+++ b/src/pages/docs/guides/nextjs.mdx
@@ -49,7 +49,7 @@ If you aren't planning to use them, you can safely delete any CSS files Next.js 
 
 ```preval include
 level: 4
-file: ./styles/global.css 
+file: ./styles/globals.css 
 ```
 
 Finally, ensure your CSS file is being imported in your `pages/_app.js` component:


### PR DESCRIPTION
match next.js `globals.css` also mentioned in this guide