### PR TITLE
docs: remove version from motion-safe link

### DIFF
--- a/src/pages/docs/animation.mdx
+++ b/src/pages/docs/animation.mdx
@@ -239,7 +239,7 @@ module.exports = {
 }
 ```
 
-Learn more in the [state variants documentation](/docs/hover-focus-and-other-states#motion-safe-v1-6-0).
+Learn more in the [state variants documentation](/docs/hover-focus-and-other-states#motion-safe).
 
 ## Responsive
 

--- a/src/pages/docs/transition-property.mdx
+++ b/src/pages/docs/transition-property.mdx
@@ -49,7 +49,7 @@ module.exports = {
 }
 ```
 
-Learn more in the [variants documentation](/docs/hover-focus-and-other-states#motion-safe-v1-6-0).
+Learn more in the [variants documentation](/docs/hover-focus-and-other-states#motion-safe).
 
 ## Responsive
 


### PR DESCRIPTION
Hi! 👋🏽 

Just a small fix to a couple of links.