### PR TITLE
Improve rendering of classes

### DIFF
--- a/src/components/ClassTable.js
+++ b/src/components/ClassTable.js
@@ -116,7 +116,7 @@ export const ClassTable = memo(
     filterProperties,
     preview,
     sort = (x) => x,
-    transformSelector = (x) => (x.length === 1 ? x : x.slice(1).replace(/\\/g, '')),
+    transformSelector = (x) => x.replace(/^\./g, '').replace(/\\/g, ''),
     transformProperties = ({ properties }) => properties,
     transformValue,
     custom,


### PR DESCRIPTION
When we have a class like `.inset-1\/4` we want it to look like
`inset-1/4`. We used to remove the first character, but that is not
correct. Some classes are structured like `*, ::before, ::after {}`.

Instead we now drop leading `.` characters instead.
