### PR TITLE
Fix documentation example for grid-start/end

### DIFF
--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -33,7 +33,7 @@ Use the `col-span-{n}` utilities to make an element span _n_ columns.
 </Example>
 
 ```html
-<div class="grid grid-cols-3 gap-4">
+<div class="grid grid-cols-6 gap-4">
   <div class="...">01</div>
   <div class="...">02</div>
   <div class="...">03</div>


### PR DESCRIPTION
I think this is a typo, the example has 6 columns, not three