### PR TITLE
Remove `prefix` from plugin api example

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -17,7 +17,7 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = {
   plugins: [
-    plugin(function({ addUtilities, addComponents, e, prefix, config }) {
+    plugin(function({ addUtilities, addComponents, e, config }) {
       // Add your custom styles here
     }),
   ]


### PR DESCRIPTION
I was looking at the example and was wondering if `prefix` should be documented.

As I learned from [this](https://github.com/tailwindlabs/tailwindcss/pull/8770#issuecomment-1173984577) comment, `prefix` is deprecated and should be removed from the documentation.