### PR TITLE
fix: generated CSS mismatches with example

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1016,9 +1016,8 @@ If you need spaces in your selector, you can use an underscore. For example, thi
 ```
 
 ```css Generated CSS
-/* https://media.giphy.com/media/uPnKU86sFa2fm/giphy.gif */
-.\[\&\:nth-child\(3\)\]\:underline:nth-child(3) {
-  text-decoration-style: underline
+.\[\&_p\]\:mt-4 p {
+    margin-top: 1rem;
 }
 ```
 


### PR DESCRIPTION
In "spaces in selector" part the generated css was mistakenly took from a previous example.