### PR TITLE
Remove instruction to create postcss plugin when using CRA

### DIFF
--- a/src/pages/docs/guides/create-react-app.js
+++ b/src/pages/docs/guides/create-react-app.js
@@ -29,7 +29,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
     },
   },
   {


### PR DESCRIPTION
Create React App's Tailwind support means that they will detect `tailwind.config.js` in the project and add `tailwindcss` to their existing `postcss` configuration. [Source in CRA](https://github.com/facebook/create-react-app/blob/5614c87bfbaae0ce52ac15aedd2cd0f91ffd420d/packages/react-scripts/config/webpack.config.js#L144)

The [guide](https://tailwindcss.com/docs/guides/create-react-app) that Tailwind offers on their site creates a dummy `postcss.config.js` - Making changes in this file does not change the actual postcss configuration. (misleading if anything)

This means that features like PostCSS Nesting that Tailwind mentions in the docs will not work if user edits the local PostCSS configuration. It should be better to simply *not* create `postcss.config.js` in the first place so that this confusion is avoided. 

[Sample SO question](https://tailwindcss.com/docs/guides/create-react-app)