### PR TITLE
remove extraneous arrow fn syntax from backgroundImage code sample

### DIFF
--- a/src/pages/docs/background-image.mdx
+++ b/src/pages/docs/background-image.mdx
@@ -45,10 +45,10 @@ You can add your own background images by editing the `theme.backgroundImage` se
   module.exports = {
     theme: {
       extend: {
-        backgroundImage: theme => ({
+        backgroundImage: {
 +         'hero-pattern': "url('/img/hero-pattern.svg')",
 +         'footer-texture': "url('/img/footer-texture.png')",
-        })
+        }
       }
     }
   }


### PR DESCRIPTION
The usage of the arrow function syntax (`theme => ({ })`) in the code sample here is confusing because it suggests that the `theme` argument will be used elsewhere in the snippet, but it is not.