### PR TITLE
Feat md:card preview to full hight

### DIFF
--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -36,7 +36,7 @@ Here's a simple example of a marketing page component that uses a stacked layout
   <div class="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
     <div class="md:flex">
       <div class="md:flex-shrink-0">
-        <img class="h-48 w-full object-cover md:w-48" src="https://images.unsplash.com/photo-1515711660811-48832a4c6f69?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=448&q=80" width="448" height="299" alt="Man looking at item at a store">
+        <img class="h-48 w-full object-cover md:h-full md:w-48" src="https://images.unsplash.com/photo-1515711660811-48832a4c6f69?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=448&q=80" width="448" height="299" alt="Man looking at item at a store">
       </div>
       <div class="p-8">
         <div class="uppercase tracking-wide text-sm text-indigo-500 font-semibold">Case study</div>
@@ -50,7 +50,7 @@ Here's a simple example of a marketing page component that uses a stacked layout
 <div class="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden **md:max-w-2xl**">
   <div class="**md:flex**">
     <div class="**md:flex-shrink-0**">
-      <img class="h-48 w-full object-cover **md:w-48**" src="/img/store.jpg" alt="Man looking at item at a store">
+      <img class="h-48 w-full object-cover **md:h-full md:w-48**" src="/img/store.jpg" alt="Man looking at item at a store">
     </div>
     <div class="p-8">
       <div class="uppercase tracking-wide text-sm text-indigo-500 font-semibold">Case study</div>
@@ -65,7 +65,7 @@ Here's how the example above works:
 
 - By default, the outer `div` is `display: block`, but by adding the `md:flex` utility, it becomes `display: flex` on medium screens and larger.
 - When the parent is a flex container, we want to make sure the image never shrinks, so we've added `md:flex-shrink-0` to prevent shrinking on medium screens and larger. Technically we could have just used `flex-shrink-0` since it would do nothing on smaller screens, but since it only matters on `md` screens, it's a good idea to make that clear in the class name.
-- On small screens the image is automatically full width by default. On medium screens and up, we've constrained that width to a fixed size using `md:w-48`.
+- On small screens the image is automatically full width by default. On medium screens and up, we've constrained that width to a fixed size and set full hight using `md:h-full md:w-48`.
 
 We've only used one breakpoint in this example, but you could easily customize this component at other sizes using the `sm`, `lg`, or `xl` responsive prefixes as well.
 

--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -65,7 +65,7 @@ Here's how the example above works:
 
 - By default, the outer `div` is `display: block`, but by adding the `md:flex` utility, it becomes `display: flex` on medium screens and larger.
 - When the parent is a flex container, we want to make sure the image never shrinks, so we've added `md:flex-shrink-0` to prevent shrinking on medium screens and larger. Technically we could have just used `flex-shrink-0` since it would do nothing on smaller screens, but since it only matters on `md` screens, it's a good idea to make that clear in the class name.
-- On small screens the image is automatically full width by default. On medium screens and up, we've constrained the width to a fixed size and ensured the image is  full height using `md:h-full md:w-48`.
+- On small screens the image is automatically full width by default. On medium screens and up, we've constrained the width to a fixed size and ensured the image is full height using `md:h-full md:w-48`.
 
 We've only used one breakpoint in this example, but you could easily customize this component at other sizes using the `sm`, `lg`, or `xl` responsive prefixes as well.
 

--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -65,7 +65,7 @@ Here's how the example above works:
 
 - By default, the outer `div` is `display: block`, but by adding the `md:flex` utility, it becomes `display: flex` on medium screens and larger.
 - When the parent is a flex container, we want to make sure the image never shrinks, so we've added `md:flex-shrink-0` to prevent shrinking on medium screens and larger. Technically we could have just used `flex-shrink-0` since it would do nothing on smaller screens, but since it only matters on `md` screens, it's a good idea to make that clear in the class name.
-- On small screens the image is automatically full width by default. On medium screens and up, we've constrained that width to a fixed size and set full hight using `md:h-full md:w-48`.
+- On small screens the image is automatically full width by default. On medium screens and up, we've constrained the width to a fixed size and ensured the image is  full height using `md:h-full md:w-48`.
 
 We've only used one breakpoint in this example, but you could easily customize this component at other sizes using the `sm`, `lg`, or `xl` responsive prefixes as well.
 


### PR DESCRIPTION
If html font-size up to 200% (accessibility test) then image should be full hight.

## Before
![image small](https://user-images.githubusercontent.com/16810067/116778030-f7c66c00-aa6f-11eb-9972-27f3b8c132ac.png)

## After
![image scaled](https://user-images.githubusercontent.com/16810067/116777980-be8dfc00-aa6f-11eb-9915-1ca981c0dfd0.png)
