### PR TITLE
Add instructions for react-app-rewired

### DIFF
--- a/src/pages/docs/guides/create-react-app.mdx
+++ b/src/pages/docs/guides/create-react-app.mdx
@@ -58,6 +58,8 @@ module.exports = {
 }
 ```
 
+If you're planning to use any other PostCSS plugins, you should read our documentation on [using PostCSS as your preprocessor](/docs/using-with-preprocessors) for more details about the best way to order them alongside Tailwind.
+
 ### Install and configure Rewired
 
 Alternatively you can use [react-app-rewired](https://github.com/timarney/react-app-rewired) :

--- a/src/pages/docs/guides/create-react-app.mdx
+++ b/src/pages/docs/guides/create-react-app.mdx
@@ -58,7 +58,42 @@ module.exports = {
 }
 ```
 
-If you're planning to use any other PostCSS plugins, you should read our documentation on [using PostCSS as your preprocessor](/docs/using-with-preprocessors) for more details about the best way to order them alongside Tailwind.
+### Install and configure Rewired
+
+Alternatively you can use [react-app-rewired](https://github.com/timarney/react-app-rewired) :
+
+```shell
+npm install react-app-rewired customize-cra
+```
+
+Once it's installed, update your `scripts` in your `package.json` file to use `react-app-rewired` instead of `react-scripts`:
+
+```diff-json
+  {
+    // ...
+    "scripts": {
+-     "start": "react-scripts start",
+-     "build": "react-scripts build",
+-     "test": "react-scripts test",
+-     "eject": "react-scripts eject"
++     "start": "react-app-rewired start",
++     "build": "react-app-rewired build",
++     "test": "react-app-rewired test",
++     "eject": "react-app-rewired eject"
+    },
+  }
+```
+
+Next, create a `config-overrides.js` at the root of our project and add the `tailwindcss` and `autoprefixer` as PostCSS plugins:
+
+```js
+// config-overrides.js
+const { override, addPostcssPlugins } = require('customize-cra')
+
+module.exports = override(
+  addPostcssPlugins([require('tailwindcss'), require("autoprefixer")])
+)
+```
 
 ```preval configuration
 postcss: false


### PR DESCRIPTION
Hello,
as it took me some time to find out about making `tailwind` work with `react-app-rewired` I thought it might be timesaving to add it to docs.