### PR TITLE
Add DEV Community link

### DIFF
--- a/src/components/home/Footer.js
+++ b/src/components/home/Footer.js
@@ -21,6 +21,7 @@ const footerNav = {
     items: [
       { title: 'GitHub', href: 'https://github.com/tailwindlabs/tailwindcss' },
       { title: 'Discord', href: '/discord' },
+      { title: 'DEV Community', href: 'https://dev.to/t/tailwindcss' },
       { title: 'Twitter', href: 'https://twitter.com/tailwindcss' },
       { title: 'YouTube', href: 'https://www.youtube.com/tailwindlabs' },
     ],

--- a/src/pages/community.mdx
+++ b/src/pages/community.mdx
@@ -24,6 +24,13 @@ Found a bug, have a feature request, or want to contribute to the framework itse
 
 [Contribute to Tailwind &rarr;](https://github.com/tailwindlabs/tailwindcss)
 
+## DEV Community
+
+Blog posts, guides and questions are posted to DEV every day.
+
+[Follow the Tailwind tag on DEV &rarr;](https://dev.to/t/tailwindcss)
+
+
 ## Twitter
 
 Want to keep up with what's new in the Tailwind ecosystem? We post all release announcements on Twitter, and share lots of interesting work from the community.


### PR DESCRIPTION
This adds a link to https://dev.to/t/tailwindcss.

This follows a similar pattern to how other projects such as Vue and React link to their tags with this same anchor text in the footer of their sites in order to guide folks towards these resources. 

`#tailwindcss` is the official canonical supported tag on DEV Community. If y'all ever want representation in the moderation of this tag, feel free to reach out to yo@dev.to.

### Screenshots:

<img width="416" alt="Screen Shot 2021-02-18 at 12 57 38 PM" src="https://user-images.githubusercontent.com/3102842/108400208-f44d7380-71e8-11eb-8639-5a554db67d2d.png">
<img width="802" alt="Screen Shot 2021-02-18 at 12 57 50 PM" src="https://user-images.githubusercontent.com/3102842/108400209-f44d7380-71e8-11eb-8670-eff11cbafba1.png">
