### PR TITLE
Fix typo in overflow.mdx example code block

### DIFF
--- a/src/pages/docs/overflow.mdx
+++ b/src/pages/docs/overflow.mdx
@@ -29,7 +29,7 @@ Use `overflow-visible` to prevent content within an element from being clipped. 
   </div>
 </template>
 
-<div class="**overflow-visible** h-24 h- ...">Lorem ipsum dolor sit amet...</div>
+<div class="**overflow-visible** h-24 ...">Lorem ipsum dolor sit amet...</div>
 ```
 
 ## Auto


### PR DESCRIPTION
Small typo I noticed while browsing the docs. Thanks for the awesome work on Tailwind CSS!