### PR TITLE
Update guide for Next.js 11

### DIFF
--- a/src/pages/docs/guides/nextjs.mdx
+++ b/src/pages/docs/guides/nextjs.mdx
@@ -17,7 +17,7 @@ This will automatically configure your Tailwind setup based on the official Next
 
 ```preval setup
 version:
-  Next.js v10: latest
+  Next.js v10 or newer: latest
   Next.js v9 or older: compat-7
 ```
 


### PR DESCRIPTION
Add "or newer" to the line mentioning the latest Next.js instructions, this way it's clear you can use Next.js 11