### PR TITLE
Fix typo in `plugins.mdx` example code block

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -608,7 +608,7 @@ module.exports = {
       // => undefined
 
       variants('customPlugin')
-      // => ['reponsive', 'hover', 'focus']
+      // => ['responsive', 'hover', 'focus']
     })
   ]
 }


### PR DESCRIPTION
Small typo I noticed while browsing the docs