### PR TITLE
Fixed CSS variable names

### DIFF
--- a/src/pages/docs/ring-offset-color.mdx
+++ b/src/pages/docs/ring-offset-color.mdx
@@ -10,7 +10,7 @@ import { Disabling } from '@/components/Disabling'
 export const classes = {
   plugin,
   transformProperties: ({ selector, properties }) => {
-    properties['box-shadow'] = `0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow)`
+    properties['box-shadow'] = `0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color), var(--tw-ring-shadow)`
     return properties
   }
 }

--- a/src/pages/docs/ring-offset-width.mdx
+++ b/src/pages/docs/ring-offset-width.mdx
@@ -10,7 +10,7 @@ import { Disabling } from '@/components/Disabling'
 export const classes = {
   plugin,
   transformProperties: ({ selector, properties }) => {
-    properties['box-shadow'] = `0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow)`
+    properties['box-shadow'] = `0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color), var(--tw-ring-shadow)`
     return properties
   }
 }


### PR DESCRIPTION
Ring CSS variables are now using a 'tw-' prefix.

Affected pages:
- https://tailwindcss.com/docs/ring-offset-width
- https://tailwindcss.com/docs/ring-offset-color