### PR TITLE
Add focus:outline-none to example code for focus-visible

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -293,7 +293,7 @@ Add the `focus-visible:` prefix to only apply a utility when an element has focu
 <button class="**focus:ring-2 focus:ring-red-500** ...">
   Ring on focus
 </button>
-<button class="**focus-visible:ring-2 focus-visible:ring-rose-500** ...">
+<button class="**focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500** ...">
   Ring on focus-visible
 </button>
 ```


### PR DESCRIPTION
See https://github.com/tailwindlabs/tailwindcss/issues/4204 (Adam said that he already updated the docs, but I don't see it here. Maybe it was in another place.)

When I first tried the example code, I didn't understand why the focus ring was still showing when I clicked the button with the mouse. I thought that using `focus-visible` alone would only show the ring when using the keyboard. It's only when inspecting the source code that I understood that `focus:outline-none` was necessary (which on a second thought makes perfect sense).