### PR TITLE
Add missing closing tags to Whitespace page

### DIFF
--- a/src/pages/docs/whitespace.mdx
+++ b/src/pages/docs/whitespace.mdx
@@ -93,6 +93,7 @@ Use `whitespace-pre-line` to preserve newlines but not spaces within an element.
       laudantium quibusdam illo nihil,
 
   reprehenderit saepe quam aliquid odio accusamus.</div>
+  </div>
 </template>
 
 <div class="w-3/4 ...">
@@ -116,6 +117,7 @@ Use `whitespace-pre-wrap` to preserve newlines and spaces within an element. Tex
       laudantium quibusdam illo nihil,
 
   reprehenderit saepe quam aliquid odio accusamus.</div>
+  </div>
 </template>
 
 <div class="w-3/4 ...">
@@ -124,6 +126,7 @@ Use `whitespace-pre-wrap` to preserve newlines and spaces within an element. Tex
       laudantium quibusdam illo nihil,
 
   reprehenderit saepe quam aliquid odio accusamus.</div>
+</div>
 ```
 
 ## Responsive


### PR DESCRIPTION
There are some formatting issues on the Whitespace page, that are visible in the "Pre Wrap" section here:

https://tailwindcss.com/docs/whitespace#pre-wrap

This PR adds some missing closing tags, which I think will fix those formatting issues.