### PR TITLE
Add role="list" to all markdown lists

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const { withTableOfContents } = require('./remark/withTableOfContents')
 const { withSyntaxHighlighting } = require('./remark/withSyntaxHighlighting')
 const { withProse } = require('./remark/withProse')
 const { withNextLinks } = require('./remark/withNextLinks')
+const { withLinkRoles } = require('./rehype/withLinkRoles')
 const minimatch = require('minimatch')
 const withCodeSamples = require('./remark/withCodeSamples')
 const { withPrevalInstructions } = require('./remark/withPrevalInstructions')
@@ -87,6 +88,9 @@ module.exports = withBundleAnalyzer({
               withTableOfContents,
               withSyntaxHighlighting,
               withNextLinks,
+            ],
+            rehypePlugins: [
+              withLinkRoles,
             ],
           },
         },

--- a/rehype/withLinkRoles.js
+++ b/rehype/withLinkRoles.js
@@ -1,0 +1,11 @@
+const visit = require('unist-util-visit')
+
+module.exports.withLinkRoles = () => {
+  return (tree) => {
+    visit(tree, 'element', (element) => {
+      if (['ol', 'ul'].includes(element.tagName)) {
+        element.properties.role = 'list'
+      }
+    })
+  }
+}


### PR DESCRIPTION
Hey there! I have a little screen reader fix for you! The [preflight docs mention that the margin reset prevents VoiceOver from announcing lists properly](https://tailwindcss.com/docs/preflight#accessibility-considerations). The workaround there is really nice and I thought it was worth applying to all the markdown lists in the docs, since those are all true lists from a semantic point-of-view and should have the standard screen reader list UX.

Here's an example of the impact of this change using what I'd consider one of the most important parts of the Tailwind docs: [the part that explains the value proposition of utility first CSS](https://tailwindcss.com/docs/utility-first). To a screen reader user, this section reads like 5 separate paragraphs because the semantic list association between the three list items is lost. It actually reads a little strange without the list structure because of the sudden jump into 2nd person present tense descriptions of the reader. By sticking `role="list"` on here, the structure becomes clear and it's obvious that the list items are the "really important benefits".

| Before | After |
|-|-|
| ![2021-04-22 22 24 04](https://user-images.githubusercontent.com/566159/115781279-73fae880-a3ba-11eb-9d15-f713f8158db8.gif) | ![2021-04-22 22 25 06](https://user-images.githubusercontent.com/566159/115781284-765d4280-a3ba-11eb-822b-0ad9784905da.gif) |

Happy to tweak this further if there are details I've missed! Just let me know! 😇
