### PR TITLE
Add link to quickly edit docs pages on GitHub

### DIFF
--- a/src/layouts/ContentsLayout.js
+++ b/src/layouts/ContentsLayout.js
@@ -8,6 +8,7 @@ import {
   useContext,
 } from 'react'
 import { ClassTable } from '@/components/ClassTable'
+import { useRouter } from 'next/router'
 import { usePrevNext } from '@/hooks/usePrevNext'
 import Link from 'next/link'
 import { SidebarLayout, SidebarContext } from '@/layouts/SidebarLayout'
@@ -158,6 +159,7 @@ export function ContentsLayoutOuter({ children, layoutProps, ...props }) {
 }
 
 export function ContentsLayout({ children, meta, classes, tableOfContents }) {
+  const router = useRouter()
   const toc = [
     ...(classes
       ? [{ title: 'Default class reference', slug: 'class-reference', children: [] }]
@@ -185,6 +187,19 @@ export function ContentsLayout({ children, meta, classes, tableOfContents }) {
             {children}
           </div>
         </ContentsContext.Provider>
+
+        <Link href={`https://github.com/tailwindlabs/tailwindcss.com/edit/master/src/pages${router.pathname}.mdx`}>
+          <a className="flex items-center mt-5 hover:text-gray-900 transition-colors duration-200">
+            <svg className="mr-1" width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+              />
+            </svg>
+            Edit this page on GitHub
+          </a>
+        </Link>
+
         {(prev || next) && (
           <>
             <hr className="border-gray-200 mt-10 mb-4" />


### PR DESCRIPTION
This is a quick and (hopefully not so) dirty addition.

A link to edit the current documentation page on GitHub – between content and prev/next links.

**Suggestion:**
Import the GitHub icon as component or remove it. The inline SVG is used multiple times now.

Closes #821 (not)

🖖