### PR TITLE
add sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "if [ -f './.next/serverless/scripts/build-rss.js' ]; then node ./.next/serverless/scripts/build-rss.js; else node ./.next/server/scripts/build-rss.js; fi",
+    "postbuild": "if [ -f './.next/serverless/scripts/build-rss.js' ]; then node ./.next/serverless/scripts/build-rss.js; else node ./.next/server/scripts/build-rss.js; fi; next-sitemap",
     "start": "next start",
     "export": "next build && next export",
     "format": "prettier '{src,remark,scripts}/**/*.{css,js,mdx}' --write"
@@ -48,6 +48,7 @@
     "mini-svg-data-uri": "^1.4.3",
     "minimatch": "^3.0.4",
     "next": "11",
+    "next-sitemap": "^3.1.11",
     "postcss": "^8.4.5",
     "postcss-focus-visible": "^5.0.0",
     "postcss-import": "^14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,6 +1003,11 @@
   version "0.1.2"
   resolved "https://registry.npmjs.org/@badrap/bar-of-progress/-/bar-of-progress-0.1.2.tgz"
 
+"@corex/deepmerge@^4.0.29":
+  version "4.0.29"
+  resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-4.0.29.tgz#af9debf07d7f6b0d2a9d04a266abf2c1418ed2f6"
+  integrity sha512-q/yVUnqckA8Do+EvAfpy7RLdumnBy9ZsducMUtZTvpdbJC7azEf1hGtnYYxm0QfphYxjwggv6XtH64prvS1W+A==
+
 "@docsearch/css@3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@docsearch/css/-/css-3.1.0.tgz"
@@ -4263,6 +4268,14 @@ natural-compare@^1.4.0:
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
+
+next-sitemap@^3.1.11:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/next-sitemap/-/next-sitemap-3.1.11.tgz#02d9cecc84e087906966a9cc800a3f0ac95772b7"
+  integrity sha512-qHq/nVzqEL3Sd5N+1ZnqoY2xN4BSmgEkIlvCjFOtMMIyl8Tr/xmVZgVau/8aZsDtxoXPKG/NzdonZssvpK4Jdw==
+  dependencies:
+    "@corex/deepmerge" "^4.0.29"
+    minimist "^1.2.6"
 
 next@11:
   version "11.1.4"


### PR DESCRIPTION
Just using the [next-sitemap](https://github.com/iamvishnusankar/next-sitemap) package. 
This'll be nice for things like [Dash](https://kapeli.com/dash) to be able to build documentation.
Left to do
[ ] add instructions to readme
[ ] make sure paths look correct