### PR TITLE
Provide Yarn examples next to npm

### DIFF
--- a/src/components/CodeGroup.js
+++ b/src/components/CodeGroup.js
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import cx from 'classnames'
+
+export function CodeGroup({ children }) {
+  const [activeCodeBlockIndex, setActiveCodeBlockIndex] = useState(0)
+  const codeBlockLabels = children.map((codeBlock) => codeBlock.props.label)
+
+  const selectCodeBlock = (idx) => {
+    setActiveCodeBlockIndex(idx)
+  }
+
+  return (
+    <div>
+      <div className="flex overflow-x-auto space-x-3 border-b border-gray-300 mb-2">
+        {codeBlockLabels.map((label, index) => {
+          const isLabelActive = activeCodeBlockIndex === index
+          return (
+            <div
+              key={label}
+              className={cx('py-1', { 'border-b-2 border-gray-700': isLabelActive })}
+            >
+              <a
+                className={isLabelActive ? '' : 'hover:text-gray-900 cursor-pointer'}
+                onClick={() => selectCodeBlock(index)}
+              >
+                {label}
+              </a>
+            </div>
+          )
+        })}
+      </div>
+
+      {children[activeCodeBlockIndex]}
+    </div>
+  )
+}
+
+export function CodeBlock({ children }) {
+  return <div>{children}</div>
+}

--- a/src/pages/docs/browser-support.mdx
+++ b/src/pages/docs/browser-support.mdx
@@ -3,6 +3,8 @@ title: Browser Support
 description: Understanding which browsers Tailwind supports and how to manage vendor prefixes.
 ---
 
+import { CodeBlock, CodeGroup } from '@/components/CodeGroup'
+
 As of v2.0, Tailwind CSS is designed for and tested on the latest stable versions of Chrome, Firefox, Edge, and Safari. Tailwind CSS v2.0 does not support any version of IE, including IE 11.
 
 If you need to support IE 11, we recommend using Tailwind CSS v1.9, which is still an excellent and very productive framework.
