### PR TITLE
docs: replace unescaped font names used in sample

### DIFF
--- a/src/pages/docs/font-family.mdx
+++ b/src/pages/docs/font-family.mdx
@@ -123,7 +123,7 @@ For convenience, [Preflight](/docs/preflight) sets the font family on the `html`
     theme: {
       extend: {
         fontFamily: {
-+         'sans': ['Proxima Nova', ...defaultTheme.fontFamily.sans],
++         'sans': ['"Proxima Nova"', ...defaultTheme.fontFamily.sans],
         },
       }
     }


### PR DESCRIPTION
I was looking at the docs regarding escaping font names.

The docs said that:
```
// Won't work:
'sans': ['Exo 2', ...],
```

But later on has this in the sample code snippet:
```
module.exports = {
  theme: {
    extend: {
      fontFamily: {
+        'sans': ['Proxima Nova', ...defaultTheme.fontFamily.sans],
      },
    }
  }
}
```

So if I understand correctly, this should be a typo?