### PR TITLE
Fix multiple escapes in plugin code example

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -1064,7 +1064,7 @@ module.exports = {
         supportsRule.append(container.nodes)
         container.append(supportsRule)
         supportsRule.walkRules(rule => {
-          rule.selector = `.${e(`supports-grid${separator}${rule.selector.slice(1)}`)}`
+          rule.selector = `.${e(`supports-grid${separator}`)}${rule.selector.slice(1)}`
         })
       })
     })


### PR DESCRIPTION
Minor fix to "supports-grid" plugin example to avoid multiple escapes of content in `${rule.selector.slice(1)}`.

**Example**:

`class="supports-grid:hover:underline"`

Before:
```
@supports (display: grid) {
  .supports-grid\:hover\\\:underline\:hover {
    text-decoration: underline;
  }
}
```

After:
```
@supports (display: grid) {
  .supports-grid\:hover\:underline:hover {
    text-decoration: underline;
  }
}
```
