### PR TITLE
Fix jiggle upon opening DocSearch

### DIFF
--- a/src/css/docsearch.css
+++ b/src/css/docsearch.css
@@ -1,13 +1,9 @@
-.DocSearch--active {
-  overflow: hidden !important;
-}
-
 .DocSearch-Container {
-  height: 100vh;
+  height: 100%;
   left: 0;
   position: fixed;
   top: 0;
-  width: 100vw;
+  width: 100%;
   z-index: 200;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
I noticed a jiggle when launching DocSearch, as the scrollbar is removed & the modal overlay is set to `100vh` `100vw`.

Here's a quick change to remove the jiggle. As a side effect, now you can scroll the BG content, which may or may not be what you guys want.