### PR TITLE
Fix typo in generated code for plugins docs

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -343,11 +343,11 @@ module.exports = {
 .tw-btn-blue:hover {
   background-color: #2779bd;
 }
-.tw-btn-blue {
+.tw-btn-red {
   background-color: #e3342f;
   color: #fff;
 }
-.tw-btn-blue:hover {
+.tw-btn-red:hover {
   background-color: #cc1f1a;
 }
 ```


### PR DESCRIPTION
This PR fixes a typo in the Tailwind docs for plugins that I just stumbled upon.
The generated class names are all ending in `-blue` where the latter two should be named `-red`.