### PR TITLE
fix(docs): delete 'opacity-50' in items SidebarLayout.js (ISSUE: #744)

### DIFF
--- a/src/layouts/SidebarLayout.js
+++ b/src/layouts/SidebarLayout.js
@@ -21,8 +21,7 @@ const NavItem = forwardRef(({ href, children, isActive, isPublished, fallbackHre
         >
           <span
             className={clsx('rounded-md absolute inset-0 bg-cyan-50', {
-              'opacity-50': isActive,
-              'opacity-0': !isActive,
+              'opacity-0': !isActive
             })}
           />
           <span className="relative">{children}</span>


### PR DESCRIPTION
[What is] Remove `opacity-50` when item is selected in SidebarLayout because the contrast is poor.
[Issue] #744
[URL] https://tailwindcss.com, when item is selected in Sidebar