### PR TITLE
Fix class name for arbitrary duration values

### DIFF
--- a/src/pages/docs/transition-duration.mdx
+++ b/src/pages/docs/transition-duration.mdx
@@ -76,4 +76,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="transition-duration" featuredClass="transition-[2000ms]" />
+<ArbitraryValues property="transition-duration" featuredClass="duration-[2000ms]" />


### PR DESCRIPTION
The `duration` docs currently display `transition-[2000ms]` as an example of an arbitrary value for the `duration` class.