### PR TITLE
docs: add Angular integration guide

### DIFF
--- a/src/components/IntegrationGuides.js
+++ b/src/components/IntegrationGuides.js
@@ -40,6 +40,11 @@ const guides = [
     logo: GatsbyLogo,
     link: '/docs/guides/gatsby',
   },
+  {
+    name: 'Angular',
+    logo: AngularLogo,
+    link: '/docs/guides/angular',
+  },
 ]
 
 export function IntegrationGuides() {

--- a/src/pages/docs/guides/angular.mdx
+++ b/src/pages/docs/guides/angular.mdx
@@ -20,100 +20,24 @@ script: ng new
 
 ```preval setup
 version: latest 
-dependencies:
-  - postcss-loader
-  - '@angular-builders/custom-webpack'
 ```
 
 
 ```preval configuration
 postcss: false
 purge: 
-  - ./resources/**/*.blade.php
-  - ./resources/**/*.js
-  - ./resources/**/*.vue
+  - ./src/**/*.{html,ts}
 ```
 
-Next, let's create a `webpack.config.js` at the root of our project, and tell webpack to handle CSS files with the `postcss-loader`:
-
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        loader: "postcss-loader",
-        options: {
-          postcssOptions: {
-            ident: "postcss",
-            plugins: () => [require("tailwindcss"), require("autoprefixer")],
-          },
-        },
-      },
-    ],
-  },
-}
-```
 
 ```preval include
 file: ./src/styles.css
-```
-
-Finally, we need to update the `angular.json` file to let it know about our custom webpack config. We'll need to update the `architect.build` and `architect.serve` sections of the config.
-
-Locate the `architect.build` key, and under `builder`, replace `@angular-devkit/build-angular:browser` with `@angular-builders/custom-webpack:browser`.
-
-```diff-json
-  "architect": {
-    "build": {
--      "builder": "@angular-devkit/build-angular:browser"
-+      "builder": "@angular-builders/custom-webpack:browser"
-    }
-  }
-```
-
-In the `options` just below, add a `customWebpackConfig` object with the `path` to the webpack config:
-
-```diff-json
-  "architect": {
-    "build": {
-      "builder": "@angular-builders/custom-webpack:browser",
-      "options": {
-+       "customWebpackConfig": {
-+         "path": "./webpack.config.js"
-+       },
-        "outputPath": "dist/angular",
-      }
-    }
-  }
-```
-
-Now, let's do something very similar in `architect.serve`:
-
-```diff-json
-  "architect": {
-    "serve": {
--     "builder": "@angular-devkit/build-angular:dev-server",
-+     "builder": "@angular-builders/custom-webpack:dev-server",
-      "options": {
-        "browserTarget": "angular:build",
-+       "customWebpackConfig": {
-+         "path": "./webpack.config.js"
-+       }
-      }
-    }
-  }
-```
-
-```preval configuration
-purge: 
-  - ./path/to/files 
 ```
 
 ---
 
 ```preval finish
 scripts:
-  - npm run start
+  - ng build
 ```
 


### PR DESCRIPTION
Angular supports Tailwind out of the box from version `11.2` https://github.com/angular/angular-cli/pull/19935
So the integration guide will be pretty simple.

There are two known issues (I've described them detailed in Angulars repo https://github.com/angular/angular-cli/issues/20015):
1. Angular is not setting `process.env.NODE_ENV` to `production` (reasonable https://github.com/angular/angular-cli/issues/20015#issuecomment-777760069), so right now purge is not working.
I think this is pretty critical, so I mark this PR as a draft until [this](https://github.com/angular/angular-cli/pull/20036) or other PR with fix will be merged.
2. Tailwind dark mode directives won't work correctly in component styles with view encapsulation other than `none`, as tailwind will just try to prepend class with `.dark`, so the result code will be something like `.dark[_ng-content-**] .value[_ng-content-**]` instead of expected `.dark .value[_ng-content-**]`

The Angular team response:
> Regarding point 2: ViewEncapsulation.None will be highly recommended with Tailwind due to the reasons you mentioned. View encapsulation doesn't really provide much value for Tailwind users anyways, since most styling is done via directly applied classes. We're hoping to avoid building additional tooling and over-engineer a solution where ViewEncapsulation.None would solve most of those issues

I don't think that this is a critical issue, but maybe it should be mentioned in the guide? Or maybe you would want to plan some fixes on your side towards Angular?