### PR TITLE
Use diff-js for create-react-app setup step

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -124,7 +124,7 @@ function Code({ code, lang, pad }) {
       className={clsx('text-sm leading-6 text-gray-50 flex ligatures-none', pad && 'overflow-auto')}
     >
       <code
-        className={clsx('flex-none min-w-full', pad && 'p-5')}
+        className={clsx('flex-none min-w-full', pad && 'p-5', pad && lang === 'diff-js' && 'px-9')}
         dangerouslySetInnerHTML={{
           __html: code
             .split('\n')

--- a/src/pages/docs/guides/create-react-app.js
+++ b/src/pages/docs/guides/create-react-app.js
@@ -40,11 +40,12 @@ let steps = [
     ),
     code: {
       name: 'tailwind.config.js',
-      lang: 'js',
+      lang: 'diff-js',
       code: `  module.exports = {
->   content: [
->     "./src/**/*.{js,jsx,ts,tsx}",
->   ],
+-   content: [],
++   content: [
++     "./src/**/*.{js,jsx,ts,tsx}",
++   ],
     theme: {
       extend: {},
     },


### PR DESCRIPTION
Reformat step 3 on https://tailwindcss.com/docs/guides/create-react-app.

From this:

![2022-01-01-235429_831x414_scrot](https://user-images.githubusercontent.com/2747249/147866717-7b43dfc0-653b-44f4-b830-a252372bfe8c.png)

To this:

![2022-01-01-234414_842x442_scrot](https://user-images.githubusercontent.com/2747249/147866567-163e676b-9b00-494d-8953-f871fa6c2991.png)

## Why?
The default tailwind.config.js has an empty content array. Of course dumb me forgot to remove it when I followed those instructions. I ended up with a broken config which looked like this:

```js
module.exports = {
  content: [
    "./src/**/*.{js,jsx,ts,tsx}",
  ],
  content: [],  // this effectively disables Tailwind :-(
  theme: {
    extend: {},
  },
  plugins: [],
}
```

## Details
Although diff-js wasn't being used in this way previously, I was able to integrate with a bit of extra padding.

Why `px-9` instead of `pl-9`? Originally I just tried adding padding to the left, but then due to negative margins each line would overflow on the right side by about 4. I tried adding overflow-hidden, but then there was no right padding for long diff lines while viewing on small screens. Hence `px-9`.

## Testing
- Scrolling works. Padding on long diff lines. No unexpected scrollbars
- Tested on chrome mobile viewer including very small screens
- The `diff-js` lang will probably not work as expected if pad=false in the Code component