### PR TITLE
Wrap headings in anchors

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -38,26 +38,29 @@ export function Heading({
       style={{ ...(hidden ? { marginBottom: 0 } : {}), ...style }}
       {...props}
     >
-      {!hidden && (
-        // eslint-disable-next-line
-        <a
-          href={`#${id}`}
-          className="absolute after:hash opacity-0 group-hover:opacity-100"
-          style={{ marginLeft: '-1em', paddingRight: '0.5em', boxShadow: 'none', color: '#a1a1aa' }}
-          aria-label="Anchor"
-        />
-      )}
-      {number && (
-        <span className="bg-cyan-100 w-8 h-8 inline-flex items-center justify-center rounded-full text-cyan-700 text-xl mr-3 flex-none">
-          {number}
-        </span>
-      )}
-      <span className={hidden ? 'sr-only' : undefined}>{children}</span>
-      {badge && (
-        <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-green-150 text-green-900">
-          {badge}
-        </span>
-      )}
+      <a
+        href={`#${id}`}
+        style={{ fontWeight: 700, boxShadow: 'none', color: '#111827' }}
+      >
+        {!hidden && (
+            <nav
+              className="absolute after:hash opacity-0 group-hover:opacity-100 hidden lg:block"
+              style={{ marginLeft: '-1em', paddingRight: '0.5em', boxShadow: 'none', fontWeight: 500, color: '#a1a1aa' }}
+              aria-label="Anchor"
+            />
+        )}
+        {number && (
+          <span className="bg-cyan-100 w-8 h-8 inline-flex items-center justify-center rounded-full text-cyan-700 text-xl mr-3 flex-none">
+            {number}
+          </span>
+        )}
+        <span className={clsx({ 'sr-only': hidden }, 'pb-1 border-b border-transparent border-dashed group-hover:border-gray-200')}>{children}</span>
+        {badge && (
+          <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-green-150 text-green-900">
+            {badge}
+          </span>
+        )}
+      </a>
     </Component>
   )
 }


### PR DESCRIPTION
This is a re-write of #646 

This wraps the headings in the anchor tag, with additional style overrides to counter the `.prose a` rules to bring the design back to how it is now.

The # is now hidden on breakpoints smaller than lg since there's not space for it there.

On lg and larger:
![Screenshot 2021-03-03 at 11 34 50](https://user-images.githubusercontent.com/6286310/109799974-8e171680-7c14-11eb-815e-2633847e3a42.png)

Smaller than lg:
![Screenshot 2021-03-03 at 11 37 00](https://user-images.githubusercontent.com/6286310/109800373-fe259c80-7c14-11eb-978d-d6bc451dbfea.jpg)