### PR TITLE
Typo Fix

### DIFF
--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -84,7 +84,7 @@ let steps = [
       lang: 'js',
       code: `  import { createApp } from 'vue'
   import App from './App.vue'
-> import './index.css'
+> import './src/index.css'
 
   createApp(App).mount('#app')`,
     },


### PR DESCRIPTION
Step 5 in the Vite installation guide suggests importing the newly-created `./src/index.css` file but the code snippet is missing the `src` directory.