### PR TITLE
match comment color to demo color

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -251,7 +251,7 @@ You can also style an element when it's an odd or even child using the `odd` and
   <!-- ... -->
   <tbody>
     {#each people as person}
-      <!-- Use a white background for odd rows, and slate-100 for even rows -->
+      <!-- Use a white background for odd rows, and slate-50 for even rows -->
       <tr class="**odd:bg-white** **even:bg-slate-50**">
         <td>{person.name}</td>
         <td>{person.title}</td>


### PR DESCRIPTION
The comments explained a different color than was used in the demonstration. I've changed the comment to say the correct color.