### PR TITLE
Fix link in anchor

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -272,7 +272,7 @@ Before using the CDN build, please note that many of the features that make Tail
   <ListItemBad>You can't tree-shake unused styles</ListItemBad>
 </List>
 
-To get the most out of Tailwind, you really should [install it as a PostCSS plugin](#installing-tailwind-as-a-post-css-plugin).
+To get the most out of Tailwind, you really should [install it as a PostCSS plugin](#add-tailwind-as-a-post-css-plugin).
 
 To pull in Tailwind for quick demos or just giving the framework a spin, grab the latest default configuration build via CDN:
 


### PR DESCRIPTION
Minor update because the link to adding tailwind as a PostCSS plugin within the anchor was broken. 