### PR TITLE
Fix link to Gatsby global style guide

### DIFF
--- a/src/pages/docs/guides/gatsby.mdx
+++ b/src/pages/docs/guides/gatsby.mdx
@@ -48,7 +48,7 @@ Finally, create a `./gatsby-browser.js` file at the root of your project if it d
 + import './src/styles/global.css';
 ```
 
-Read [the Gatsby documentation on using global styles](https://www.gatsbyjs.com/tutorial/part-two/#using-global-styles) to learn more about working with global CSS files in Gatsby.
+Read [the Gatsby documentation on using global styles](https://www.gatsbyjs.com/docs/recipes/styling-css/#using-global-css-files-without-a-layout-component) to learn more about working with global CSS files in Gatsby.
 
 ---
 


### PR DESCRIPTION
The old link's anchor is no longer relevant. This change points to a more relevant entry in Gatsby documentation.