### PR TITLE
Fix a typo in the docs

### DIFF
--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -285,7 +285,7 @@ Traditionally these would be classes like `card`, `btn`, `badge` — that kind 
 }
 ```
 
-By defining component classes in the `components` layer, you can still user utility classes to override them when necessary:
+By defining component classes in the `components` layer, you can still use utility classes to override them when necessary:
 
 ```html
 <!-- Will look like a card, but with square corners -->


### PR DESCRIPTION
Original Sentence (with typo):
> By defining component classes in the `components` layer, you can still user utility classes to override them when necessary:

Changed "user" to "use".