### PR TITLE
Fix a typo: black -> blue

### DIFF
--- a/src/pages/docs/just-in-time-mode.mdx
+++ b/src/pages/docs/just-in-time-mode.mdx
@@ -410,7 +410,7 @@ This means that it's not possible to specify the variant order per core plugin a
 To handle these situations with the JIT engine, we recommend using stacked variants instead:
 
 ```html
-<!-- This ensures the element is black on hover, even if it's also focused -->
+<!-- This ensures the element is blue on hover, even if it's also focused -->
 <div class="focus:bg-red-500 hover:bg-blue-500 **hover:focus:bg-blue-500**">
 ```
 


### PR DESCRIPTION
Fixes a typo in the docs, where the code comment references black color even though `bg-blue-500` is the class that's being used.