### PR TITLE
Update Vue 3 + Vite guide

### DIFF
--- a/src/pages/docs/guides/vue-3-vite.mdx
+++ b/src/pages/docs/guides/vue-3-vite.mdx
@@ -6,7 +6,7 @@ tool: Vue 3 and Vite
 
 ```preval installation
 tool: Vite
-script: npx create-vite-app 
+script: npm init @vitejs/app -t vue
 npmInstall: true
 ```
 
@@ -14,7 +14,7 @@ npmInstall: true
 
 ```preval setup
 dev: true
-version: compat-7
+version: latest
 ```
 
 ```preval configuration
@@ -26,7 +26,7 @@ purge:
 ```preval include
 tool: Vite
 file: ./src/index.css
-withChromiumBug: true
+create: true
 ```
 
 Finally, ensure your CSS file is being imported in your `./src/main.js` file:

--- a/src/pages/docs/guides/vue-3-vite.mdx
+++ b/src/pages/docs/guides/vue-3-vite.mdx
@@ -6,7 +6,7 @@ tool: Vue 3 and Vite
 
 ```preval installation
 tool: Vite
-script: npm init @vitejs/app -t vue
+script: npm init @vitejs/app
 npmInstall: true
 ```
 


### PR DESCRIPTION
- Vite scaffolding package changed
- Vite 2 uses postcss 8 by default
- Vite 2 has temporarily stopped using constructed stylesheets so the chrome fix is not needed
- Vite 2's Vue template no longer has the `src/index.css` so it needs to be created

Notably since, Vite 2 is now framework agnostic so maybe this can also be refactored into a more generic "Vite + X" guide.