### PR TITLE
Rename animation timing function

### DIFF
--- a/src/pages/docs/animation.mdx
+++ b/src/pages/docs/animation.mdx
@@ -91,11 +91,11 @@ export const classes = (
               @keyframes bounce {
                 0%, 100% {
                   transform: translateY(-25%);
-                  animationTimingFunction: cubic-bezier(0.8, 0, 1, 1);
+                  animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
                 }
                 50% {
                   transform: translateY(0);
-                  animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);
+                  animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
                 }
               }
             `).trim()}


### PR DESCRIPTION
I think the CSS Property should be renamed to `animation-timing-function` in the docs regarding the MDN Web documentation:

https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function