### PR TITLE
Remove duplicate class from docs

### DIFF
--- a/src/pages/docs/grid-auto-flow.mdx
+++ b/src/pages/docs/grid-auto-flow.mdx
@@ -40,7 +40,7 @@ Use the `grid-flow-{keyword}` utilities to control how the auto-placement algori
 To control the grid-auto-flow property at a specific breakpoint, add a `{screen}:` prefix to any existing grid-auto-flow utility. For example, use `md:grid-flow-col` to apply the `grid-flow-col` utility at only medium screen sizes and above.
 
 ```html
-<div class="grid grid-flow-col **md:grid-flow-col** ...">
+<div class="grid **md:grid-flow-col** ...">
   <div>1</div>
   <!-- ... -->
   <div>9</div>


### PR DESCRIPTION
I'm fairly certain this is a mistake, because from what I understand, this would actually not do anything if both were there?