### PR TITLE
Update gird xl col span to fit page neatly

### DIFF
--- a/src/components/GridLockup.js
+++ b/src/components/GridLockup.js
@@ -62,14 +62,14 @@ GridLockup.Grid = function Inner({ left, right, leftProps = {}, rightProps = {} 
     <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 lg:grid lg:grid-cols-12 lg:gap-8">
       <div
         {...leftProps}
-        className={clsx('lg:col-span-5 xl:col-span-6 flex flex-col', leftProps.className)}
+        className={clsx('lg:col-span-5 xl:col-span-5 flex flex-col', leftProps.className)}
       >
         {left}
       </div>
       <div
         {...rightProps}
         className={clsx(
-          'mt-4 -mx-4 sm:mx-0 lg:mt-0 lg:col-span-7 xl:col-span-6',
+          'mt-4 -mx-4 sm:mx-0 lg:mt-0 lg:col-span-7 xl:col-span-5',
           rightProps.className
         )}
       >


### PR DESCRIPTION
# Problem
Before, the code went off the div and users had to scroll horizontally.
The problem only existed in 'xl'.

![before](https://user-images.githubusercontent.com/78584173/167164615-806d1c82-7ae0-41cd-95d6-53c6a4cb9ba3.png)

# What is fixed
Now, the image grid is smaller and code div is bigger.

![after](https://user-images.githubusercontent.com/78584173/167164678-c9150b7e-7f98-4784-8506-75f1f24606b2.png)
