### PR TITLE
Fading to transparent - Fixed in 15.4 note

### DIFF
--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -111,7 +111,7 @@ Gradients with a `from-{color}` and `via-{color}` will fade out to transparent b
 
 ### Fading to transparent
 
-Gradients fade out to transparent by default, without requiring you to add `to-transparent` explicitly. Tailwind intelligently calculates the _right_ "transparent" value to use based on the starting color to avoid [a bug in Safari](https://bugs.webkit.org/show_bug.cgi?id=150940) that causes fading to simply the `transparent` keyword to fade through gray, which just looks awful.
+Gradients fade out to transparent by default, without requiring you to add `to-transparent` explicitly. Tailwind intelligently calculates the _right_ "transparent" value to use based on the starting color to avoid [a bug in Safari 15.3 and lower](https://bugs.webkit.org/show_bug.cgi?id=150940) that causes fading to simply the `transparent` keyword to fade through gray, which just looks awful. This bug has been fixed since Safari 15.4.
 
 <TipBad>Don't add `to-transparent` explicitly</TipBad>
 

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -111,7 +111,7 @@ Gradients with a `from-{color}` and `via-{color}` will fade out to transparent b
 
 ### Fading to transparent
 
-Gradients fade out to transparent by default, without requiring you to add `to-transparent` explicitly. Tailwind intelligently calculates the _right_ "transparent" value to use based on the starting color to avoid [a bug in Safari 15.3 and lower](https://bugs.webkit.org/show_bug.cgi?id=150940) that causes fading to simply the `transparent` keyword to fade through gray, which just looks awful. This bug has been fixed since Safari 15.4.
+Gradients fade out to transparent by default, without requiring you to add `to-transparent` explicitly. Tailwind intelligently calculates the _right_ "transparent" value to use based on the starting color to avoid [a bug in Safari < 15.4](https://bugs.webkit.org/show_bug.cgi?id=150940) that causes fading to simply the `transparent` keyword to fade through gray, which just looks awful.
 
 <TipBad>Don't add `to-transparent` explicitly</TipBad>
 


### PR DESCRIPTION
Since the bug has been fixed in Safari 15.4, I thought we could add these little changes since the bug has been closed and shipped by the Webkit team. I just specified that it's up to 15.3 and solved in 15.4, but we could eventually think about removing this section altogether. Your call!