### PR TITLE
feat: add heading to class names extraction

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -195,6 +195,7 @@ export default function Button({ color, size, children }) {
   )
 }
 ```
+### Class names
 
 The most important implication of how Tailwind extracts class names is that it will only find classes that exist _as complete unbroken strings_ in your source files.
 

--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -195,7 +195,8 @@ export default function Button({ color, size, children }) {
   )
 }
 ```
-### Class names
+
+### Dynamic class names
 
 The most important implication of how Tailwind extracts class names is that it will only find classes that exist _as complete unbroken strings_ in your source files.
 
@@ -429,9 +430,7 @@ Or creating a new folder mid-project that wasn't covered originally and forgetti
   }
 ```
 
-### Dynamic class names
-
-As outlined in [Class detection in-depth](#class-detection-in-depth), Tailwind doesn't actually run your source code and won't detect dynamically constructed class names.
+It could also be that you are trying to use dynamic class names, which won't work because Tailwind doesn't actually evaluate your source code and can only detect static unbroken class strings.
 
 <TipBad>Don't construct class names dynamically</TipBad>
 
@@ -446,6 +445,8 @@ Make sure you always use complete class names in your code:
 ```html
 <div class="{{ error ? 'text-red-600' : 'text-green-600' }}"></div>
 ```
+
+Read our documentation on [dynamic class names](#dynamic-class-names) for more details.
 
 ### Styles rebuild in an infinite loop
 


### PR DESCRIPTION
Hi, 
In this PR, I'm adding the title Class names so it is easier to share a direct link to the documentation about Tailwind extracting class names and why we should not use string interpolation or concatenate partial names. 