### PR TITLE
Remove broken link from functions and directives

### DIFF
--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -240,7 +240,7 @@ If you need to access a value that contains a dot (like the `2.5` value in the s
 }
 ```
 
-Since Tailwind uses a [nested object syntax](/docs/colors#nested-object-syntax) to define its default color palette, make sure to use dot notation to access the nested colors.
+Since Tailwind uses a nested object syntax to define its default color palette, make sure to use dot notation to access the nested colors.
 
 <TipBad>Don't use the dash syntax when accessing nested color values</TipBad>
 

--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -240,7 +240,7 @@ If you need to access a value that contains a dot (like the `2.5` value in the s
 }
 ```
 
-Since Tailwind uses a nested object syntax to define its default color palette, make sure to use dot notation to access the nested colors.
+Since Tailwind uses a [nested object syntax](/docs/customizing-colors#color-object-syntax) to define its default color palette, make sure to use dot notation to access the nested colors.
 
 <TipBad>Don't use the dash syntax when accessing nested color values</TipBad>
 


### PR DESCRIPTION
This small PR removes a broken link from the functions and directives page. It looks like the `#nested-object-syntax` section on the colors page isn't present in the v3.0 docs, breaking this link.