### PR TITLE
chore(postcss): fix code example for using postcss

### DIFF
--- a/src/pages/docs/using-with-preprocessors.mdx
+++ b/src/pages/docs/using-with-preprocessors.mdx
@@ -153,7 +153,7 @@ Then pass the plugin itself as an argument to `tailwindcss/nesting` in your Post
 module.exports = {
   plugins: [
     require('postcss-import'),
-    require('tailwindcss/nesting')(require('postcss-nesting')),
+    require('tailwindcss/nesting')(require('postcss-nested')),
     require('tailwindcss'),
     require('autoprefixer'),
   ]


### PR DESCRIPTION
As mentioned in the text below, the package is called `postcss-nested` and *not* `postcss-nesting`.
 
`postcss-nesting` is not the official/standard package to include, so it would be maybe less confusing when copy the example code, which mentions a not so common package (postcss-nesting).