### PR TITLE
Link to Layer doc on Optimizing for Production page

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -231,7 +231,7 @@ We generally do not recommend this and believe that the risks outweigh the benef
 
 ### Purging specific layers
 
-By default, Tailwind will purge all styles in the `base`, `components`, and `utilities` layers. If you'd like to change this, use the `layers` option to manually specify the layers you'd like to purge:
+By default, Tailwind will purge all styles in the `base`, `components`, and `utilities` [layers](/docs/functions-and-directives#layer). If you'd like to change this, use the `layers` option to manually specify the layers you'd like to purge:
 
 ```js
 // tailwind.config.js


### PR DESCRIPTION
Similar to #854. 
When utilizing `@layer` for purging purposes, I didn't realize at first that a `@layer` could not be named anything I wanted, and could only be named `base`, `components`, and `utilities`. 

I eventually found the document on `@layer`. It would have helped me find the relevant info faster if the "optimizing for production" page linked to the doc on layers. 

I was specifically looking at the "Removing all unused styles" section, under the "Purging specific layers" section that I've added the link into, but the wording there was less straight forward to add a link to and putting a link on the `@layer` code snippet seemed undesirable.
