### PR TITLE
Remove incorrect bracket from plugin code example

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -803,7 +803,7 @@ module.exports = plugin.withOptions(function (options) {
     }))
 
     addUtilities(utilities, gradientVariants)
-  })
+  }
 }, function (options) {
   return {
     theme: {


### PR DESCRIPTION
This change is to remove an invalid bracket from one of the plugin code examples