### PR TITLE
Use plural in upgrade guide

### DIFF
--- a/src/pages/docs/upgrade-guide.mdx
+++ b/src/pages/docs/upgrade-guide.mdx
@@ -397,4 +397,4 @@ The `@tailwind screens` layer has been renamed to `@tailwind variants`:
 +  @tailwind variants;
 ```
 
-I think you are more likely to be attacked by a shark while working at your desk than you are to be affected by this change.
+We think you are more likely to be attacked by a shark while working at your desk than you are to be affected by this change.


### PR DESCRIPTION
Indeed I wasn't affected by the change, and no sharks in sight so far :crossed_fingers:.

But I think it's better to use the plural here to be congruent with the rest of the text.

Great job with the guide by the way, it was a really easy upgrade :D.