### PR TITLE
Add required quotes to font name in example

### DIFF
--- a/src/pages/docs/font-family.mdx
+++ b/src/pages/docs/font-family.mdx
@@ -89,7 +89,7 @@ By default, Tailwind provides three font family utilities: a cross-browser sans-
 -       'serif': ['ui-serif', 'Georgia', ...],
 -       'mono': ['ui-monospace', 'SFMono-Regular', ...],
 +       'display': ['Oswald', ...],
-+       'body': ['Open Sans', ...],
++       'body': ['"Open Sans"', ...],
       }
     }
   }


### PR DESCRIPTION
This is a minor change to add quotes to a multi-word font name in the documentation around font families. This double quote requirement is mentioned in the section below.