### PR TITLE
Add missing space

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -341,7 +341,7 @@ When you need to style an element based on the state of some _parent_ element, m
 </Example>
 
 ```html
-<a href="#" class="**group** block max-w-xs mx-auto rounded-lg p-6 bg-whitering-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
+<a href="#" class="**group** block max-w-xs mx-auto rounded-lg p-6 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
   <div class="flex items-center space-x-3">
     <svg class="h-6 w-6 stroke-sky-500 **group-hover:stroke-white**" fill="none" viewBox="0 0 24 24"><!-- ... --></svg>
     <h3 class="text-slate-900 **group-hover:text-white** text-sm font-semibold">New project</h3>


### PR DESCRIPTION
This change adds a missing space between the `bg-white` and `ring-1` classes in the "Styling based on parent state" example.