### PR TITLE
Updating color for breakpoint example

### DIFF
--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -103,10 +103,10 @@ Tailwind's breakpoints only include a `min-width` and don't include a `max-width
 
 If you'd like to apply a utility at one breakpoint only, the solution is to *undo* that utility at larger sizes by adding another utility that counteracts it.
 
-Here is an example where the background color is red at the `md` breakpoint, but teal at every other breakpoint:
+Here is an example where the background color is red at the `md` breakpoint, but green at every other breakpoint:
 
 ```html
-<div class="bg-teal-500 md:bg-red-500 lg:bg-teal-500">
+<div class="bg-green-500 md:bg-red-500 lg:bg-green-500">
   <!-- ... -->
 </div>
 ```


### PR DESCRIPTION
The current example has `bg-teal-500` but it looks like `teal` doesn't exist in the color palette for the latest version (2.2.14) of tailwindcss https://tailwindcss.com/docs/customizing-colors.