### PR TITLE
Update dark-mode.mdx

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -86,6 +86,8 @@ module.exports = {
 
 Now instead of `dark:{class}` classes being applied based on `prefers-color-scheme`, they will be applied whenever `dark` class is present earlier in the HTML tree.
 
+In addition, you need to note that if a prefix is configured, you also need to add a prefix before dark
+
 ```html
 <!-- Dark mode not enabled -->
 <html>


### PR DESCRIPTION
I think adding this line can explain why it can be more detailed, because I have been wondering why my dark mode does not work these days. It is because I configured the prefix, but I see that the official website does not say that if the prefix is configured,dark mode must be prefixed to work, I think this can make people less to step on the hole