### PR TITLE
Update screens.mdx documentation

### DIFF
--- a/src/pages/docs/screens.mdx
+++ b/src/pages/docs/screens.mdx
@@ -111,8 +111,8 @@ const defaultTheme = require('tailwindcss/defaultTheme')
 module.exports = {
   theme: {
     screens: {
-      'xs': '475px',
       ...defaultTheme.screens,
+      'xs': '475px',
     },
   },
   variants: {},


### PR DESCRIPTION
In the "Adding smaller breakpoints" section, move the spreading of `defaultTheme.screens` above the custom 'xs' size definition.

Following the current documentation would cause the default screen sizes to override if a user was to add custom definitions for existing sizes e.g. for 'sm' and placed it above the default spread. See example below.

**Before: Potential issue following the existing documentation to spread at the end of the object:**
```
{
  'xs': '475px',
  'sm': '550px',
  ...defaultTheme.screens,
}
```

With this config, the 'sm' value would still be the default of 640px, as it has been overwritten by the spreading of the defaults. The xs size would correctly be 475px only because it does not exist on the default screens object.

**After: Documentation update on the spread position:**
```
{
  ...defaultTheme.screens,
  'xs': '475px',
  'sm': '550px',
}
```
With this configuration of spreading first, both of the custom sizes are respected and override the defaults as one would expect.