### PR TITLE
Docs: Add example to safelist responsive variants

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -343,6 +343,26 @@ module.exports = {
 }
 ```
 
+You can also generate responsive utility variants, for that you must specify each of them:
+
+```js tailwind.config.js
+module.exports = {
+  content: [
+    './pages/**/*.{html,js}',
+    './components/**/*.{html,js}',
+  ],
+  safelist: [
+    'text-2xl',
+    'text-3xl',
+    {
+      pattern: /bg-(red|green|blue)-(100|200|300)/,
+      variants: ['sm', 'md', 'lg', 'xl', '2xl'],
+    },
+  ],
+  // ...
+}
+```
+
 ---
 
 ## Transforming source files

--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -336,27 +336,7 @@ module.exports = {
     'text-3xl',
     {
       pattern: /bg-(red|green|blue)-(100|200|300)/,
-      variants: ['hover', 'focus'],
-    },
-  ],
-  // ...
-}
-```
-
-You can also generate responsive utility variants, for that you must specify each of them:
-
-```js tailwind.config.js
-module.exports = {
-  content: [
-    './pages/**/*.{html,js}',
-    './components/**/*.{html,js}',
-  ],
-  safelist: [
-    'text-2xl',
-    'text-3xl',
-    {
-      pattern: /bg-(red|green|blue)-(100|200|300)/,
-      variants: ['sm', 'md', 'lg', 'xl', '2xl'],
+      variants: ['lg', 'hover', 'focus', 'lg:hover'],
     },
   ],
   // ...


### PR DESCRIPTION
I think it will be good if we describe that each responsive variant must be specified in the array.