### PR TITLE
Add "env" keyword to docs for cross-platform .env

### DIFF
--- a/src/pages/docs/just-in-time-mode.mdx
+++ b/src/pages/docs/just-in-time-mode.mdx
@@ -86,9 +86,9 @@ By default, Tailwind will start a long-running watch process if `NODE_ENV=develo
   // ...
   scripts: {
     // Will start a long-running watch process
-    "dev": "NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css -w"
+    "dev": "env NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css -w"
     // Will perform a one-off build
-    "build": "NODE_ENV=production postcss tailwind.css -o ./dist/tailwind.css"
+    "build": "env NODE_ENV=production postcss tailwind.css -o ./dist/tailwind.css"
   },
   // ...
 }
@@ -102,11 +102,11 @@ If it appears like your one-off build process is hanging, it's almost certainly 
   // ...
   scripts: {
     // Will start a long-running watch process
-    "dev": "TAILWIND_MODE=watch NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css -w"
+    "dev": "env TAILWIND_MODE=watch NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css -w"
     // Will perform a one-off development build
-    "build:dev": "TAILWIND_MODE=build NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css"
+    "build:dev": "env TAILWIND_MODE=build NODE_ENV=development postcss tailwind.css -o ./dist/tailwind.css"
     // Will perform a one-off production build
-    "build:prod": "TAILWIND_MODE=build NODE_ENV=production postcss tailwind.css -o ./dist/tailwind.css"
+    "build:prod": "env TAILWIND_MODE=build NODE_ENV=production postcss tailwind.css -o ./dist/tailwind.css"
   },
   // ...
 }


### PR DESCRIPTION
Adding "env" before setting environmental variables makes it cross-platform (i.e. work on Windows in addition to Unix / Mac).

Tested Windows 10 x64

"@Infinity @jamie-penney env NODE_ENV=test mocha --reporter spec will use the declared environment variable in a natively cross platform fashion, but the key is it is used by npm in an ad hoc and one-time fashion, just for the npm script execution. (It's not set or exported for future reference.) As long as you're running your command from the npm script, there's no issue. Also, the "&&" must be removed when doing it this way. – estaples Apr 5 '18 at 16:10 " Source: https://stackoverflow.com/a/27090755