### PR TITLE
Fixes typo by adding the missing 'process.env'

### DIFF
--- a/src/pages/docs/optimizing-for-production.mdx
+++ b/src/pages/docs/optimizing-for-production.mdx
@@ -30,7 +30,7 @@ module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-    ...(NODE_ENV === 'production' ? { cssnano: {} } : {})
+    ...(process.env.NODE_ENV === 'production' ? { cssnano: {} } : {})
   }
 }
 ```


### PR DESCRIPTION
## Details
This PR adds the missing "process.env" for the optimizing section.