### PR TITLE
Add missing step

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -69,6 +69,26 @@ let steps = [
     },
   },
   {
+    title: 'Enable global styles',
+    body: () => (
+      <p>
+        Create an <code>./pages/_app.js</code> file
+      </p>
+    ),
+    code: {
+      name: '_app.js',
+      lang: 'js',
+      code: `import '../styles/globals.css'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp
+`,  
+    },
+  },
+  {
     title: 'Start your build process',
     body: () => (
       <p>


### PR DESCRIPTION
I followed the exact same steps on this page but failed to enable tailwind with nextjs until I find this missing file in the example, also global style is mentioned in nextjs's tutorial: https://nextjs.org/learn/basics/assets-metadata-css/global-styles