### PR TITLE
fix: renaming purge to content on presets doc

### DIFF
--- a/src/pages/docs/presets.mdx
+++ b/src/pages/docs/presets.mdx
@@ -124,7 +124,7 @@ Project-specific configurations (those found in your `tailwind.config.js` file) 
 
 The following options in `tailwind.config.js` simply **replace** the same option if present in a preset:
 
-- `purge`
+- `content`
 - `darkMode`
 - `prefix`
 - `important`


### PR DESCRIPTION
Small fix to update **purge** to **content** at https://tailwindcss.com/docs/presets#merging-logic-in-depth.