### PR TITLE
Fix Doc Search icon repeats and look odd

### DIFF
--- a/src/css/docsearch.css
+++ b/src/css/docsearch.css
@@ -92,6 +92,7 @@
 .DocSearch-MagnifierLabel {
   @apply flex-none w-6 h-6;
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m19 19-3.5-3.5' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle cx='11' cy='11' r='6' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat round;
 
   .dark & {
     background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m19 19-3.5-3.5' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle cx='11' cy='11' r='6' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");


### PR DESCRIPTION
Hi 👋

when searching for something on the documentation page  that search icon is the only thing that looks something odd. 
![image](https://user-images.githubusercontent.com/63112138/147385761-a96e003d-f7f0-437f-8c33-2c28fcb128ea.png)

so i checked in the developer tools and it shows the normal search icon as in the following image.
![image](https://user-images.githubusercontent.com/63112138/147385784-e2b9b38c-7856-4f8c-a8e8-74fec67f6b3a.png)

so i guessed the second image get repeated that creates a weird look. so i removed the background repeat and it looks cool now!

Thanks 