### PR TITLE
Order: Fix responsive paragraph

### DIFF
--- a/src/pages/docs/order.mdx
+++ b/src/pages/docs/order.mdx
@@ -29,10 +29,9 @@ Use `order-{order}` to render flex items in a different order than they appear i
 </div>
 ```
 
-
 ## Responsive
 
-To apply a flex direction utility only at a specific breakpoint, add a `{screen}:` prefix to the existing class name. For example, adding the class `md:flex-row` to an element would apply the `flex-row` utility at medium screen sizes and above.
+To apply a flex order utility only at a specific breakpoint, add a `{screen}:` prefix to the existing class name. For example, adding the class `md:order-last` to an element would apply the `order-last` utility at medium screen sizes and above.
 
 ```html
 <div class="flex">


### PR DESCRIPTION
This commit fixes the example used to explain the responsive feature for order utilities. It now matches the example below instead of referencing unrelated utility classes.