### PR TITLE
Add p-2 to search bar.

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -66,7 +66,7 @@ export function Search() {
         type="button"
         ref={searchButtonRef}
         onClick={onOpen}
-        className="group leading-6 font-medium flex items-center space-x-3 sm:space-x-4 hover:text-gray-600 transition-colors duration-200"
+        className="group leading-6 font-medium flex items-center space-x-3 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 p-2"
       >
         <svg
           width="24"


### PR DESCRIPTION
Add some padding to the search bar. Initially, I also added focus styles but I think it is better to use the default browser focus styles to stay consistent with other components in the header section.

**Before**
![image](https://user-images.githubusercontent.com/33981584/103167921-3baf2780-486a-11eb-8c0a-32244c751ff8.png)


**After**
![image](https://user-images.githubusercontent.com/33981584/103167890-03a7e480-486a-11eb-8c38-6cabaca7cc17.png)
