### PR TITLE
Fixed Typo in Documentation

### DIFF
--- a/src/pages/docs/container.mdx
+++ b/src/pages/docs/container.mdx
@@ -81,7 +81,7 @@ If you'd like to center your containers by default or include default horizontal
 The `container` class also includes responsive variants like `md:container` by default that allow you to make something behave like a container at only a certain breakpoint and up:
 
 ```html
-<!-- Full-width fluid until the `lg` breakpoint, then lock to container -->
+<!-- Full-width fluid until the `md` breakpoint, then lock to container -->
 <div class="**md:container md:mx-auto**">
   <!-- ... -->
 </div>


### PR DESCRIPTION
Comment didn't match the code snippet. The `div` will be Full-width fluid until the `md` breakpoint, not `lg` breakpoint according to code snippet.