### PR TITLE
Fix classes in inset-x example code

### DIFF
--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -54,7 +54,7 @@ Combined with Tailwind's padding and margin utilities, you'll probably find that
 
 <!-- Span top edge -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-x-0 top-0** h-16 w-16 ...">1</div>
+  <div class="absolute **inset-x-0 top-0** h-16 ...">1</div>
 </div>
 
 <!-- Span right edge -->
@@ -64,7 +64,7 @@ Combined with Tailwind's padding and margin utilities, you'll probably find that
 
 <!-- Span bottom edge -->
 <div class="relative h-32 w-32 ...">
-  <div class="absolute **inset-x-0 bottom-0** h-16 w-16 ...">3</div>
+  <div class="absolute **inset-x-0 bottom-0** h-16 ...">3</div>
 </div>
 
 <!-- Span left edge -->


### PR DESCRIPTION
In https://tailwindcss.com/docs/top-right-bottom-left, the classes in the top-right-bottom-left demonstration do not match the classes in the example code.

Setting the width for inset-x elements would not create the "span edge" effect.