### PR TITLE
Fix a typo in PostCSS 7 compatibility build

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -334,7 +334,7 @@ If you run into the error mentioned above, uninstall Tailwind and re-install usi
 
 ```shell
 npm uninstall tailwindcss postcss autoprefixer
-npm install tailwindcss@npm:@tailwindcss/postcss7-compat @tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9
+npm install tailwindcss@compat @tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9
 ```
 
 The compatibility build is identical to the main build in every way, so you aren't missing out on any features or anything like that.


### PR DESCRIPTION
The `compat` tag is actually published to npm: https://www.npmjs.com/package/tailwindcss