### PR TITLE
Fixed "Open/closed state example" with Dark Mode

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -860,7 +860,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
     <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 open:text-gray-900 dark:text-white font-semibold select-none">
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white dark:open:text-gray-900 font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">
@@ -874,7 +874,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 ```html
   <div class="max-w-lg mx-auto p-8">
 >   <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 open:text-gray-900 dark:text-white font-semibold select-none">
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white dark:open:text-gray-900 font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -874,7 +874,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 ```html
   <div class="max-w-lg mx-auto p-8">
 >   <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
+      <summary class="text-sm leading-6 open:text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -859,7 +859,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
-    <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
+    <details class="open:bg-white dark:open:bg-gray-900 open:ring-1 open:ring-black/5 dark:open:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
       <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
@@ -873,7 +873,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 ```html
   <div class="max-w-lg mx-auto p-8">
->   <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
+>   <details class="open:bg-white dark:open:bg-gray-900 open:ring-1 open:ring-black/5 dark:open:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
       <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -860,7 +860,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
     <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
+      <summary class="text-sm leading-6 open:text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -860,7 +860,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
     <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 font-semibold select-none">
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">
@@ -874,7 +874,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 ```html
   <div class="max-w-lg mx-auto p-8">
 >   <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 font-semibold select-none">
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
       <div class="mt-3 text-sm leading-6 text-gray-600">

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -859,11 +859,11 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
-    <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 dark:text-white dark:open:text-gray-900 font-semibold select-none">
+    <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/5 open:shadow-lg p-6 rounded-lg" open>
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
-      <div class="mt-3 text-sm leading-6 text-gray-600">
+      <div class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-400">
         <p>The mug is round. The jar is round. They should call it Roundtine.</p>
       </div>
     </details>
@@ -873,11 +873,11 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 ```html
   <div class="max-w-lg mx-auto p-8">
->   <details class="open:bg-white open:ring-1 open:ring-black/5 open:shadow-lg p-6 rounded-lg" open>
-      <summary class="text-sm leading-6 text-gray-900 dark:text-white dark:open:text-gray-900 font-semibold select-none">
+>   <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/5 open:shadow-lg p-6 rounded-lg" open>
+      <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
-      <div class="mt-3 text-sm leading-6 text-gray-600">
+      <div class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-400">
         <p>The mug is round. The jar is round. They should call it Roundtine.</p>
       </div>
     </details>

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -859,7 +859,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 <Example hint="Try toggling the disclosure to see the styles change">
   <div class="max-w-lg mx-auto">
-    <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/5 open:shadow-lg p-6 rounded-lg" open>
+    <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
       <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>
@@ -873,7 +873,7 @@ Use the `open` modifier to conditionally add styles when a `<details>` or `<dial
 
 ```html
   <div class="max-w-lg mx-auto p-8">
->   <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/5 open:shadow-lg p-6 rounded-lg" open>
+>   <details class="open:bg-white dark:bg-gray-900 open:ring-1 open:ring-black/5 dark:ring-white/10 open:shadow-lg p-6 rounded-lg" open>
       <summary class="text-sm leading-6 text-gray-900 dark:text-white font-semibold select-none">
         Why do they call it Ovaltine?
       </summary>


### PR DESCRIPTION
In the [Open/closed state](https://tailwindcss.com/docs/hover-focus-and-other-states#open-closed-state) The `summary` text is almost invisible while in closed state with Dark mode. 

Current view:
![Screenshot (683)](https://user-images.githubusercontent.com/79575415/146806271-0f3a1bb0-6ac8-47b5-a320-e32ef1a2b936.png)

Added some `dark:` utilities so it can work with Dark mode.