### PR TITLE
Remove duplicated class in List markers example

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -553,7 +553,7 @@ Style the counters or bullets in lists using the `marker` modifier:
 </Example>
 
 ```html
-<ul role="list" class="**marker:text-sky-400** list-disc pl-5 space-y-3 text-gray-500 marker:text-sky-400">
+<ul role="list" class="**marker:text-sky-400** list-disc pl-5 space-y-3 text-gray-500">
   <li>5 cups chopped Porcini mushrooms</li>
   <li>1/2 cup of olive oil</li>
   <li>3lb of celery</li>


### PR DESCRIPTION
`marker:text-sky-400` is duplicated in the same element:

`<ul role="list" class="**marker:text-sky-400** list-disc pl-5 space-y-3 text-gray-500 marker:text-sky-400">`

Output generated HTML Code is:
```HTML
<ul role="list" class="marker:text-sky-400 list-disc pl-5 space-y-3 text-gray-500 marker:text-sky-400">
  <li>5 cups chopped Porcini mushrooms</li>
  <li>1/2 cup of olive oil</li>
  <li>3lb of celery</li>
</ul>
```
And since you can select the first(Highlighted) for copy and paste without the highlight formatting, there's no need for the last class.

https://user-images.githubusercontent.com/79575415/145547786-9ec39a0b-c2b4-46c6-8950-692f5cd6a490.mp4


