### PR TITLE
Update SvelteKit installation guide

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -98,12 +98,12 @@ let steps = [
     title: 'Import the CSS file',
     body: () => (
       <p>
-        Create a <code>./src/routes/__layout.svelte</code> file and import the newly-created{' '}
+        Create a <code>./src/routes/+layout.svelte</code> file and import the newly-created{' '}
         <code>app.css</code> file.
       </p>
     ),
     code: {
-      name: '__layout.svelte',
+      name: '+layout.svelte',
       lang: 'html',
       code: `<script>
   import "../app.css";
@@ -129,7 +129,7 @@ let steps = [
     title: 'Start using Tailwind in your project',
     body: () => <p>Start using Tailwind’s utility classes to style your content.</p>,
     code: {
-      name: 'index.svelte',
+      name: '+page.svelte',
       lang: 'html',
       code: `<h1 class="text-3xl font-bold underline">
   Hello world!


### PR DESCRIPTION
SvelteKit recently introduced changes to the its router ([among others](https://github.com/sveltejs/kit/discussions/5774)): The `__layout.svelte` file is now named `+layout.svelte`, and `index.svelte` → `+page.svelte`. This PR changes those two file names so the installation guide is up-to-date again.

See here for a complete overview of the filename changes: https://github.com/sveltejs/kit/discussions/5774