### PR TITLE
fix(home/mobileFirst): remove extra top padding on sm screens

### DIFF
--- a/src/components/home/MobileFirst.js
+++ b/src/components/home/MobileFirst.js
@@ -95,7 +95,7 @@ const { code: html, lines, classNames } = tokenizeWithLines.html(
         imgSmContainer: 'relative hidden',
       },
       md: {
-        container: 'grid grid-cols-2 px-8 py-12 gap-x-8',
+        container: 'grid grid-cols-2 px-8 py-12 gap-x-8 pt-0',
         header: 'relative z-10 col-start-1 row-start-1 bg-none',
         preheading: 'text-sm font-medium mb-1 text-gray-500',
         heading: 'text-2xl leading-7 font-semibold text-black',


### PR DESCRIPTION
Hello ! 

When copy/pasting the code from the home/mobileFirst example, there is an extra top padding on sm screens

![image](https://user-images.githubusercontent.com/456239/103756755-1c558e80-5010-11eb-9640-268d24b3be8b.png)

A way to fix the problem is adding `sm:pt-0` to the same element that has `pt-40`.

This PR contains this exact change

Cheers


 