### PR TITLE
fix(docs): Document safelist inside options

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -153,13 +153,15 @@ If you need to safelist specific classes to make sure they are never accidentall
 module.exports = {
   purge: {
     content: ['./src/**/*.html'],
-    safelist: [
-      'bg-blue-500',
-      'text-center',
-      'hover:opacity-100',
-      // ...
-      'lg:text-right',
-    ]
+    options: {
+      safelist: [
+        'bg-blue-500',
+        'text-center',
+        'hover:opacity-100',
+        // ...
+        'lg:text-right',
+      ]
+    }
   },
   // ...
 }


### PR DESCRIPTION
In the documentation page for optimizing for production https://tailwindcss.com/docs/optimizing-for-production the `safelist` option for purgeCSS  should be inside `options` but in the first occurance its mentioned directly inside "purge" which will not work. a bit bellow on the page it is well documented already so thats how eventually I was able to find out I was putting my safelist in the wrong place :laughing: 