### PR TITLE
Update docs for Flex Basis chapter

### DIFF
--- a/src/pages/docs/flex-basis.mdx
+++ b/src/pages/docs/flex-basis.mdx
@@ -100,4 +100,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="flex-basis" featuredClass="flex-basis-[14.2857143%]" />
+<ArbitraryValues property="flex-basis" featuredClass="basis-[14.2857143%]" />


### PR DESCRIPTION
The `flex-basis-[14.2857143%]` won't work, it should be `basis-[14.2857143%]`.