### PR TITLE
list-style-position: Clarify and illustrate the different text indentation behavior of list-inside vs. list-outside

### DIFF
--- a/src/pages/docs/list-style-position.mdx
+++ b/src/pages/docs/list-style-position.mdx
@@ -16,7 +16,7 @@ export const classes = { plugin }
 
 ## Usage
 
-Control the position of the markers in a list using the `list-inside` and `list-outside` utilities.
+Control the position of the markers and text indentation in a list using the `list-inside` and `list-outside` utilities.
 
 ```html lightBlue
 <template preview class="p-4 px-8">
@@ -25,7 +25,7 @@ Control the position of the markers in a list using the `list-inside` and `list-
     <ul class="list-disc list-inside bg-light-blue-200 bg-stripes bg-stripes-white text-light-blue-600 py-2 rounded-md">
       <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
       <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
-      <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
+      <li>Quia temporibus eveniet a libero incidunt suscipit laborum, rerum accusantium modi quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
     </ul>
   </p>
   </div>
@@ -34,7 +34,7 @@ Control the position of the markers in a list using the `list-inside` and `list-
     <ul class="list-disc list-outside bg-light-blue-200 bg-stripes bg-stripes-white text-light-blue-600 py-2 rounded-md">
       <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
       <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
-      <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
+      <li>Quia temporibus eveniet a libero incidunt suscipit laborum, rerum accusantium modi quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
Clarify that the utility classes not only change the position of the marker, but also how text indentation works.

The third list element is now multi line, so the effect becomes visible. And the intro sentence hints that this util changes more than just the position.

Pages: 
- Current: https://tailwindcss.com/docs/list-style-position
- This PR: https://tailwindcss-com-git-fork-tordans-patch-2-tailwindlabs.vercel.app/docs/list-style-position

See also https://github.com/tailwindlabs/tailwindcss/issues/4549 by @jpwynn 

Personally, I would even go a step further, and reverse the order of utils (currently (1) inside, (2) outside). This nudged me towards the inside option being the smarter choice, but TBH I don't see when that would be true – unless you can be sure that your list will never get multiline. 

The example could also add (or at least hint to add) a `ml-5` to the outside-list.