### PR TITLE
Fix reference to safelist option as top-level configuration

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -146,7 +146,7 @@ We recommend only removing unused styles in production, as removing them in deve
 
 ### Safelisting specific classes
 
-If you need to safelist specific classes to make sure they are never accidentally removed from your CSS (perhaps because they are used in content that comes from a database or similar), you can use our top-level `safelist` option:
+If you need to safelist specific classes to make sure they are never accidentally removed from your CSS (perhaps because they are used in content that comes from a database or similar), you can use our `safelist` purge option:
 
 ```js
 // tailwind.config.js


### PR DESCRIPTION
This PR fixes a tiny inconsistency between the documentation text and its corresponding snippet of code. 

The `safelist` option should live under the `purge` option, not in the top-level configuration.