### PR TITLE
Fix outline focus color to ring-blue-500

### DIFF
--- a/src/pages/docs/outline.mdx
+++ b/src/pages/docs/outline.mdx
@@ -20,7 +20,7 @@ It is highly recommended to apply your own focus styling for accessibility when 
 <template preview>
   <div class="flex space-x-6 justify-center">
     <input type="text" class="px-4 py-3 leading-5 border rounded-md" placeholder="Default focus style" />
-    <input type="text" class="px-4 py-3 leading-5 border rounded-md focus:outline-none focus:ring focus:border-blue-400" placeholder="Custom focus style" />
+    <input type="text" class="px-4 py-3 leading-5 border rounded-md focus:outline-none focus:ring focus:ring-blue-400" placeholder="Custom focus style" />
   </div>
 </template>
 


### PR DESCRIPTION
 - The website example didn't seem to do anything even when I
   removed focus:border-blue-400. The ring documentation suggested
   ring prefix instead of border. This seemed to work.
---

Note: It only looks the same as the default when I use blue-500 and focus:ring-opacity-50 in. But I did not want to make a change on something I didn't understand. 