### PR TITLE
MaxWidth-Section: Clarify `max-width-screen-*`

### DIFF
--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -65,7 +65,7 @@ For more information about Tailwind's responsive design features, check out the 
 
 ## Responsive breakpoint
 
-The `max-w-screen-*\` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
+The `max-w-screen-*` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
 
 ```html
 <div class="max-w-screen-2xl">
@@ -79,7 +79,7 @@ The `max-w-screen-*\` classes are derived from the [`theme.screens` section](/do
 
 ### Max-Width Scale
 
-Customize Tailwind's default max-width scale for the `max-w-\*` classes in the `theme.maxWidth` section of your `tailwind.config.js` file. 
+Customize Tailwind's default max-width scale for the `max-w-*` classes in the `theme.maxWidth` section of your `tailwind.config.js` file. 
 
 ```diff-js
   // tailwind.config.js
@@ -94,7 +94,7 @@ Customize Tailwind's default max-width scale for the `max-w-\*` classes in the `
   }
 ```
 
-The `max-w-screen-*\` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
+The `max-w-screen-*` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
 
 Learn more about customizing the default theme in the [theme customization documentation](/docs/theme#customizing-the-default-theme).
 

--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -15,7 +15,7 @@ export const classes = {
 
 ## Usage
 
-Set the maximum width of an element using the `max-w-{size}` utilities.
+Set the maximum width of an element using the `max-w-{size}` or `max-w-screen-{breakpoint}` utilities.
 
 ```html emerald
 <template preview>
@@ -63,11 +63,23 @@ For more information about Tailwind's responsive design features, check out the 
 
 ---
 
+## Responsive breakpoint
+
+The `max-w-screen-*\` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
+
+```html
+<div class="max-w-screen-2xl">
+  <!-- ... -->
+</div>
+```
+
+---
+
 ## Customizing
 
 ### Max-Width Scale
 
-Customize Tailwind's default max-width scale in the `theme.maxWidth` section of your `tailwind.config.js` file.
+Customize Tailwind's default max-width scale for the `max-w-\*` classes in the `theme.maxWidth` section of your `tailwind.config.js` file. 
 
 ```diff-js
   // tailwind.config.js
@@ -81,6 +93,8 @@ Customize Tailwind's default max-width scale in the `theme.maxWidth` section of 
     }
   }
 ```
+
+The `max-w-screen-*\` classes are derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
 
 Learn more about customizing the default theme in the [theme customization documentation](/docs/theme#customizing-the-default-theme).
 


### PR DESCRIPTION
Clarify that the `max-width-screen-*` classes use the themen.screen configuration.

We changed our themen.screens settings last week and lost some max-width-screen-* classes due to this change which I was not aware of and did not find any reference about in the docs. This PRs is an attempt to clarify the secondary source of values (not only the size-, but also the screen-values are used).

I understand this PR more as an github-issue with some pointer to where I was missing information. If it's also something that can be merged, all the better; otherwise please treat it as an issue with a problem description and suggestion.