### PR TITLE
Remove dots from animation classes

### DIFF
--- a/src/pages/docs/animation.mdx
+++ b/src/pages/docs/animation.mdx
@@ -23,7 +23,7 @@ export const classes = (
       <tbody className="align-baseline">
         <tr>
           <td className="py-2 font-mono text-xs text-violet-600 whitespace-nowrap">
-            .animate-none
+            animate-none
           </td>
           <td className="py-2 font-mono text-xs text-light-blue-600 whitespace-pre">
             animation: none;
@@ -31,7 +31,7 @@ export const classes = (
         </tr>
         <tr>
           <td className="py-2 font-mono text-xs text-violet-600 whitespace-nowrap border-t border-gray-200">
-            .animate-spin
+            animate-spin
           </td>
           <td className="py-2 font-mono text-xs text-light-blue-600 whitespace-pre border-t border-gray-200">
             {redent(`
@@ -49,7 +49,7 @@ export const classes = (
         </tr>
         <tr>
           <td className="py-2 font-mono text-xs text-violet-600 whitespace-nowrap border-t border-gray-200">
-            .animate-ping
+            animate-ping
           </td>
           <td className="py-2 font-mono text-xs text-light-blue-600 whitespace-pre border-t border-gray-200">
             {redent(`
@@ -65,7 +65,7 @@ export const classes = (
         </tr>
         <tr>
           <td className="py-2 font-mono text-xs text-violet-600 whitespace-nowrap border-t border-gray-200">
-            .animate-pulse
+            animate-pulse
           </td>
           <td className="py-2 font-mono text-xs text-light-blue-600 whitespace-pre border-t border-gray-200">
             {redent(`
@@ -83,7 +83,7 @@ export const classes = (
         </tr>
         <tr>
           <td className="py-2 font-mono text-xs text-violet-600 whitespace-nowrap border-t border-gray-200">
-            .animate-bounce
+            animate-bounce
           </td>
           <td className="py-2 font-mono text-xs text-light-blue-600 whitespace-pre border-t border-gray-200">
             {redent(`


### PR DESCRIPTION
Unlike other classes in the documentation, classes for animation had dots in the names. This PR removes the dots.