### PR TITLE
Specify wrong use of `important` with selector may cause failure on generating classes

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -428,6 +428,16 @@ Or creating a new folder mid-project that wasn't covered originally and forgetti
   }
 ```
 
+If you're using `important` with [selector strategy](https://tailwindcss.com/docs/configuration#selector-strategy), make sure the speficied selector matches with the root element of your site.
+
+```diff-js tailwind.config.js
+  module.exports = {
+-   important: 'root'
++   important: '#root'
+    // ...
+  }
+```
+
 ### Dynamic class names
 
 As outlined in [Class detection in-depth](#class-detection-in-depth), Tailwind doesn't actually run your source code and won't detect dynamically constructed class names.


### PR DESCRIPTION
I personally experienced it(https://github.com/tailwindlabs/tailwindcss/discussions/8341#discussioncomment-2749008). It's a very simple typo, but this may help people like me.

