### PR TITLE
Prevent page reload when hitting Enter in input

### DIFF
--- a/src/components/home/StateVariants.js
+++ b/src/components/home/StateVariants.js
@@ -152,6 +152,9 @@ export function StateVariants() {
                       setStates((states) => states.filter((x) => x !== 'input-focus'))
                       // resetScroll()
                     }}
+                    onKeyPress={(e) => {
+                      e.key === 'Enter' && e.preventDefault();
+                    }}
                     type="text"
                     aria-label="Filter projects"
                     placeholder="Filter projects..."


### PR DESCRIPTION
When hitting enter while being in the `Filter Projects...` input, the whole page reloads and does not scroll back to the position the user was before. IMHO this is bad for UX.