### PR TITLE
add 3.1 types support to example

### DIFF
--- a/src/pages/docs/installation/index.js
+++ b/src/pages/docs/installation/index.js
@@ -28,7 +28,8 @@ let steps = [
     code: {
       name: 'tailwind.config.js',
       lang: 'js',
-      code: `  module.exports = {
+      code: `  /** @type {import('tailwindcss').Config} */
+  module.exports = {
 >   content: ["./src/**/*.{html,js}"],
     theme: {
       extend: {},


### PR DESCRIPTION
Since the new `npx tailwindcss init` also provides the new type comment; I added it to the installation example as well.