### PR TITLE
fix docs typo in `motion-reduce` and `motion-safe`

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -371,7 +371,7 @@ module.exports = {
   // ...
   variants: {
     extend: {
-      translate: ['motion-safe'],
+      animation: ['motion-safe'],
     }
   },
 }
@@ -419,7 +419,7 @@ module.exports = {
   // ...
   variants: {
     extend: {
-      translate: ['motion-reduce'],
+      animation: ['motion-reduce'],
     }
   },
 }


### PR DESCRIPTION
Change `translate` key in extend variants section to `animation`