### PR TITLE
Update angular.js

### DIFF
--- a/src/pages/docs/guides/angular.js
+++ b/src/pages/docs/guides/angular.js
@@ -28,7 +28,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
     },
   },
   {


### PR DESCRIPTION
Adding `autoprefixer` and `postcss` as peer dependencies.
`tailwindcss` does not work without them.