### PR TITLE
add the -p option for installation instructions for postcss

### DIFF
--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {


### PR DESCRIPTION
Someone pointed this out in Discord and it makes sense to me. It won't touch an existing `postcss.config.js` file and makes the next step *way* easier.