### PR TITLE
Add blog link to footer

### DIFF
--- a/src/components/home/Footer.js
+++ b/src/components/home/Footer.js
@@ -19,6 +19,7 @@ const footerNav = {
   },
   Community: {
     items: [
+      { title: 'Blog', href: 'https://blog.tailwindcss.com' },
       { title: 'GitHub', href: 'https://github.com/tailwindlabs/tailwindcss' },
       { title: 'Discord', href: '/discord' },
       { title: 'Twitter', href: 'https://twitter.com/tailwindcss' },


### PR DESCRIPTION
While browsing the site today, I was trying to find a link to the blog on the home page, but couldn't find it anywhere. Once you're in the documentation area, there is the "News" link, but there isn't anything on the home page.

This PR adds a new "Blog" link under the "community" section in the footer on the home page. I called it blog, since that's what I expected, but it could be "News" as well.

![image](https://user-images.githubusercontent.com/882133/129642918-68b0910e-03d5-40e2-ab92-ed8470499afa.png)
