### PR TITLE
Revert "Update postcss.config.js to use array for plugins"

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -82,10 +82,11 @@ npx tailwindcss init tailwindcss-config.js
 If you use a custom file name, you will need to specify it when including Tailwind as a plugin in your PostCSS configuration as well:
 
 ```js
+// postcss.config.js
 module.exports = {
-  plugins: [
-    require('tailwindcss')('./tailwindcss-config.js'),
-  ]
+  plugins: {
+    tailwindcss: { config: './tailwindcss-config.js' },
+  },
 }
 ```
 
@@ -101,10 +102,10 @@ This will generate a `postcss.config.js` file in your project that looks like th
 
 ```js
 module.exports = {
-  plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
-  ]
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }
 ```
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -303,11 +303,11 @@ Note that currently only [Chrome, Edge, and Firefox](https://caniuse.com/?search
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: [
-    require('tailwindcss'),
-    require('postcss-focus-visible'),
-    require('autoprefixer'),
-  ]
+  plugins: {
+    tailwindcss: {},
+    'postcss-focus-visible': {},
+    autoprefixer: {}
+  }
 }
 ```
 

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -55,10 +55,10 @@ Add `tailwindcss` and `autoprefixer` to your PostCSS configuration. Most of the 
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
-  ]
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
 }
 ```
 


### PR DESCRIPTION
Going to revert this for now because our own `tailwindcss init -p` command uses the object syntax, and the array syntax with `require` doesn't work in Next.js. Going to continue recommending object syntax for now, we can switch to the array syntax that uses tuples in the future instead if we can verify it's well supported by tools that integrate PostCSS out of the box.