### PR TITLE
Remove extra `onInput` parameter

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -38,7 +38,6 @@ export function SearchProvider({ children }) {
     isOpen,
     onOpen,
     onClose,
-    onInput,
   })
 
   return (


### PR DESCRIPTION
The `onInput` parameter is not used in the `useDocSearchKeyboardEvents` hook.