### PR TITLE
fix: generated CSS mismatches with HTML

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -9,7 +9,7 @@ import { SnippetGroup } from '@/components/SnippetGroup'
 
 Every utility class in Tailwind can be applied _conditionally_ by adding a modifier to the beginning of the class name that describes the condition you want to target.
 
-For example, to apply the `bg-sky-500` class on hover, use the `hover:bg-sky-700` class:
+For example, to apply the `bg-sky-700` class on hover, use the `hover:bg-sky-700` class:
 
 <Example hint="Hover over this button to see the background color change">
   <div class="grid place-items-center">

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -9,7 +9,7 @@ import { SnippetGroup } from '@/components/SnippetGroup'
 
 Every utility class in Tailwind can be applied _conditionally_ by adding a modifier to the beginning of the class name that describes the condition you want to target.
 
-For example, to apply the `bg-sky-700` class on hover, use the `hover:bg-sky-700` class:
+For example, to apply the `bg-sky-500` class on hover, use the `hover:bg-sky-700` class:
 
 <Example hint="Hover over this button to see the background color change">
   <div class="grid place-items-center">
@@ -20,7 +20,7 @@ For example, to apply the `bg-sky-700` class on hover, use the `hover:bg-sky-700
 </Example>
 
 ```html
-<button class="bg-sky-600 **hover:bg-sky-700** ...">
+<button class="bg-sky-500 **hover:bg-sky-700** ...">
   Save changes
 </button>
 ```


### PR DESCRIPTION
Rendering `bg-sky-500` but showing `bg-sky-600` and `bg-sky-700` in the documentation