### PR TITLE
docs: update Laravel doc link

### DIFF
--- a/src/pages/docs/extracting-components.mdx
+++ b/src/pages/docs/extracting-components.mdx
@@ -143,7 +143,7 @@ By creating a single source of truth for a template, you can keep using utility 
 </script>
 ```
 
-The above example uses [Vue](https://vuejs.org/v2/guide/components.html), but the same approach can be used with [React components](https://reactjs.org/docs/components-and-props.html), [ERB partials](https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#using-partials), [Blade components](https://laravel.com/docs/8.x/blade#components), [Twig includes](https://twig.symfony.com/doc/2.x/templates.html#including-other-templates), etc.
+The above example uses [Vue](https://vuejs.org/v2/guide/components.html), but the same approach can be used with [React components](https://reactjs.org/docs/components-and-props.html), [ERB partials](https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#using-partials), [Blade components](https://laravel.com/docs/blade#components), [Twig includes](https://twig.symfony.com/doc/2.x/templates.html#including-other-templates), etc.
 
 ---
 

--- a/src/pages/docs/extracting-components.mdx
+++ b/src/pages/docs/extracting-components.mdx
@@ -143,7 +143,7 @@ By creating a single source of truth for a template, you can keep using utility 
 </script>
 ```
 
-The above example uses [Vue](https://vuejs.org/v2/guide/components.html), but the same approach can be used with [React components](https://reactjs.org/docs/components-and-props.html), [ERB partials](https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#using-partials), [Blade components](https://laravel.com/docs/5.8/blade#components-and-slots), [Twig includes](https://twig.symfony.com/doc/2.x/templates.html#including-other-templates), etc.
+The above example uses [Vue](https://vuejs.org/v2/guide/components.html), but the same approach can be used with [React components](https://reactjs.org/docs/components-and-props.html), [ERB partials](https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#using-partials), [Blade components](https://laravel.com/docs/8.x/blade#components), [Twig includes](https://twig.symfony.com/doc/2.x/templates.html#including-other-templates), etc.
 
 ---
 


### PR DESCRIPTION
Updates Laravel documentation link to the latest stable version in `docs/extracting-components.mdx`.