### PR TITLE
Take out line where global.css is removed

### DIFF
--- a/src/pages/docs/guides/nextjs.mdx
+++ b/src/pages/docs/guides/nextjs.mdx
@@ -37,7 +37,6 @@ If you aren't planning to write any custom CSS in your project, the fastest way 
 
 ```diff-js
   // pages/_app.js
-- import '../styles/globals.css'
 + import 'tailwindcss/tailwind.css'
 
   function MyApp({ Component, pageProps }) {


### PR DESCRIPTION
In the section "Import Tailwind directly in your JS", the first code block indicates to remove `import '../styles/globals.css'`. Later on the same section, there's a note to "ensure your CSS file is being imported" in the same place we removed it earlier.