### PR TITLE
Fix typo in responsive design doc

### DIFF
--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -92,7 +92,7 @@ Where this approach surprises people most often is that to style something for m
 
 ```html
 <!-- This will center text on mobile, and left align it on screens 640px and wider -->
-<div class="text-center sm:text-left"></div>
+<div class="text-center md:text-left"></div>
 ```
 
 For this reason, it's often a good idea to implement the mobile layout for a design first, then layer on any changes that make sense for `sm` screens, followed by `md` screens, etc.


### PR DESCRIPTION
From the context, I think it should be a typo, `sm` should be `md`.