### PR TITLE
Improve homepage performance by lazy loading images

### DIFF
--- a/src/components/HtmlZenGarden.js
+++ b/src/components/HtmlZenGarden.js
@@ -37,6 +37,7 @@ const themes = {
       src: require('@/img/classic-utility-jacket.jpg').default,
       originalWidth: 1200,
       originalHeight: 1600,
+      loading: "lazy"
     },
     contentContainer: 'p-6',
     header: '-mt-6 pt-6 pb-6',
@@ -98,6 +99,7 @@ const themes = {
       src: require('@/img/kids-jumper.jpg').default,
       originalWidth: 1200,
       originalHeight: 1700,
+      loading: "lazy",
       className: ['-mt-2 -mx-2', '-mt-2 -mx-2', '-my-2 -ml-2'],
     },
     contentContainer: 'p-6',
@@ -383,6 +385,7 @@ export function HtmlZenGarden({ theme }) {
                       key={name}
                       src={themes[name].image.src}
                       alt=""
+                      loading="lazy"
                       className="absolute max-w-none"
                       style={fit(
                         themes[theme].image.width({ containerWidth, col }),

--- a/src/components/HtmlZenGarden.js
+++ b/src/components/HtmlZenGarden.js
@@ -385,7 +385,7 @@ export function HtmlZenGarden({ theme }) {
                       key={name}
                       src={themes[name].image.src}
                       alt=""
-                      loading="lazy"
+                      loading={themes[name].image.loading}
                       className="absolute max-w-none"
                       style={fit(
                         themes[theme].image.width({ containerWidth, col }),

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -15,7 +15,6 @@ export function Steps({ steps, code, level = 2 }) {
         <img
           src={require('@/img/beams/installation.jpg').default}
           alt=""
-          
           className="w-[52.6875rem] max-w-none"
         />
       </div>

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -15,6 +15,7 @@ export function Steps({ steps, code, level = 2 }) {
         <img
           src={require('@/img/beams/installation.jpg').default}
           alt=""
+          
           className="w-[52.6875rem] max-w-none"
         />
       </div>

--- a/src/components/home/BuildAnything.js
+++ b/src/components/home/BuildAnything.js
@@ -18,7 +18,7 @@ import { lines } from '../../samples/build-anything.html?highlight'
 const code = {
   Simple: `<div class="flex font-sans">
   <div class="flex-none w-48 relative">
-    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover" />
+    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover" loading="lazy" />
   </div>
   <form class="flex-auto p-6">
     <div class="flex flex-wrap">
@@ -66,7 +66,7 @@ const code = {
 </div>`,
   Playful: `<div class="flex font-sans">
   <div class="flex-none w-56 relative">
-    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover rounded-lg" />
+    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover rounded-lg" loading="lazy" />
   </div>
   <form class="flex-auto p-6">
     <div class="flex flex-wrap">
@@ -114,7 +114,7 @@ const code = {
 </div>`,
   Elegant: `<div class="flex font-serif">
   <div class="flex-none w-52 relative">
-    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover rounded-lg" />
+    <img src="/classic-utility-jacket.jpg" alt="" class="absolute inset-0 w-full h-full object-cover rounded-lg" loading="lazy" />
   </div>
   <form class="flex-auto p-6">
     <div class="flex flex-wrap items-baseline">
@@ -162,7 +162,7 @@ const code = {
 </div>`,
   Brutalist: `<div class="flex p-6 font-mono">
   <div class="flex-none w-48 mb-10 relative z-10 before:absolute before:top-1 before:left-1 before:w-full before:h-full before:bg-teal-400">
-    <img src="/classic-utility-jacket.jpg" alt="" class="absolute z-10 inset-0 w-full h-full object-cover rounded-lg" />
+    <img src="/classic-utility-jacket.jpg" alt="" class="absolute z-10 inset-0 w-full h-full object-cover rounded-lg" loading="lazy" />
   </div>
   <form class="flex-auto pl-6">
     <div class="relative flex flex-wrap items-baseline pb-6 before:bg-black before:absolute before:-top-6 before:bottom-0 before:-left-60 before:-right-6">

--- a/src/components/home/ModernFeatures.js
+++ b/src/components/home/ModernFeatures.js
@@ -84,7 +84,7 @@ function Block({ src, filter, ...props }) {
           filter
         )}
       >
-        <img src={src} alt="" className="absolute inset-0 w-full h-full object-cover" />
+        <img src={src} alt="" className="absolute inset-0 w-full h-full object-cover" loading="lazy" />
       </div>
     </motion.div>
   )
@@ -198,6 +198,7 @@ export function ModernFeatures() {
                   src={require('@/img/modern-features/5.jpg').default}
                   alt=""
                   className="absolute inset-0 w-full h-full object-cover"
+                  loading="lazy"
                 />
               </motion.div>
             </div>

--- a/src/components/home/ReadyMadeComponents.js
+++ b/src/components/home/ReadyMadeComponents.js
@@ -10,6 +10,7 @@ function AnimatedImage({ animate = false, delay = 0, ...props }) {
       animate={animate ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }}
       transition={{ duration: 0.5, delay }}
       alt=""
+      loading="lazy"
       {...props}
     />
   )

--- a/src/samples/build-anything.html
+++ b/src/samples/build-anything.html
@@ -1,6 +1,6 @@
 <div class="_">
   <div class="_">
-    <img src="__content__" alt="" class="_" />
+    <img src="__content__" alt="" class="_" loading="lazy" />
   </div>
   <form class="_">
     <div class="_">

--- a/src/samples/dark-mode.html
+++ b/src/samples/dark-mode.html
@@ -1,6 +1,6 @@
 <div class="(light)bg-white (light)border-slate-100 demo-dark:bg-slate-800 demo-dark:border-slate-500 border-b rounded-t-xl p-4 pb-6 sm:p-10 sm:pb-8 lg:p-6 xl:p-10 xl:pb-8 space-y-6 sm:space-y-8 lg:space-y-6 xl:space-y-8">
   <div class="flex items-center space-x-4">
-    <img src="/full-stack-radio.png" alt="" width="88" height="88" class="flex-none rounded-lg bg-slate-100" />
+    <img src="/full-stack-radio.png" alt="" width="88" height="88" class="flex-none rounded-lg bg-slate-100" loading="lazy" />
     <div class="min-w-0 flex-auto space-y-1 font-semibold">
       <p class="(light)text-cyan-500 demo-dark:text-cyan-400 text-sm leading-6">
         <abbr title="Episode">Ep.</abbr> 128

--- a/src/samples/editor-tools.html
+++ b/src/samples/editor-tools.html
@@ -6,7 +6,7 @@
     </div>
     <p class="mt-1 text-slate-500 text-sm truncate">Regional Paradigm Technician</p>
   </div>
-  <img class="w-10 h-10 bg-slate-300 rounded-full shrink-0" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=4&amp;w=256&amp;h=256&amp;q=60" alt="">
+  <img class="w-10 h-10 bg-slate-300 rounded-full shrink-0" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=4&amp;w=256&amp;h=256&amp;q=60" alt="" loading="lazy">
 </div>
 <div class="border-t border-slate-200">
   <div class="-mt-px flex">

--- a/src/samples/filters.html
+++ b/src/samples/filters.html
@@ -1,17 +1,17 @@
 <div class="grid grid-flow-col grid-rows-2 grid-cols-3 gap-8">
   <div class="[blur]">
-    <img src="/mountains-1.jpg" alt="">
+    <img src="/mountains-1.jpg" alt="" loading="lazy">
   </div>
   <div class="col-start-3 [sepia]">
-    <img src="/mountains-2.jpg" alt="">
+    <img src="/mountains-2.jpg" alt="" loading="lazy">
   </div>
   <div class="[saturate-200]">
-    <img src="/mountains-3.jpg" alt="">
+    <img src="/mountains-3.jpg" alt="" loading="lazy">
   </div>
   <div class="[grayscale]">
-    <img src="/mountains-4.jpg" alt="">
+    <img src="/mountains-4.jpg" alt="" loading="lazy">
   </div>
   <div class="row-start-1 col-start-2 col-span-2 [invert]">
-    <img src="/mountains-5.jpg" alt="">
+    <img src="/mountains-5.jpg" alt="" loading="lazy">
   </div>
 </div>

--- a/src/samples/grid.html
+++ b/src/samples/grid.html
@@ -1,17 +1,17 @@
 <div class="grid grid-flow-col grid-rows-2 grid-cols-3 gap-8">
   <div>
-    <img src="/mountains-1.jpg" alt="">
+    <img src="/mountains-1.jpg" alt="" loading="lazy">
   </div>
   <div class="col-start-3">
-    <img src="/mountains-2.jpg" alt="">
+    <img src="/mountains-2.jpg" alt="" loading="lazy">
   </div>
   <div>
-    <img src="/mountains-3.jpg" alt="">
+    <img src="/mountains-3.jpg" alt="" loading="lazy">
   </div>
   <div>
-    <img src="/mountains-4.jpg" alt="">
+    <img src="/mountains-4.jpg" alt="" loading="lazy">
   </div>
   <div class="row-start-1 col-start-2 col-span-2">
-    <img src="/mountains-5.jpg" alt="">
+    <img src="/mountains-5.jpg" alt="" loading="lazy">
   </div>
 </div>

--- a/src/samples/transforms.html
+++ b/src/samples/transforms.html
@@ -1,17 +1,17 @@
 <div class="grid grid-flow-col grid-rows-2 grid-cols-3 gap-8">
   <div class="[transform scale-110 -rotate-6]">
-    <img src="/mountains-1.jpg" alt="">
+    <img src="/mountains-1.jpg" alt="" loading="lazy">
   </div>
   <div class="col-start-3 [transform scale-75 rotate-6 translate-x-2 translate-y-15]">
-    <img src="/mountains-2.jpg" alt="">
+    <img src="/mountains-2.jpg" alt="" loading="lazy">
   </div>
   <div class="[transform scale-150 translate-y-11]">
-    <img src="/mountains-3.jpg" alt="">
+    <img src="/mountains-3.jpg" alt="" loading="lazy">
   </div>
   <div class="[transform translate-y-24]">
-    <img src="/mountains-4.jpg" alt="">
+    <img src="/mountains-4.jpg" alt="" loading="lazy">
   </div>
   <div class="row-start-1 col-start-2 col-span-2 [transform translate-x-20 translate-y-4]">
-    <img src="/mountains-5.jpg" alt="">
+    <img src="/mountains-5.jpg" alt="" loading="lazy">
   </div>
 </div>


### PR DESCRIPTION
Hey TailwindLabs,

I started a personal project where I'm trying to make 100 page performance-related contributions to the projects I use and love.

TailwindCSS is one of these projects, and also the first one I've choosen to start my project with.

I've noticed that the Core Web Vitals are failing for the homepage, so I found some low-hanging fruits to start fixing these issues.

![image](https://user-images.githubusercontent.com/20286399/168318965-23fd8daf-cf4c-4fc8-8d95-54ee9df2dada.png)

I've updated the code loading the images + the code samples to reflect the changes I've introduced to the components you feature on the homepage.

I managed to delay 1MB of images that weren't used on the first load.

Here are the "before stats" (Localhost, focus was on the IMG tab from the Chrome Dev Tools):
![before_lazy_loading_images](https://user-images.githubusercontent.com/20286399/168319125-69612f16-84c2-46a4-a42c-e56f0623feb9.png)

Here are the "after stats":
![after_lazy_loading_images](https://user-images.githubusercontent.com/20286399/168319108-6f0063a2-774c-4b4f-82b6-c5770ef35487.png)