### PR TITLE
Add `npm install` step after init on Vite guide

### DIFF
--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -18,7 +18,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm init vite my-project\ncd my-project',
+      code: 'npm init vite my-project\ncd my-project && npm install',
     },
   },
   {


### PR DESCRIPTION
When creating a new vite app with `npm init vite xxx`, the dependencies are not installed and this is a required step.