### PR TITLE
Update Next.js <> Tailwind guide.

### DIFF
--- a/src/pages/docs/guides/nextjs.mdx
+++ b/src/pages/docs/guides/nextjs.mdx
@@ -8,8 +8,10 @@ tool: Next.js
 reference:
   name: Create Next App
   link: https://nextjs.org/docs/api-reference/create-next-app
-script: npx create-next-app
+script: npx create-next-app -e with-tailwindcss
 ```
+
+This will automatically configure your Tailwind setup based on the official Next.js example. If you'd like to configure Tailwind manually, continue with the rest of this guide.
 
 ---
 


### PR DESCRIPTION
While reviewing [this PR](https://github.com/vercel/next.js/pull/22964), I realized the docs should suggest using the official example as they're [now identical](https://github.com/vercel/next.js/pull/19750).

Let me know if the format of the PR is correct (wasn't sure with the preval stuff). Thanks!