### PR TITLE
Fix mobile/desktop theme toggle sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "stringify-object": "^3.3.0",
     "tailwindcss": "^3.0.24",
     "tinytime": "^0.2.6",
-    "unist-util-visit": "^2.0.3"
+    "unist-util-visit": "^2.0.3",
+    "zustand": "^4.0.0-rc.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "2.x",

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -1,7 +1,13 @@
 import { useIsomorphicLayoutEffect } from '@/hooks/useIsomorphicLayoutEffect'
 import { Listbox } from '@headlessui/react'
 import clsx from 'clsx'
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
+import create from 'zustand'
+
+const useSetting = create((set) => ({
+  setting: 'system',
+  setSetting: (setting) => set({ setting }),
+}))
 
 function update() {
   if (
@@ -105,7 +111,7 @@ function PcIcon({ selected, ...props }) {
 }
 
 function useTheme() {
-  let [setting, setSetting] = useState('system')
+  let { setting, setSetting } = useSetting()
   let initial = useRef(true)
 
   useIsomorphicLayoutEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7157,6 +7157,11 @@ use-subscription@1.5.1:
   dependencies:
     object-assign "^4.1.1"
 
+use-sync-external-store@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz#d98f4a9c2e73d0f958e7e2d2c2bfb5f618cbd8fd"
+  integrity sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -7465,6 +7470,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.0.0-rc.0:
+  version "4.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.0.0-rc.0.tgz#644982d70ea1eba3b6983790608bfe101afdd649"
+  integrity sha512-jMimx6EIlLb/hwgnkVZ4Wd/UI73wXedUB6L/kcdIYbOYHcjIFRc7JEB8IXFZt+1rQq2qwuts7kN6kuHhFss47A==
+  dependencies:
+    use-sync-external-store "1.0.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This PR fixes theme toggle state sync. When updating the theme setting (`light`, `dark`, or `system`) on mobile the desktop version of the toggle will now be updated correctly, and vice versa.