### PR TITLE
Mention using theme() inside arbitrary values

### DIFF
--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -82,7 +82,7 @@ This works for everything in the framework, including things like background col
 </div>
 ```
 
-It's even possible to use the `theme` function to access your config values:
+It's even possible to use the [`theme` function](/docs/functions-and-directives#theme) to reference the design tokens in your `tailwind.config.js` file:
 
 ```html
 <div class="grid grid-cols-[fit-content(theme(spacing.32))]">

--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -82,6 +82,14 @@ This works for everything in the framework, including things like background col
 </div>
 ```
 
+It's even possible to use the `theme` function to access your config values:
+
+```html
+<div class="grid grid-cols-[fit-content(theme(spacing.32))]">
+  <!-- ... -->
+</div>
+```
+
 ### Arbitrary properties
 
 If you ever need to use a CSS property that Tailwind doesn't include a utility for out of the box, you can also use square bracket notation to write completely arbitrary CSS:


### PR DESCRIPTION
Hey everyone, I've [just learnt](https://twitter.com/adamwathan/status/1561370840415223808) that it's possible to use `theme()` within arbitrary values , and realised it wasn't mentioned in the docs, so I've added a quick example. 

There's a few use cases for it, I've used the top one in the code demo:
```
grid grid-cols-[fit-content(theme(spacing.32))]

w-[calc(theme(screens.lg)/12)]

bg-[conic-gradient(theme(colors.green.400),black)]
```

See the generated CSS in [Tailwind Play](https://play.tailwindcss.com/Gr3fFYnumf)