### PR TITLE
Link to Tailwind CSS 2.2 blog post in Latest Updates

### DIFF
--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -63,6 +63,13 @@ const whatsNew = [
 
 const latestUpdates = [
   {
+    title: 'Tailwind CSS v2.2',
+    date: '2021-06-17T19:00:00.000Z',
+    url: 'https://blog.tailwindcss.com/tailwindcss-2-2',
+    description:
+      "We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selector variants, and tons more.",
+  },
+  {
     title: 'Tailwind CSS v2.1',
     date: '2021-04-05T19:00:00.000Z',
     url: 'https://blog.tailwindcss.com/tailwindcss-2-1',

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -66,7 +66,7 @@ const latestUpdates = [
     title: 'Tailwind CSS v2.2',
     date: '2021-06-17T19:00:00.000Z',
     url: 'https://blog.tailwindcss.com/tailwindcss-2-2',
-    description: `Over the last few weeks, we've been having a ton of fun dumping new and exciting features into Tailwind. Now feels like the right time to cut a release, so here it is — Tailwind CSS v2.2! We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selectors, variants for styling highlighted text, and tons more.`,
+    description: `Over the last few weeks, we've been having a ton of fun dumping new and exciting features into Tailwind. Now feels like the right time to cut a release, so here it is — Tailwind CSS v2.2! We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selector variants, the ability to style highlighted text, and tons more.`,
   },
   {
     title: 'Tailwind CSS v2.1',

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -66,8 +66,9 @@ const latestUpdates = [
     title: 'Tailwind CSS v2.2',
     date: '2021-06-17T19:00:00.000Z',
     url: 'https://blog.tailwindcss.com/tailwindcss-2-2',
-    description:
-      "We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selector variants, and tons more.",
+    description: `Over the last few weeks, we've been having a ton of fun dumping new and exciting features into Tailwind. Now feels like the right time to cut a release, so here it is — Tailwind CSS v2.2!
+
+      We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selectors, variants for styling highlighted text, and tons more.`,
   },
   {
     title: 'Tailwind CSS v2.1',

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -66,9 +66,7 @@ const latestUpdates = [
     title: 'Tailwind CSS v2.2',
     date: '2021-06-17T19:00:00.000Z',
     url: 'https://blog.tailwindcss.com/tailwindcss-2-2',
-    description: `Over the last few weeks, we've been having a ton of fun dumping new and exciting features into Tailwind. Now feels like the right time to cut a release, so here it is — Tailwind CSS v2.2!
-
-      We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selectors, variants for styling highlighted text, and tons more.`,
+    description: `Over the last few weeks, we've been having a ton of fun dumping new and exciting features into Tailwind. Now feels like the right time to cut a release, so here it is — Tailwind CSS v2.2! We've built-in a new high-performance CLI tool, added before and after pseudo-element support, introduced new sibling selectors, variants for styling highlighted text, and tons more.`,
   },
   {
     title: 'Tailwind CSS v2.1',


### PR DESCRIPTION
This PR adds a link to the Tailwind CSS 2.2 blog post in the latest updates timeline from the `/docs` page