### PR TITLE
Mention how custom classes should be made.

### DIFF
--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -265,7 +265,7 @@ Use the [`theme`](/docs/functions-and-directives#theme) function or [`@apply`](/
 
 ### Adding component classes
 
-Use the `components` layer for any more complicated classes you want to add to your project that you'd still like to be able to override with utility classes.
+Use the `components` layer for any more complicated classes you want to add to your project that you'd still like to be able to override with utility classes. Keep in mind you can't use Tailwind style classnames when naming custom css, for example `hover:` won't work, use something like instead `hover-` to avoid issues.
 
 Traditionally these would be classes like `card`, `btn`, `badge` — that kind of thing.
 

--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -265,7 +265,7 @@ Use the [`theme`](/docs/functions-and-directives#theme) function or [`@apply`](/
 
 ### Adding component classes
 
-Use the `components` layer for any more complicated classes you want to add to your project that you'd still like to be able to override with utility classes. Keep in mind you can't use Tailwind style classnames when naming custom css, for example `hover:` won't work, use something like instead `hover-` to avoid issues.
+Use the `components` layer for any more complicated classes you want to add to your project that you'd still like to be able to override with utility classes. Keep in mind you can't use Tailwind style classnames when naming custom css, for example `hover:` won't work, instead use something like `hover-` to avoid issues.
 
 Traditionally these would be classes like `card`, `btn`, `badge` — that kind of thing.
 


### PR DESCRIPTION
You can't use Tailwind style class names for states like `hover:` instead, use something like `hover-` to avoid issues. The docs should mention this, <TipBad> might be a good idea.

An example of what I mean: https://play.tailwindcss.com/y6q8geyDzX