### PR TITLE
Update HTML comment in 'flex-none' example block

### DIFF
--- a/src/pages/docs/flex.mdx
+++ b/src/pages/docs/flex.mdx
@@ -173,7 +173,7 @@ Use `flex-none` to prevent a flex item from growing or shrinking:
     <!-- Will grow and shrink as needed -->
   </div>
   <div class="**flex-none** ...">
-    <!-- Will grow and shrink as needed taking initial size into account -->
+    <!-- Will not grow or shrink -->
   </div>
   <div class="flex-1 ...">
     <!-- Will grow and shrink as needed -->


### PR DESCRIPTION
Hi! Just a quick fix that I noticed while browsing the documentation. I updated the example code block to indicate that flex-none items will not grow or shrink.