### PR TITLE
Fixing valid/invalid variant docs

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1276,15 +1276,15 @@ Style an input when it's required using the `required` modifier:
 Style an input when it's valid using the `valid` modifier:
 
 ```html
-<input class="**required:border-green-500** ..." />
+<input class="**valid:border-green-500** ..." />
 ```
 
 #### invalid <small>(:invalid)</small>
 
-Style an input when it's valid using the `valid` modifier:
+Style an input when it's invalid using the `invalid` modifier:
 
 ```html
-<input class="**required:border-red-500** ..." />
+<input class="**invalid:border-red-500** ..." />
 ```
 
 #### in-range <small>(:in-range)</small>


### PR DESCRIPTION
Noticed that the valid/invalid variants were copied from required and weren't changed.