### PR TITLE
Installation. PossCSS config file creation

### DIFF
--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {


### PR DESCRIPTION
Add key `-p` for creating PossCSS config file:
`npx tailwindcss init -p`

Without that key `postcss.config.js` file will not being created.