### PR TITLE
added white color for blockQuote in dark prose theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -213,6 +213,9 @@ module.exports = {
             'tbody tr': {
               borderBottomColor: 'rgb(148 163 184 / 0.1)',
             },
+            blockQuote: {
+              color: theme('colors.white'),
+            },
           },
         },
       }),


### PR DESCRIPTION
Block quotes in `prose-dark` uses `prose-slate`'s color which is too dark to see in dark mode

Resolves #1197 