### PR TITLE
Corrected spelling on Rotate.mdx

### DIFF
--- a/src/pages/docs/rotate.mdx
+++ b/src/pages/docs/rotate.mdx
@@ -19,7 +19,7 @@ export const classes = {
   },
 }
 
-## Basic sage
+## Basic usage
 
 ### Rotating an element
 


### PR DESCRIPTION
changed "Basic _sage" to "Basic usage"