### PR TITLE
Add pointer-events-none to ping examples so they don't overlay the buttons underneath

### DIFF
--- a/src/pages/docs/animation.mdx
+++ b/src/pages/docs/animation.mdx
@@ -146,14 +146,14 @@ Add the `animate-ping` utility to make an element scale and fade like a radar pi
     <button type="button" class="inline-flex items-center px-4 py-2 border border-gray-400 text-base leading-6 font-medium rounded-md text-gray-800 bg-white hover:text-gray-700 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:text-gray-800 active:bg-gray-50 transition ease-in-out duration-150">
       Transactions
     </button>
-    <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+    <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1 pointer-events-none">
       <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75"></span>
       <span class="relative inline-flex rounded-full h-3 w-3 bg-pink-500"></span>
     </span>
   </span>
 </template>
 
-<span class="flex h-3 w-3">
+<span class="flex h-3 w-3 pointer-events-none">
   <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75"></span>
   <span class="relative inline-flex rounded-full h-3 w-3 bg-pink-500"></span>
 </span>


### PR DESCRIPTION
As in the example, pings tend to be used on interactive buttons etc. Disabling pointer events means that the ping won't interfere with those buttons.