### PR TITLE
Add note about purging important selector

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -326,6 +326,8 @@ module.exports = {
 }
 ```
 
+When using `important` selector, and purge is enabled, make sure that you include in the `purge.content`, the file that contains the selector.
+
 This configuration will prefix all of your utilities with the given selector, effectively increasing their specificity without actually making them `!important`.
 
 After you specify the `important` selector, you'll need to ensure that the root element of your site matches it.  Using the example above, we would need to set our root element's `id` attribute to `app` in order for styles to work properly.

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -354,7 +354,7 @@ After your configuration is all set up and your root element matches the selecto
 </html>
 ```
 
-When using the selector strategy, be sure that the template file that includes your root selector is included in your [purge configuration](https://tailwindcss.com/docs/optimizing-for-production#basic-usage), otherwise all of your CSS will be removed when building for production.
+When using the selector strategy, be sure that the template file that includes your root selector is included in your [purge configuration](/docs/optimizing-for-production#basic-usage), otherwise all of your CSS will be removed when building for production.
 
 
 ## Separator

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -326,8 +326,6 @@ module.exports = {
 }
 ```
 
-When using `important` selector, and purge is enabled, make sure that you include in the `purge.content`, the file that contains the selector.
-
 This configuration will prefix all of your utilities with the given selector, effectively increasing their specificity without actually making them `!important`.
 
 After you specify the `important` selector, you'll need to ensure that the root element of your site matches it.  Using the example above, we would need to set our root element's `id` attribute to `app` in order for styles to work properly.
@@ -355,6 +353,8 @@ After your configuration is all set up and your root element matches the selecto
 </body>
 </html>
 ```
+
+When using the selector strategy, be sure that the template file that includes your root selector is included in your [purge configuration](https://tailwindcss.com/docs/optimizing-for-production#basic-usage), otherwise all of your CSS will be removed when building for production.
 
 
 ## Separator


### PR DESCRIPTION
It took me 1 day of experiments to understand why purging is removing all my utilities. 😄 

My use case is that I have a library of Vue components and Storybook.
And the `important` selector was in `.storybook/preview-body.html`

```html
<body class="ui-root"></body>
```

I had to update purge in `tailwind.config.js`

```js
{
  important: '.ui-root',
  purge: {
    content: [
      /**
       * When using `important` option in Tailwind you need also to tell purge the file
       * where this selector is contained
       */
      './.storybook/preview-body.html',

      './src/**/*.js',
      './src/**/*.ts',
      './src/**/*.vue',
    ],
  },
}
```