### PR TITLE
Document fontSize default lineHeight object syntax

### DIFF
--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -148,6 +148,21 @@ module.exports = {
 }
 ```
 
+You can also specify a default line-height using object syntax:
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    fontSize: {
+      sm: ['14px', {
+        lineHeight: '20px',
+      }],
+    }
+  }
+}
+```
+
 We already provide default line heights for each `.text-{size}` class.
 
 ### Providing a default letter-spacing


### PR DESCRIPTION
The font-size documentation says that a default line-height can be given with `[<font-size>, <line-height>]`, and that when specifying both a default line-height and a default letter-spacing the defaults go in an object:

```js
[<font-size>, {
  letterSpacing: <letter-spacing>,
  lineHeight: <line-height>
}]
```

Support for using an object when specifying a default line-height _without_ a default letter-spacing is undocumented. 