### PR TITLE
feat: add copy to clipboard for selectors

### DIFF
--- a/src/components/ClassTable.js
+++ b/src/components/ClassTable.js
@@ -3,6 +3,7 @@ import { isObject } from '@/utils/isObject'
 import { castArray } from '@/utils/castArray'
 import clsx from 'clsx'
 import { Heading } from '@/components/Heading'
+import { CopyButton } from '@/components/Steps'
 
 function renderProperties(
   properties,
@@ -55,6 +56,8 @@ export const ClassTable = memo(
     let isScrollable = scroll || classes.length > 12
     let isCollapsable = classes.length > 10
     let [isCollapsed, setIsCollapsed] = useState(isCollapsable)
+    const [isCopyShown, setIsCopyShown] = useState(false)
+    const [selectedUtility, setSelectedUtility] = useState('')
     let ref = useRef()
     let isInitial = useRef(true)
 
@@ -122,17 +125,33 @@ export const ClassTable = memo(
                   let properties = { ...utilities[selector] }
 
                   return (
-                    <tr key={utility} style={rowStyle ? rowStyle({ css: properties }) : undefined}>
+                    <tr
+                      key={utility}
+                      style={rowStyle ? rowStyle({ css: properties }) : undefined}
+                      onMouseEnter={() => {
+                        setIsCopyShown(true)
+                        setSelectedUtility(utility)
+                      }}
+                      onMouseLeave={() => {
+                        setIsCopyShown(false)
+                        setSelectedUtility('')
+                      }}
+                    >
                       <td
                         translate="no"
                         className={clsx(
-                          'py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400',
+                          'relative py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400',
                           {
                             'border-t border-slate-100 dark:border-slate-400/10': i !== 0,
                           }
                         )}
                       >
                         {transformSelector(selector)}
+                        {isCopyShown && selectedUtility === utility && (
+                          <span className={'absolute right-2 top-1'}>
+                            <CopyButton code={transformSelector(selector)} />
+                          </span>
+                        )}
                       </td>
                       <td
                         translate="no"

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -45,7 +45,7 @@ export function Steps({ steps, code, level = 2 }) {
   )
 }
 
-function CopyButton({ code }) {
+export function CopyButton({ code }) {
   let [{ state, i }, setState] = useState({ state: 'idle', i: 0 })
 
   useEffect(() => {


### PR DESCRIPTION
As a dev who uses Tailwind every day and who keeps the docs open 24/7 when working, this feature has been on my mind since day one. I find myself clicking on the selectors as a habit even though I realise it won't do anything. I'm sure I'm not the only one. 

My suggestion is to add the already implemented copy functionality to the classes components too. 

This PR is only a friendly suggestion and no feelings will get hurt if it gets thrown out. I'm open to suggestions and comments for improving on this PR.

Also, thank you for what you're doing. I'm a big fan of Tailwind.

https://user-images.githubusercontent.com/50806665/182046020-43f98303-bcab-4459-8027-cc3797bc1422.mov