### PR TITLE
Add closing span tag to peer classes example

### DIFF
--- a/src/pages/docs/just-in-time-mode.mdx
+++ b/src/pages/docs/just-in-time-mode.mdx
@@ -325,7 +325,8 @@ Similar to the `group-*` variants we've supported for years for styling an eleme
 <label>
   <input type="checkbox" class="peer sr-only">
   <span class="h-4 w-4 bg-gray-200 peer-checked:bg-blue-500">
-  <!-- ... -->
+    <!-- ... -->
+  </span>
 </label>
 ```
 

--- a/src/pages/docs/just-in-time-mode.mdx
+++ b/src/pages/docs/just-in-time-mode.mdx
@@ -327,6 +327,7 @@ Similar to the `group-*` variants we've supported for years for styling an eleme
   <span class="h-4 w-4 bg-gray-200 peer-checked:bg-blue-500">
     <!-- ... -->
   </span>
+  <!-- ... -->  
 </label>
 ```
 


### PR DESCRIPTION
A closing tag for the `<span>` in the example for the peer classes was missing which resulted in incorrect HTML.