### PR TITLE
spacing docs not correct

### DIFF
--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -33,8 +33,8 @@ module.exports = {
     },
     extend: {
       spacing: {
-        '128': '32rem',
-        '144': '36rem',
+        128: '32rem',
+        144: '36rem',
       },
       borderRadius: {
         '4xl': '2rem',


### PR DESCRIPTION
After searching for 30 minutes i've finally found why i couldn't extend te spacing.
My config doesnt accept the notation of the docs.