### PR TITLE
postcss.config.js syntax has changed

### DIFF
--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -276,9 +276,9 @@ npx tailwindcss --postcss -o tailwind.css
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: [
-    require('postcss-100vh-fix'),
-  ]
+  plugins: {
+    'postcss-100vh-fix': {},
+  }
 }
 ```
 
@@ -287,11 +287,11 @@ By default, plugins are applied _after_ Tailwind generates your CSS. If you have
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: [
-    require('postcss-import'),
-    require('tailwindcss'),
-    require('postcss-100vh-fix'),
-  ]
+  plugins: {
+    'postcss-import': {},
+    tailwindcss: {},
+    'postcss-100vh-fix': {},
+  }
 }
 ```
 


### PR DESCRIPTION
The `postcss.config.js` syntax has changed and the documentation does not match the syntax that is generated by `tailwindcss init --postcss`.