### PR TITLE
Update postcss.config.js to use array for plugins

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -82,11 +82,10 @@ npx tailwindcss init tailwindcss-config.js
 If you use a custom file name, you will need to specify it when including Tailwind as a plugin in your PostCSS configuration as well:
 
 ```js
-// postcss.config.js
 module.exports = {
-  plugins: {
-    tailwindcss: { config: './tailwindcss-config.js' },
-  },
+  plugins: [
+    require('tailwindcss')('./tailwindcss-config.js'),
+  ]
 }
 ```
 
@@ -102,10 +101,10 @@ This will generate a `postcss.config.js` file in your project that looks like th
 
 ```js
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ]
 }
 ```
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -303,11 +303,11 @@ Note that currently only [Chrome, Edge, and Firefox](https://caniuse.com/?search
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    'postcss-focus-visible': {},
-    autoprefixer: {}
-  }
+  plugins: [
+    require('tailwindcss'),
+    require('postcss-focus-visible'),
+    require('autoprefixer'),
+  ]
 }
 ```
 

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -55,10 +55,10 @@ Add `tailwindcss` and `autoprefixer` to your PostCSS configuration. Most of the 
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  }
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ]
 }
 ```
 


### PR DESCRIPTION
Hello,

I found that the tailwind documentation was using what appears to be outdated or a deprecated `postcss.config.js` .

I'm happy to make any changes and feel free to close if this isn't relevant.

Expected:
```
// postcss.config.js
module.exports = {
  plugins: [
    require('tailwindcss'),
    require('autoprefixer'),
  ]
}
```

Actual:
```
// postcss.config.js
module.exports = {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  }
}
```

