### PR TITLE
Keep v2 documentation to use TailwindCSS v2

### DIFF
--- a/remark/withPrevalInstructions.js
+++ b/remark/withPrevalInstructions.js
@@ -207,7 +207,7 @@ function createPrevals({ tool: pageTool = error('UNKNOWN') } = {}) {
       version = 'latest',
     }) {
       let knownDependencies = {
-        latest: ['tailwindcss@latest', 'postcss@latest', 'autoprefixer@latest'],
+        latest: ['tailwindcss@^2', 'postcss@latest', 'autoprefixer@latest'],
         'compat-7': [
           'tailwindcss@npm:@tailwindcss/postcss7-compat',
           'postcss@^7',

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -119,7 +119,7 @@ If you'd rather scaffold a complete configuration file that includes all of Tail
 npx tailwindcss init --full
 ```
 
-You'll get a file that matches the [default configuration file](https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js) Tailwind uses internally.
+You'll get a file that matches the [default configuration file](https://unpkg.com/browse/tailwindcss@^2/stubs/defaultConfig.stub.js) Tailwind uses internally.
 
 ## Theme
 

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -35,7 +35,7 @@ If this is a bit over your head and you'd like to try Tailwind without configuri
 For most projects (and to take advantage of Tailwind's customization features), you'll want to install Tailwind and its peer-dependencies via npm.
 
 ```shell
-npm install -D tailwindcss@latest postcss@latest autoprefixer@latest
+npm install -D tailwindcss@^2 postcss@latest autoprefixer@latest
 ```
 
 Since Tailwind [does not automatically add vendor prefixes](/docs/browser-support#vendor-prefixes) to the CSS it generates, we recommend installing [autoprefixer](https://github.com/postcss/autoprefixer) to handle this for you like we've shown in the snippet above.
@@ -393,5 +393,5 @@ Once the rest of your tools have added support for PostCSS 8, you can move off o
 
 ```shell
 npm uninstall tailwindcss
-npm install -D tailwindcss@latest postcss@latest autoprefixer@latest
+npm install -D tailwindcss@^2 postcss@latest autoprefixer@latest
 ```

--- a/src/pages/docs/upgrading-to-v2.mdx
+++ b/src/pages/docs/upgrading-to-v2.mdx
@@ -18,7 +18,7 @@ Tailwind CSS v2.0 has been updated for the latest PostCSS release which requires
 Update Tailwind and install PostCSS and autoprefixer using npm:
 
 ```shell
-npm install tailwindcss@latest postcss@latest autoprefixer@latest
+npm install tailwindcss@^2 postcss@latest autoprefixer@latest
 ```
 
 If you run into issues, you may need to use our [PostCSS 7 compatibility build](/docs/installation#post-css-7-compatibility-build) instead.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ import Head from 'next/head'
 
 function NpmInstallButton() {
   function copy() {
-    navigator.clipboard.writeText('npm install tailwindcss').catch((e) => {
+    navigator.clipboard.writeText('npm install tailwindcss@^2').catch((e) => {
       console.log(e)
     })
   }
@@ -36,7 +36,7 @@ function NpmInstallButton() {
         <span className="hidden sm:inline text-gray-500" aria-hidden="true">
           ${' '}
         </span>
-        npm install tailwindcss
+        npm install tailwindcss@^2
       </span>
       <span className="sr-only">(click to copy to clipboard)</span>
       <svg width="24" height="24" fill="none" stroke="currentColor" strokeWidth={1.5}>


### PR DESCRIPTION
Prevent accidentally install TailwindCSS v3 when view v2 documentation.