### PR TITLE
Add core plugins reference in PlayCDN

### DIFF
--- a/src/pages/docs/installation/play-cdn.js
+++ b/src/pages/docs/installation/play-cdn.js
@@ -2,8 +2,6 @@ import NextLink from 'next/link'
 import { DocumentationLayout } from '@/layouts/DocumentationLayout'
 import { InstallationLayout } from '@/layouts/InstallationLayout'
 import { Steps } from '@/components/Steps'
-import { black } from 'tailwindcss/colors'
-import { theme } from 'tailwind.config'
 
 let steps = [
   {
@@ -89,7 +87,6 @@ let steps = [
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com"></script>
-    <script>/* ... */</script>
 >   <style type="text/tailwindcss">
 >     @layer utilities {
 >       .content-auto {
@@ -107,10 +104,11 @@ let steps = [
     },
   },
   {
-    title: 'Extend by plugins',
+    title: 'Try working with a core plugin',
     body: () => (
       <p>
-        Use <code>forms</code>,<code>typography</code>,<code>aspect-ratio</code>,<code>line-clamp</code> to enable officiall plugins independently.
+        Enable core plugins, like forms and typography, using the <code>plugins</code> query
+        parameter.
       </p>
     ),
     code: {
@@ -121,11 +119,10 @@ let steps = [
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
->    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
-    <script>/* ... */</script>
+>   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
   </head>
   <body>
->   <div class="line-clamp-3">
+>   <div class="prose">
       <!-- ... -->
     </div>
   </body>

--- a/src/pages/docs/installation/play-cdn.js
+++ b/src/pages/docs/installation/play-cdn.js
@@ -106,6 +106,32 @@ let steps = [
   </html>`,
     },
   },
+  {
+    title: 'Extend by plugins',
+    body: () => (
+      <p>
+        Use <code>forms</code>,<code>typography</code>,<code>aspect-ratio</code>,<code>line-clamp</code> to enable officiall plugins independently.
+      </p>
+    ),
+    code: {
+      name: 'index.html',
+      lang: 'html',
+      code: `  <!doctype html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+>    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
+    <script>/* ... */</script>
+  </head>
+  <body>
+>   <div class="line-clamp-3">
+      <!-- ... -->
+    </div>
+  </body>
+  </html>`,
+    },
+  },
 ]
 
 export default function PlayCdn({ code }) {


### PR DESCRIPTION
From discussion https://github.com/tailwindlabs/tailwindcss/discussions/6473
Reference core plugins in last section as option to extend functionality