### PR TITLE
Use default colors in gradient examples (teal -> green, orange -> yellow)

### DIFF
--- a/src/pages/docs/background-image.mdx
+++ b/src/pages/docs/background-image.mdx
@@ -16,7 +16,7 @@ To give an element a linear gradient background, use one of the `bg-gradient-{di
 
 ```html
 <template preview>
-  <div class="h-24 bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500"></div>
+  <div class="h-24 bg-gradient-to-r from-orange-400 via-red-500 to-pink-500"></div>
 </template>
 
 <div class="**bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500** ..."></div>

--- a/src/pages/docs/background-image.mdx
+++ b/src/pages/docs/background-image.mdx
@@ -16,10 +16,10 @@ To give an element a linear gradient background, use one of the `bg-gradient-{di
 
 ```html
 <template preview>
-  <div class="h-24 bg-gradient-to-r from-orange-400 via-red-500 to-pink-500"></div>
+  <div class="h-24 bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500"></div>
 </template>
 
-<div class="**bg-gradient-to-r from-orange-400 via-red-500 to-pink-500** ..."></div>
+<div class="**bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500** ..."></div>
 ```
 
 ## Responsive

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -55,10 +55,10 @@ Set the ending color of a gradient using the `to-{color}` utilities.
 
 ```html
 <template preview>
-  <div class="h-24 bg-gradient-to-r from-teal-400 to-blue-500"></div>
+  <div class="h-24 bg-gradient-to-r from-green-400 to-blue-500"></div>
 </template>
 
-<div class="bg-gradient-to-r from-teal-400 **to-blue-500** ..."></div>
+<div class="bg-gradient-to-r from-green-400 **to-blue-500** ..."></div>
 ```
 
 Gradients to **do not** fade in from transparent by default. To fade in from transparent, reverse the gradient direction and use a `from-{color}` utility.
@@ -83,7 +83,7 @@ Gradients with a `from-{color}` and `via-{color}` will fade out to transparent b
 To control the gradient color stops of an element at a specific breakpoint, add a `{screen}:` prefix to any existing gradient color stop utility. For example, use `md:from-green-500` to apply the `from-green-500` utility at only medium screen sizes and above.
 
 ```html
-<div class="bg-gradient-to-r from-purple-400 **md:from-orange-500**"></div>
+<div class="bg-gradient-to-r from-purple-400 **md:from-yellow-500**"></div>
 ```
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
@@ -96,13 +96,13 @@ To control the gradient color stops of an element on hover, add the `hover:` pre
 ```html
 <template preview>
   <div class="flex justify-center">
-    <button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-md">
+    <button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white font-semibold px-6 py-3 rounded-md">
       Hover me
     </button>
   </div>
 </template>
 
-<button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 **hover:from-pink-500 hover:to-orange-500** ...">
+<button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 **hover:from-pink-500 hover:to-yellow-500** ...">
   Hover me
 </button>
 ```
@@ -120,13 +120,13 @@ To control the gradient color stops of an element on focus, add the `focus:` pre
 ```html
 <template preview>
   <div class="flex justify-center">
-    <button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 focus:from-pink-500 focus:to-orange-500 text-white font-semibold px-6 py-3 rounded-md">
+    <button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 focus:from-pink-500 focus:to-yellow-500 text-white font-semibold px-6 py-3 rounded-md">
       Focus me
     </button>
   </div>
 </template>
 
-<button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 **focus:from-pink-500 focus:to-orange-500**">
+<button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 **focus:from-pink-500 focus:to-yellow-500**">
   Focus me
 </button>
 ```

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -55,7 +55,7 @@ Set the ending color of a gradient using the `to-{color}` utilities.
 
 ```html
 <template preview>
-  <div class="h-24 bg-gradient-to-r from-green-400 to-blue-500"></div>
+  <div class="h-24 bg-gradient-to-r from-teal-400 to-blue-500"></div>
 </template>
 
 <div class="bg-gradient-to-r from-green-400 **to-blue-500** ..."></div>
@@ -96,7 +96,7 @@ To control the gradient color stops of an element on hover, add the `hover:` pre
 ```html
 <template preview>
   <div class="flex justify-center">
-    <button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white font-semibold px-6 py-3 rounded-md">
+    <button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-md">
       Hover me
     </button>
   </div>
@@ -120,7 +120,7 @@ To control the gradient color stops of an element on focus, add the `focus:` pre
 ```html
 <template preview>
   <div class="flex justify-center">
-    <button type="button" class="bg-gradient-to-r from-green-400 to-blue-500 focus:from-pink-500 focus:to-yellow-500 text-white font-semibold px-6 py-3 rounded-md">
+    <button type="button" class="bg-gradient-to-r from-teal-400 to-blue-500 focus:from-pink-500 focus:to-orange-500 text-white font-semibold px-6 py-3 rounded-md">
       Focus me
     </button>
   </div>


### PR DESCRIPTION
This is basically an extension of #625 where I spent an embarrassingly long amount of time trying to figure out why the code examples weren't working for me and it was because both teal and orange aren't default colors anymore.