### PR TITLE
Tip Component: Add viewBox to SVGs to fix clipping

### DIFF
--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -1,7 +1,7 @@
 export function TipGood({ children }) {
   return (
     <p className="flex items-start mt-8 mb-4 space-x-2">
-      <svg className="w-6 h-6 flex-none mt-0.5" fill="none">
+      <svg className="w-6 h-6 flex-none mt-0.5" fill="none" viewBox="0 0 24 24">
         <circle cx="12" cy="12" r="12" fill="#A7F3D0" />
         <path d="M18 8l-8 8-4-4" stroke="#047857" strokeWidth="2" />
       </svg>
@@ -13,7 +13,7 @@ export function TipGood({ children }) {
 export function TipBad({ children }) {
   return (
     <p className="flex items-start mt-8 mb-4 space-x-2">
-      <svg className="w-6 h-6 flex-none mt-0.5" fill="none">
+      <svg className="w-6 h-6 flex-none mt-0.5" fill="none" viewBox="0 0 24 24">
         <circle cx="12" cy="12" r="12" fill="#FECDD3" />
         <path d="M8 8l8 8M16 8l-8 8" stroke="#B91C1C" strokeWidth="2" />
       </svg>


### PR DESCRIPTION
Minor patch to fix the SVG clipping by adding a `viewBox` to the SVGs to the `TipGood` and `TipBad` components. Example page: https://tailwindcss.com/docs/responsive-design#mobile-first

**Before** 
<img width="724" alt="Before viewBox change, shows SVG clipping" src="https://user-images.githubusercontent.com/15662837/126271972-548a2c65-820c-4b91-b60a-f4d2f8b0df63.png">

**After**
<img width="724" alt="After viewBox change, shows SVG is no longer clipping" src="https://user-images.githubusercontent.com/15662837/126272246-f029a68f-e32e-4bfb-9c20-be151e265f70.png">
