### PR TITLE
fix(docs): delete Pink in customizing-colors (ISSUE: #751)

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -236,8 +236,7 @@ module.exports = {
       gray: colors.coolGray,
       red: colors.red,
       yellow: colors.amber,
-      blue: colors.blue,
-      pink: colors.pink,
+      blue: colors.blue
     }
   }
 }


### PR DESCRIPTION
[What is] This fixes a mistake about of the documentation about excluding colors.
[Issue] https://github.com/tailwindlabs/tailwindcss.com/issues/751
[URL] https://tailwindcss.com/docs/customizing-colors#disabling-a-default-color
[Photo] 

![Captura de pantalla 2021-02-13 a las 19 25 31](https://user-images.githubusercontent.com/15108191/107858238-788fa780-6e33-11eb-99e2-e42e32704c7b.png)
