### PR TITLE
Update postcss-import example

### DIFF
--- a/src/pages/docs/using-with-preprocessors.mdx
+++ b/src/pages/docs/using-with-preprocessors.mdx
@@ -33,7 +33,7 @@ The canonical plugin for handling this with PostCSS is [postcss-import](https://
 To use it, install the plugin via npm:
 
 ```shell
-npm install postcss-import
+npm install -D postcss-import
 ```
 
 Then add it as the very first plugin in your PostCSS configuration:


### PR DESCRIPTION
The example used to install `postcss-import` should install it as a dev dependency