### PR TITLE
Fix: Docs `cursor-none` image

### DIFF
--- a/public/img/cursors/cursor-none.svg
+++ b/public/img/cursors/cursor-none.svg
@@ -1,2 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-</svg>

--- a/public/img/cursors/cursor-none.svg
+++ b/public/img/cursors/cursor-none.svg
@@ -1,11 +1,2 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="path-1-outside-1_118_575" maskUnits="userSpaceOnUse" x="0.75" y="0.75" width="18" height="19" fill="black">
-<rect fill="white" x="0.75" y="0.75" width="18" height="19"/>
-<path d="M8 18.25L2.75 2.75L17.25 9L9.75 10.75L8 18.25Z"/>
-</mask>
-<path d="M8 18.25L2.75 2.75L17.25 9L9.75 10.75L8 18.25Z" fill="#0F172A"/>
-<path d="M8 18.25L2.75 2.75L17.25 9L9.75 10.75L8 18.25Z" stroke="white" stroke-width="3" stroke-linejoin="round" mask="url(#path-1-outside-1_118_575)"/>
-<circle cx="17.5" cy="17.5" r="5.25" fill="white" stroke="white" stroke-width="1.5"/>
-<circle cx="17.5" cy="17.5" r="3.75" fill="white" stroke="#0F172A" stroke-width="1.5"/>
-<path d="M15 15L20 20" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/pages/docs/cursor.mdx
+++ b/src/pages/docs/cursor.mdx
@@ -12,10 +12,13 @@ export const classes = {
   utilities,
   rowStyle: ({ css }) => css,
   preview: (css, { className, utility }) => (
-    <td
-      className={`align-middle ${className}`}
-    >
-      <img className="w-6 h-6 mx-auto drop-shadow" src={`/img/cursors/${utility.substr(1)}.svg`} />
+    <td className={`align-middle ${className}`}>
+      {utility !== '.cursor-none' && (
+        <img
+          className="w-6 h-6 mx-auto drop-shadow"
+          src={`/img/cursors/${utility.substr(1)}.svg`}
+        />
+      )}
     </td>
   ),
 }


### PR DESCRIPTION
This tiny PR is a one-file change which fixes the `cursor-none` image example—it’s currently displaying as `not-allowed` instead of nothing.