### PR TITLE
📝defaultClass to grid-template-columns arbitrary values

### DIFF
--- a/src/pages/docs/grid-template-columns.mdx
+++ b/src/pages/docs/grid-template-columns.mdx
@@ -80,4 +80,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="grid-template-columns" featuredClass="grid-cols-[200px_minmax(900px,_1fr)_100px]" />
+<ArbitraryValues property="grid-template-columns" defaultClass="grid" featuredClass="grid-cols-[200px_minmax(900px,_1fr)_100px]" />


### PR DESCRIPTION
the arbitrary values should not be working if the class list doesn't contain a grid class. To avoid confusion a defaultClass="grid" should help mitigate the problem.