### PR TITLE
Adding notes about the fade to transparency

### DIFF
--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -47,7 +47,7 @@ Set the starting color of a gradient using the `from-{color}` utilities.
 <div class="bg-gradient-to-r **from-red-500** ..."></div>
 ```
 
-Gradients fade out to transparent by default without adding the ending color class. This is on purpose to make the notation concise, but also because iOS Safari still has a [bug](https://bugs.webkit.org/show_bug.cgi?id=150940) related to CoreGraphics being unable to interpolate the keyword "transparent". In such, do not use `to-transparent` to set a color to fade to its transparent counterpart. It will work in most browsers, but smudge your gradient on Safari for iOS.
+Gradients fade out to transparent by default without adding the ending color class. This is on purpose to make the notation concise, but also because iOS Safari still has a [bug](https://bugs.webkit.org/show_bug.cgi?id=150940) related to CoreGraphics being unable to interpolate the keyword "transparent". In such, do not use `to-transparent` to set a color to fade to its transparent counterpart. It will work in most browsers, but not on Safari for iOS.
 
 ```diff-html
 - <div class="bg-gradient-to-r from-red-500 to-transparent"></div>

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -47,7 +47,7 @@ Set the starting color of a gradient using the `from-{color}` utilities.
 <div class="bg-gradient-to-r **from-red-500** ..."></div>
 ```
 
-Gradients fade out to transparent by default without adding the ending color class. This is on purpose to make the notation concise, but also because iOS Safari still has a [bug](https://bugs.webkit.org/show_bug.cgi?id=150940) related to CoreGraphics being unable to interpolate the keyword "transparent". In such, do not use `to-transparent` to set a color to fade to its transparent counterpart. It will work in most browsers, but not on Safari for iOS.
+Gradients fade out to transparent by default without adding the ending color class. This is on purpose to make the notation concise, but also because iOS Safari still has a [bug](https://bugs.webkit.org/show_bug.cgi?id=150940) related to CoreGraphics being unable to interpolate the keyword `transparent`. In such, do not use `to-transparent` to set a color to fade to its transparent counterpart. It will work in most browsers, but not on Safari for iOS.
 
 ```diff-html
 - <div class="bg-gradient-to-r from-red-500 to-transparent"></div>

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -47,7 +47,12 @@ Set the starting color of a gradient using the `from-{color}` utilities.
 <div class="bg-gradient-to-r **from-red-500** ..."></div>
 ```
 
-Gradients fade out to transparent by default.
+Gradients fade out to transparent by default without adding the ending color class. This is on purpose to make the notation concise, but also because iOS Safari still has a [bug](https://bugs.webkit.org/show_bug.cgi?id=150940) related to CoreGraphics being unable to interpolate the keyword "transparent". In such, do not use `to-transparent` to set a color to fade to its transparent counterpart. It will work in most browsers, but smudge your gradient on Safari for iOS.
+
+```diff-html
+- <div class="bg-gradient-to-r from-red-500 to-transparent"></div>
++ <div class="bg-gradient-to-r from-red-500"></div>
+```
 
 ## Ending color
 


### PR DESCRIPTION
Hi!

I just hit this bug on iOS for the 1000th time in my career and all because I had the good intention of writing concisely "to-transparent" where I wanted my gradients to fade to transparent. After analyzing Tailwind's gradients code, I had a POG moment seeing that the fade to the correct transparency with rgba was default. I read this documentation page multiple times before, but didn't notice that it was mentioned and didn't realize it was also to prevent this iOS bug (be it willingly or not). So I thought adding a little more details couldn't hurt. 

Feel free to reject or reword! 🔥