### PR TITLE
Grid customizing should include how to use it

### DIFF
--- a/src/pages/docs/grid-template-columns.mdx
+++ b/src/pages/docs/grid-template-columns.mdx
@@ -75,6 +75,7 @@ You have direct access to the `grid-template-columns` CSS property here so you c
     }
   }
 ```
+When you have created your custom column values you can use it within your HTML by prefixing it with `grid-cols-` in the above examples you would use `grid-cols-16` or `grid-cols-footer`. 
 
 Learn more about customizing the default theme in the [theme customization](/docs/theme#customizing-the-default-theme) documentation.
 


### PR DESCRIPTION
Currently customizing your theme tells you how to create a theme it does not instruct you how to use it. This commit would change that.