### PR TITLE
docs: correction in the line ``` return `rgb(var(${variable}) / ${opacityValue})` ```

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -347,7 +347,7 @@ function withOpacityValue(variable) {
     if (opacityValue === undefined) {
       return `rgb(var(${variable}))`
     }
-    return `rgb(var(${variable}) / ${opacityValue})`
+    return `rgb(var(${variable}), ${opacityValue})`
   }
 }
 


### PR DESCRIPTION
Perhaps a correction should be made in the line  

``` return `rgb(var(${variable}) / ${opacityValue})` ```

like this 

``` return `rgb(var(${variable}), ${opacityValue})` ```