### PR TITLE
Update SvelteKit guide

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -41,7 +41,7 @@ let steps = [
     body: () => (
       <p>
         In your <code>svelte.config.js</code> file, import <code>svelte-preprocess</code> and
-        configure it to enable postcss pre-processing of <code>&lt;style&gt;</code> blocks.
+        configure it to process <code>&lt;style&gt;</code> blocks as PostCSS.
       </p>
     ),
     code: {

--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -25,15 +25,37 @@ let steps = [
     title: 'Install Tailwind CSS',
     body: () => (
       <p>
-        Install <code>tailwindcss</code> and its peer dependencies via npm, and then run the
-        following commands to generate both <code>tailwind.config.cjs</code> and{' '}
-        <code>postcss.config.cjs</code>.
+        Using npm, install <code>tailwindcss</code> and its peer dependencies, as well as{' '}
+        <code>svelte-preprocess</code>, and then run the following commands to generate both{' '}
+        <code>tailwind.config.cjs</code> and <code>postcss.config.cjs</code>.
       </p>
     ),
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init tailwind.config.cjs -p\nmv postcss.config.js postcss.config.cjs',
+      code: 'npm install -D tailwindcss postcss autoprefixer svelte-preprocess\nnpx tailwindcss init tailwind.config.cjs -p\nmv postcss.config.js postcss.config.cjs',
+    },
+  },
+  {
+    title: 'Enable use of PostCSS in <style> blocks',
+    body: () => (
+      <p>
+        In your <code>svelte.config.js</code> file, import <code>svelte-preprocess</code> and
+        configure it to enable postcss pre-processing of <code>&lt;style&gt;</code> blocks.
+      </p>
+    ),
+    code: {
+      name: 'svelte.config.js',
+      lang: 'js',
+      code: `> import preprocess from "svelte-preprocess";
+
+  const config = {
+>   preprocess: [
+>     preprocess({
+>       postcss: true,
+>     }),
+>   ],
+  }`,
     },
   },
   {


### PR DESCRIPTION
The CSS grammar allows any characters that are not `;` or `{` as part of an at-rule "preamble" but Svelte's CSS parsing breaks on at-rules containing a `:` when nested inside rules. This situation occurs when user's apply classes with variants, for example, `@apply dark:bg-white`. To combat this we need to add `svelte-preprocess` and configure it run postcss on `<style>` blocks before svelte has a chance to analyze the CSS. It'd be great to not need this but, at least for now, we do.

Fixes #1221