### PR TITLE
Add `--minify` to just-in-time-mode.mdx

### DIFF
--- a/src/pages/docs/just-in-time-mode.mdx
+++ b/src/pages/docs/just-in-time-mode.mdx
@@ -508,7 +508,7 @@ For example, if you are using `postcss-cli`, set `TAILWIND_MODE=watch` in your d
     "dev": "TAILWIND_MODE=watch postcss -i tailwind.css -o build.css --watch",
 
     // Do not set TAILWIND_MODE for one-off builds
-    "build": "postcss -i tailwind.css -o build.css",
+    "build": "postcss -i tailwind.css -o build.css --minify",
     // ...
   },
   // ...
@@ -582,10 +582,10 @@ You can use packages like `npm-run-all` or `concurrently` to compile your CSS al
   "scripts": {
     "dev": "npm-run-all --parallel dev:*",
     "dev:parcel": "parcel serve ./src/index.html",
-    "dev:css": "tailwindcss -o src/tailwind.css -w",
+    "dev:css": "tailwindcss -o src/tailwind.css --watch",
     "build": "npm-run-all build:css build:parcel",
     "build:parcel": "parcel build ./src/index.html",
-    "build:css": "tailwindcss -o src/tailwind.css",
+    "build:css": "tailwindcss -o src/tailwind.css --minify",
   },
 }
 ```


### PR DESCRIPTION
In https://youtu.be/oG6XPy1t1KA?t=995 I learned about the `--minify` option.
Minifying the output sounds like a smart default for `build` scripts.

However, I could not find any reference to it in the docs, yet. So this adds it to the examples at least.

I suggest also adding a list of all option values or link to an external list if there is one.


---

Update: I found the reference to minify in the CLI section at https://tailwindcss.com/docs/installation#building-for-production. I still think a list of all cli options and also using this specific option on this page is a good idea. 

---

This PR also changes the IMO cryptic `-w` in favor `--watch`.