### PR TITLE
Add `important` selector strategy note to `purge`

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -123,6 +123,8 @@ module.exports = {
 
 **This list should include *any* files in your project that reference any of your styles by name.** For example, if you have a JS file in your project that dynamically toggles some classes in your HTML, you should make sure to include that file in this list.
 
+When using `important` with the [selector strategy](/docs/configuration#selector-strategy), be sure that the template file that includes your root selector is included in your purge configuration, otherwise all of your CSS will be removed when building for production.
+
 Now whenever you compile your CSS with `NODE_ENV` set to `production`, Tailwind will automatically purge unused styles from your CSS.
 
 ### Enabling manually


### PR DESCRIPTION
## Changes
* Add `important` selector strategy note to `purge`
  - Use same wording from [`important` selector strategy section](https://tailwindcss.com/docs/configuration#selector-strategy), with added "`important` with"

## Rationale
When I had problems with my `purge` not working as expected, the [Optimizing for Production > Basic Usage page](https://tailwindcss.com/docs/optimizing-for-production#basic-usage) is the page I came to. I solved my problem because I saw this [issue](https://github.com/tailwindlabs/tailwindcss/issues/1924), and I completely missed the note in the [Configuration > Selector Strategy](https://tailwindcss.com/docs/configuration#selector-strategy) section. 