### PR TITLE
Update the link in doc `gatsby.mdx`

### DIFF
--- a/src/pages/docs/guides/gatsby.mdx
+++ b/src/pages/docs/guides/gatsby.mdx
@@ -48,7 +48,7 @@ Finally, create a `./gatsby-browser.js` file at the root of your project if it d
 + import './src/styles/global.css';
 ```
 
-Read [the Gatsby documentation on using global styles](https://www.gatsbyjs.com/tutorial/part-two/#using-global-styles) to learn more about working with global CSS files in Gatsby.
+Read [the Gatsby documentation on using global styles](https://www.gatsbyjs.com/docs/how-to/styling/global-css/#adding-global-styles-without-a-layout-component) to learn more about working with global CSS files in Gatsby.
 
 ---
 


### PR DESCRIPTION
The article pointed to by the previous link in the doc `src/pages/docs/guides/gatsby.mdx` now does not have the section "using global styles". I found an [alternative](https://www.gatsbyjs.com/docs/how-to/styling/global-css/#adding-global-styles-without-a-layout-component), including a tutorial on how to work with global CSS files in Gatsby.