### PR TITLE
Changed @vitejs/app to vite as per the latest changes

### DIFF
--- a/src/pages/docs/guides/vue-3-vite.mdx
+++ b/src/pages/docs/guides/vue-3-vite.mdx
@@ -6,7 +6,7 @@ tool: Vue 3 and Vite
 
 ```preval installation
 tool: Vite
-script: npm init @vitejs/app
+script: npm init vite
 npmInstall: true
 ```
 


### PR DESCRIPTION
I just noticed that `@vitejs/app` is deprecated now and we should use `npm init vite` instead of that. So I updated the docs accordingly

![image](https://user-images.githubusercontent.com/51731966/125888022-36a594a0-b903-4d6e-a600-378f6a489f70.png)
