### PR TITLE
Fix to refer dark mode docs

### DIFF
--- a/src/pages/docs/adding-new-utilities.mdx
+++ b/src/pages/docs/adding-new-utilities.mdx
@@ -107,7 +107,7 @@ Tailwind will automatically generate prefixed versions of each custom utility th
 <div class="filter-grayscale **dark:filter-none**"></div>
 ```
 
-Learn more about responsive utilities in the [responsive design documentation](/docs/responsive-design).
+Learn more about dark mode utilities in the [dark mode documentation](/docs/dark-mode).
 
 ### Generating state variants
 


### PR DESCRIPTION
In Dark Mode section, fix to refer dark mode docs, instead of responsive design docs.