### PR TITLE
Fix: Relative line-heights html code snippet

### DIFF
--- a/src/pages/docs/line-height.mdx
+++ b/src/pages/docs/line-height.mdx
@@ -40,9 +40,9 @@ Use the `leading-none`, `leading-tight`, `leading-snug`, `leading-normal`, `lead
 </Example>
 
 ```html
-<p class="**leading-6** ...">So I started to walk into the water...</p>
-<p class="**leading-7** ...">So I started to walk into the water...</p>
-<p class="**leading-8** ...">So I started to walk into the water...</p>
+<p class="**leading-normal** ...">So I started to walk into the water...</p>
+<p class="**leading-relaxed** ...">So I started to walk into the water...</p>
+<p class="**leading-loose** ...">So I started to walk into the water...</p>
 ```
 
 ### Fixed line-heights


### PR DESCRIPTION
This PR fixes an inconsistency between the documentation text and its corresponding snippet of code.
The relative line-height had an example for fixed-line heights.