### PR TITLE
Add ts,tsx to guides/create-react-app.js

### DIFF
--- a/src/pages/docs/guides/create-react-app.js
+++ b/src/pages/docs/guides/create-react-app.js
@@ -37,6 +37,7 @@ let steps = [
     body: () => (
       <p>
         Add the paths to all of your template files in your <code>tailwind.config.js</code> file.
+        Include <code>ts,tsx</code> if the project is using typescript.
       </p>
     ),
     code: {
@@ -44,7 +45,7 @@ let steps = [
       lang: 'js',
       code: `  module.exports = {
 >   content: [
->     "./src/**/*.{js,jsx}",
+>     "./src/**/*.{js,jsx,ts,tsx}",
 >   ],
     theme: {
       extend: {},

--- a/src/pages/docs/guides/create-react-app.js
+++ b/src/pages/docs/guides/create-react-app.js
@@ -37,7 +37,6 @@ let steps = [
     body: () => (
       <p>
         Add the paths to all of your template files in your <code>tailwind.config.js</code> file.
-        Include <code>ts,tsx</code> if the project is using typescript.
       </p>
     ),
     code: {


### PR DESCRIPTION
I was stuck on an issue for about an hour where my typescript files weren't getting styles and this was the culprit. It's a little obvious and I should have seen it coming, but mentioning it in the docs might help the next person using typescript and trying to add tailwind.