### PR TITLE
fix setup documentation for nuxt

### DIFF
--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -63,9 +63,11 @@ let steps = [
       code: `  export default {
     build: {
 >     postcss: {
->       plugins: {
->         tailwindcss: {},
->         autoprefixer: {},
+>       postcssOptions: {
+>         plugins: {
+>           tailwindcss: {},
+>           autoprefixer: {},
+>         },
 >       },
 >     },
     }


### PR DESCRIPTION
**postcss** must have **postcssOptions** before **plugins**
```
postcss: {
    postcssOptions: {
        plugins: {
            tailwindcss: {},
            autoprefixer: {},
        },
    },
},
```