@@ -15,15 +17,24 @@ If you're compiling your CSS using the `tailwindcss` CLI tool, vendor prefixes w
 
 If not, we recommend that you use [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-To use it, install it via npm:
+To use it, install it using your favorite package manager:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
-# Using npm
 npm install autoprefixer
+```
 
-# Using Yarn
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
 yarn add autoprefixer
 ```
+
+  </CodeBlock>
+</CodeGroup>
 
 Then add it to the very end of your plugin list in your PostCSS configuration:
 

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -8,8 +8,7 @@ import { List, ListItemBad } from '@/components/List'
 import { IntegrationGuides } from '@/components/IntegrationGuides'
 import Link from 'next/link'
 import stats from '@/utils/stats'
-
-
+import { CodeGroup, CodeBlock } from '@/components/CodeGroup'
 
 ## Integration guides
 
@@ -31,13 +30,27 @@ If you've never heard of PostCSS or are wondering how it's different from tools 
 
 If this is a bit over your head and you'd like to try Tailwind without configuring PostCSS, read our instructions on [using Tailwind without PostCSS](#using-tailwind-without-post-css) instead.
 
-### Install Tailwind via npm
+### Install Tailwind
 
-For most projects (and to take advantage of Tailwind's customization features), you'll want to install Tailwind and its peer-dependencies via npm.
+For most projects (and to take advantage of Tailwind's customization features), you'll want to install Tailwind and its peer-dependencies.
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
 npm install tailwindcss@latest postcss@latest autoprefixer@latest
 ```
+
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
+yarn add tailwindcss@latest postcss@latest autoprefixer@latest
+```
+
+  </CodeBlock>
+</CodeGroup>
+
 
 Since Tailwind [does not automatically add vendor prefixes](/docs/browser-support#vendor-prefixes) to the CSS it generates, we recommend installing [autoprefixer](https://github.com/postcss/autoprefixer) to handle this for you like we've shown in the snippet above.
 
@@ -122,7 +135,7 @@ import "tailwindcss/tailwind.css"
 
 ### Building your CSS
 
-How you actually build your project will depend on the tools that you're using. Your framework may include a command like `npm run dev` to start a development server that compiles your CSS in the background, you may be running `webpack` yourself, or maybe you're using `postcss-cli` and running a command like `postcss styles.css -o compiled.css`.
+How you actually build your project will depend on the tools that you're using. Your framework may include a command like `npm run dev` / `yarn dev` to start a development server that compiles your CSS in the background, you may be running `webpack` yourself, or maybe you're using `postcss-cli` and running a command like `postcss styles.css -o compiled.css`.
 
 If you're already familiar with PostCSS you probably know what you need to do, if not refer to the documentation for the tool you are using.
 
@@ -323,16 +336,46 @@ To help bridge the gap until everyone has updated, we also publish a PostCSS 7 c
 
 If you run into the error mentioned above, uninstall Tailwind and re-install using the compatibility build instead:
 
+<CodeGroup>
+  <CodeBlock label="NPM">
+
 ```shell
 npm uninstall tailwindcss postcss autoprefixer
 npm install tailwindcss@npm:@tailwindcss/postcss7-compat @tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9
 ```
 
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
+yarn remove tailwindcss postcss autoprefixer
+yarn add tailwindcss@npm:@tailwindcss/postcss7-compat @tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9
+```
+
+  </CodeBlock>
+</CodeGroup>
+
+
 The compatibility build is identical to the main build in every way, so you aren't missing out on any features or anything like that.
 
 Once the rest of your tools have added support for PostCSS 8, you can move off of the compatibility build by re-installing Tailwind and its peer-dependencies using the `latest` tag:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
 npm uninstall tailwindcss @tailwindcss/postcss7-compat
 npm install tailwindcss@latest postcss@latest autoprefixer@latest
 ```
+
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
+yarn remove tailwindcss @tailwindcss/postcss7-compat
+yarn add tailwindcss@latest postcss@latest autoprefixer@latest
+```
+
+  </CodeBlock>
+</CodeGroup>
+

--- a/src/pages/docs/upgrading-to-v2.mdx
+++ b/src/pages/docs/upgrading-to-v2.mdx
@@ -3,6 +3,8 @@ title: "Upgrade Guide"
 description: "Upgrading from Tailwind CSS v1.x to v2.0."
 ---
 
+import { CodeGroup, CodeBlock } from '@/components/CodeGroup'
+
 Tailwind CSS v2.0 is the first new major version since v1.0 was released in May 2019, and as such it includes a handful of small breaking changes.
 
 We don't take breaking changes lightly and have worked hard to make sure the upgrade path is as simple as possible. For most projects, upgrading should take less than 30 minutes.
@@ -15,11 +17,24 @@ If your project uses the `@tailwindcss/ui` plugin, be sure to read the [Tailwind
 
 Tailwind CSS v2.0 has been updated for the latest PostCSS release which requires installing `postcss` and `autoprefixer` as peer dependencies alongside Tailwind itself.
 
-Update Tailwind and install PostCSS and autoprefixer using npm:
+Update Tailwind and install PostCSS and autoprefixer:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
 npm install tailwindcss@latest postcss@latest autoprefixer@latest
 ```
+
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
+yarn add tailwindcss@latest postcss@latest autoprefixer@latest
+```
+
+  </CodeBlock>
+</CodeGroup>
 
 If you run into issues, you may need to use our [PostCSS 7 compatibility build](/docs/installation#post-css-7-compatibility-build) instead.
 

--- a/src/pages/docs/using-with-preprocessors.mdx
+++ b/src/pages/docs/using-with-preprocessors.mdx
@@ -4,6 +4,7 @@ description: A guide to using Tailwind with common CSS preprocessors like Sass, 
 ---
 
 import { TipGood, TipBad } from '@/components/Tip'
+import { CodeGroup, CodeBlock } from '@/components/CodeGroup'
 
 Since Tailwind is a PostCSS plugin, there's nothing stopping you from using it with Sass, Less, Stylus, or other preprocessors, just like you can with other PostCSS plugins like [Autoprefixer](https://github.com/postcss/autoprefixer).
 
@@ -30,15 +31,24 @@ One of the most useful features preprocessors offer is the ability to organize y
 
 The canonical plugin for handling this with PostCSS is [postcss-import](https://github.com/postcss/postcss-import).
 
-To use it, install the plugin via npm:
+To use it, install the plugin:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
-# npm
 npm install postcss-import
+```
 
-# yarn
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
 yarn add postcss-import
 ```
+
+  </CodeBlock>
+</CodeGroup>
 
 Then add it as the very first plugin in your PostCSS configuration:
 
@@ -132,15 +142,24 @@ To add support for nested declarations, you have two options:
 
 - [postcss-nesting](https://github.com/jonathantneal/postcss-nesting), which follows the [CSS Nesting](https://drafts.csswg.org/css-nesting-1/) specification that will hopefully be available directly in the browser in the future.
 
-To use either of these plugins, install them via npm:
+To use either of these plugins, install them:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
-# npm
 npm install postcss-nested  # or postcss-nesting
+```
 
-# yarn
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
 yarn add postcss-nested  # or postcss-nesting
 ```
+
+  </CodeBlock>
+</CodeGroup>
 
 Then add them to your PostCSS configuration, somewhere after Tailwind itself but before Autoprefixer:
 
@@ -162,15 +181,24 @@ These days CSS variables (officially known as custom properties) have really goo
 
 However if you need to support IE11, you can use the [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) plugin to automatically create fallbacks for your variables.
 
-To use it, install it via npm:
+To use it, install it using your favorite package manager:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
-# npm
 npm install postcss-custom-properties
+```
 
-# yarn
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
 yarn add postcss-custom-properties
 ```
+
+  </CodeBlock>
+</CodeGroup>
 
 Then add it to your PostCSS configuration, somewhere after Tailwind itself but before Autoprefixer:
 
@@ -191,15 +219,24 @@ module.exports = {
 
 You can add support for dozens of upcoming CSS features to your project using the [postcss-preset-env](https://github.com/csstools/postcss-preset-env) plugin.
 
-To use it, install it via npm:
+To use it, install it using your favorite package manager:
+
+<CodeGroup>
+  <CodeBlock label="NPM">
 
 ```shell
-# npm
 npm install postcss-preset-env
+```
 
-# yarn
+  </CodeBlock>
+  <CodeBlock label="Yarn">
+
+```shell
 yarn add postcss-preset-env
 ```
+
+  </CodeBlock>
+</CodeGroup>
 
 Then add it to your PostCSS configuration somewhere after Tailwind itself:
 


### PR DESCRIPTION
New CodeGroup and CodeBlock components.

Added yarn samples for the npm code samples

![code-group](https://user-images.githubusercontent.com/14073399/102613853-8a0a4b00-4133-11eb-8d4a-8c7316b935aa.gif)

So far I have only added it to the pages and not the guides. Feedback is appreciated.