### PR TITLE
Safelisting specific classes

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -151,13 +151,15 @@ If you need to safelist specific classes to make sure they are never accidentall
 module.exports = {
   purge: {
     content: ['./src/**/*.html'],
-    safelist: [
-      'bg-blue-500',
-      'text-center',
-      'hover:opacity-100',
-      // ...
-      'lg:text-right',
-    ]
+    options: {
+      safelist: [
+        'bg-blue-500',
+        'text-center',
+        'hover:opacity-100',
+        // ...
+        'lg:text-right',
+      ]
+    }
   },
   // ...
 }


### PR DESCRIPTION
If we do not provide the safelist array within the options object. It does not work and purges the classes anyway. This should be the default way you should state on your website since this is gonna work for most cases.