### PR TITLE
Guide people toward using path resolution.

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -246,11 +246,14 @@ This will ensure that Tailwind _always_ includes those styles in your CSS, which
 If you've created your own reusable set of components that are styled with Tailwind and are importing them in multiple projects, make sure to configure Tailwind to scan those components for class names:
 
 ```js tailwind.config.js
+  const path = require('path');
+  const componentLibrary = require.resolve('@my-company/tailwind-components');
+  
   module.exports = {
     content: [
       './components/**/*.{html,js}',
       './pages/**/*.{html,js}',
->     './node_modules/@my-company/tailwind-components/**/*.js',
+>     path.join(componentLibrary, '**/*.js'),
     ],
     // ...
   }

--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -246,20 +246,32 @@ This will ensure that Tailwind _always_ includes those styles in your CSS, which
 If you've created your own reusable set of components that are styled with Tailwind and are importing them in multiple projects, make sure to configure Tailwind to scan those components for class names:
 
 ```js tailwind.config.js
-  const path = require('path');
-  const componentLibrary = require.resolve('@my-company/tailwind-components');
-  
   module.exports = {
     content: [
       './components/**/*.{html,js}',
       './pages/**/*.{html,js}',
->     path.join(componentLibrary, '**/*.js'),
+>     './node_modules/@my-company/tailwind-components/**/*.js',
     ],
     // ...
   }
 ```
 
 This will make sure Tailwind generates all of the CSS needed for those components as well.
+
+If you're working in a monorepo with workspaces, you may need to use `require.resolve` to make sure Tailwind can see your content files:
+
+```js tailwind.config.js
+  const path = require('path');
+
+  module.exports = {
+    content: [
+      './components/**/*.{html,js}',
+      './pages/**/*.{html,js}',
+>    path.join(require.resolve('@my-company/tailwind-components'), '**/*.js'),
+    ],
+    // ...
+  }
+```
 
 ### Configuring raw content
 


### PR DESCRIPTION
In a workspace setup encouraging people to directly path into `node_modules` will result in inconsistent outcomes. Instead rely on the system to properly identify the path of the node module, and then append the glob pattern manually.

This will result in a system-path-separator normalized absolute path which is distinct from the current `contents` items. I did not investigate if that will work as expected where these values are consumed so I wanted to draw attention to the distinction.