### PR TITLE
Fix line in Next.js guide for coding style consistency

### DIFF
--- a/src/pages/docs/guides/nextjs.mdx
+++ b/src/pages/docs/guides/nextjs.mdx
@@ -36,7 +36,7 @@ If you aren't planning to write any custom CSS in your project, the fastest way 
 ```diff-js
   // pages/_app.js
 - import '../styles/globals.css'
-+ import "tailwindcss/tailwind.css";
++ import 'tailwindcss/tailwind.css'
 
   function MyApp({ Component, pageProps }) {
     return <Component {...pageProps} />


### PR DESCRIPTION
This is a small change.

Basically, the coding style used in Next.js by default (and in the guide) is to use single quotes and without semicolons. The added import from the guide instructions is:

```js
import "tailwindcss/tailwind.css";
```

But, for consistency with the rest of the docs, it should be:

```js
import 'tailwindcss/tailwind.css'
```