### PR TITLE
Remove IE11 tip

### DIFF
--- a/src/pages/docs/position.mdx
+++ b/src/pages/docs/position.mdx
@@ -173,8 +173,6 @@ Offsets are calculated relative to the viewport and the element *will* act as a 
 
 ## Sticky
 
-<TipCompat>Note that sticky positioning is not supported in IE11.</TipCompat>
-
 Use `sticky` to position an element as `relative` until it crosses a specified threshold, then treat it as fixed until its parent is off screen.
 
 Offsets are calculated relative to the element's normal position and the element *will* act as a position reference for absolutely positioned children.


### PR DESCRIPTION
Remove this tip from the docs:

> Note that sticky positioning is not supported in IE11.

There's no point in keeping this since Internet Explorer is not supported anymore.