### PR TITLE
Fix Laravel Installer link

### DIFF
--- a/src/pages/docs/guides/laravel.mdx
+++ b/src/pages/docs/guides/laravel.mdx
@@ -8,7 +8,7 @@ tool: Laravel Mix
 tool: Laravel
 reference:
   name: the Laravel Installer 
-  link: https://laravel.com/docs/8.x#via-laravel-installer
+  link: https://laravel.com/docs/8.x#the-laravel-installer
 script: laravel new
 npmInstall: true
 ```


### PR DESCRIPTION
After the latest Laravel docs update, the link to the Laravel Installer section has been changed.