### PR TITLE
Fixed typo

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -376,15 +376,15 @@ module.exports = {
     colors: {
       // Using modern `rgb`
       primary: 'rgb(var(--color-primary) / <alpha-value>)',
-      primary: 'rgb(var(--color-secondary) / <alpha-value>)',
+      secondary: 'rgb(var(--color-secondary) / <alpha-value>)',
 
       // Using modern `hsl`
       primary: 'hsl(var(--color-primary) / <alpha-value>)',
-      primary: 'hsl(var(--color-secondary) / <alpha-value>)',
+      secondary: 'hsl(var(--color-secondary) / <alpha-value>)',
 
       // Using legacy `rgba`
       primary: 'rgba(var(--color-primary), <alpha-value>)',
-      primary: 'rgba(var(--color-secondary), <alpha-value>)',
+      secondary: 'rgba(var(--color-secondary), <alpha-value>)',
     }
   }
 }


### PR DESCRIPTION
In the example primary was listed a second time instead of secondary.