### PR TITLE
Fix logo being cut off on Firefox

### DIFF
--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -1,6 +1,6 @@
 export function Logo(props) {
   return (
-    <svg viewBox="0 0 247 31" {...props}>
+    <svg viewBox="0 0 248 31" {...props}>
       <path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
The Tailwind logo is cut off at the right on Firefox.

![image](https://user-images.githubusercontent.com/25698647/113458058-64b2fb80-9409-11eb-8f2a-5f842e1b73cd.png)

This commit fixes this issue by increasing the logo's viewBox width by 1.