### PR TITLE
Update even:bg color for table example

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -251,7 +251,7 @@ You can also style an element when it's an odd or even child using the `odd` and
   <tbody>
     {#each people as person}
       <!-- Use a white background for odd rows, and slate-100 for even rows -->
-      <tr class="**odd:bg-white** **even:bg-slate-100**">
+      <tr class="**odd:bg-white** **even:bg-slate-50**">
         <td>{person.name}</td>
         <td>{person.title}</td>
         <td>{person.email}</td>


### PR DESCRIPTION
On the **["First, last, odd and even"](https://tailwindcss.com/docs/hover-focus-and-other-states#first-last-odd-and-even)** section the table code being shown as an example mentions the use of `bg-slate-100,` but the actual color being used is `bg-slate-50`. I detected this error because the color on my code looked different.