### PR TITLE
Fixed typo: example code using wrong color class

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -49,7 +49,7 @@ To make this as easy as possible, Tailwind includes a `dark` variant that lets y
 </Example>
 
 ```html
-<div class="bg-white **dark:bg-slate-900** rounded-lg px-6 py-8 ring-1 ring-slate-900/5 shadow-xl">
+<div class="bg-white **dark:bg-slate-800** rounded-lg px-6 py-8 ring-1 ring-slate-900/5 shadow-xl">
   <div>
     <span class="inline-flex items-center justify-center p-2 bg-indigo-500 rounded-md shadow-lg">
       <svg class="h-6 w-6 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><!-- ... --></svg>


### PR DESCRIPTION
In the example that is being displayed the `bg-slate-800` class is used, see line 34.
However, the provided code snippet used `bg-slate-900`, see line 52.