### PR TITLE
Remove autoprefixer from Parcel installation guide

### DIFF
--- a/src/pages/docs/guides/parcel.js
+++ b/src/pages/docs/guides/parcel.js
@@ -23,14 +23,31 @@ let steps = [
     body: () => (
       <p>
         Install <code>tailwindcss</code> and its peer dependencies via npm, and then run the init
-        command to generate both <code>tailwind.config.js</code> and <code>postcss.config.js</code>.
+        command to generate <code>tailwind.config.js</code>.
       </p>
     ),
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss postcss\nnpx tailwindcss init',
     },
+  },
+  {
+    title: 'Configure PostCSS',
+    body: () => (
+      <p>
+        Create a <code>.postcssrc</code> file, and enable the <code>tailwindcss</code> plugin.
+      </p>
+    ),
+    code: {
+      name: '.postcssrc',
+      lang: 'json',
+      code: `{
+  "plugins": {
+    "tailwindcss": true
+  }
+}`
+    }
   },
   {
     title: 'Configure your template paths',

--- a/src/pages/docs/guides/parcel.js
+++ b/src/pages/docs/guides/parcel.js
@@ -36,7 +36,7 @@ let steps = [
     title: 'Configure PostCSS',
     body: () => (
       <p>
-        Create a <code>.postcssrc</code> file, and enable the <code>tailwindcss</code> plugin.
+        Create a <code>.postcssrc</code> file in your project root, and enable the <code>tailwindcss</code> plugin.
       </p>
     ),
     code: {
@@ -44,7 +44,7 @@ let steps = [
       lang: 'json',
       code: `{
   "plugins": {
-    "tailwindcss": true
+    "tailwindcss": {}
   }
 }`
     }


### PR DESCRIPTION
[Parcel v2.4.0](https://parceljs.org/blog/v2-4-0/) now uses [@parcel/css](https://github.com/parcel-bundler/parcel-css) by default for auto prefixing and transpilation (like postcss-preset-env). It shows a warning telling users to remove `autoprefixer` from their postcss config file, which is now redundant with the builtin auto prefixing support and can improve performance.

Unfortunately, it looks like the `tailwindcss`CLI doesn't have a way to skip autoprefixer when generating a postcss config, so I removed the `-p` option and created the postcss config containing only `tailwindcss` manually in these instructions for now.

It also seems that `autoprefixer` is a peer dependency of `tailwindcss`, and you do get a warning during install when it isn't added. Maybe that could be made optional instead?

Also switched from a `postcss.config.js` to a `.postcssrc` which enables Parcel's caching to work better.