### PR TITLE
docs(variants): update list of variants

### DIFF
--- a/src/pages/docs/configuring-variants.mdx
+++ b/src/pages/docs/configuring-variants.mdx
@@ -51,6 +51,9 @@ The following variants are supported out of the box:
 | `focus-visible` | Targets the `focus-visible` pseudo-class. |
 | `active` | Targets the `active` pseudo-class. |
 | `disabled` | Targets the `disabled` pseudo-class. |
+| `empty` | Targets the `empty` pseudo-class. |
+| `before` | Targets the `before` pseudo-element. |
+| `after` | Targets the `after` pseudo-element. |
 
 For more information about how variants work, read our documentation on [responsive variants](/docs/responsive-design), [dark mode variants](/docs/dark-mode), and [hover, focus and other state variants](/docs/hover-focus-and-other-states).
 


### PR DESCRIPTION
From https://github.com/tailwindlabs/tailwindcss/issues/5332#issuecomment-908462161 it seems that the `empty` and `before` variants already exist. I assume `after` does as well, so I added all three to the documentation.

Let me know if other sections need updating as well.