### PR TITLE
Fix anchor link for file quick-reference

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1025,7 +1025,7 @@ A quick reference table of every single modifier included in Tailwind by default
 | <a href="#first-line-and-first-letter" className="whitespace-nowrap">first-line</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::first-line</code> |
 | <a href="#highlighted-text" className="whitespace-nowrap">marker</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::marker</code> |
 | <a href="#selection" className="whitespace-nowrap">selection</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::selection</code> |
-| <a href="#file" className="whitespace-nowrap">file</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::file-selector-button</code> |
+| <a href="#file-input-buttons" className="whitespace-nowrap">file</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::file-selector-button</code> |
 | <a href="#placeholder" className="whitespace-nowrap">placeholder</a>  | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-gray-400">&</span>::placeholder</code> |
 | <a href="#responsive-breakpoints" className="whitespace-nowrap">sm</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media (min-width: 640px)</code> |
 | <a href="#responsive-breakpoints" className="whitespace-nowrap">md</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media (min-width: 768px)</code> |


### PR DESCRIPTION
The anchor link for `file` on the [states quick reference](https://tailwindcss.com/docs/hover-focus-and-other-states#quick-reference) is wrong.

It points to [#file](https://tailwindcss.com/docs/hover-focus-and-other-states#file) which is wrong.

[#file-input-buttons](https://tailwindcss.com/docs/hover-focus-and-other-states#file-input-buttons) works