### PR TITLE
Fixed bug in code sample container DEFAULT -> default

### DIFF
--- a/src/pages/docs/container.mdx
+++ b/src/pages/docs/container.mdx
@@ -127,7 +127,7 @@ module.exports = {
   theme: {
     container: {
       padding: {
-        DEFAULT: '1rem',
+        default: '1rem',
         sm: '2rem',
         lg: '4rem',
         xl: '5rem',


### PR DESCRIPTION
The container page contains a snipped on how to deal with responsive containers and it's default padding. To set a default padding you have to use the 'default' key. In the example code snippet it actually shows 'DEFAULT', which doesn't work. This PR fixes that.