### PR TITLE
fix: SolidJS Example `className` attribute

### DIFF
--- a/src/pages/docs/guides/solidjs.js
+++ b/src/pages/docs/guides/solidjs.js
@@ -89,7 +89,7 @@ let steps = [
       lang: 'jsx',
       code: `  export default function App() {
     return (
->     <h1 className="text-3xl font-bold underline">
+>     <h1 class="text-3xl font-bold underline">
 >       Hello world!
 >     </h1>
     )


### PR DESCRIPTION
Thanks for adding a SolidJS guide. The JSX example included in the last step uses the `className` attribute in the JSX. This is invalid SolidJS JSX syntax. We can just use `class` attribute directly here without any issue 😄

<img width="612" alt="Screenshot 2022-08-27 at 1 15 51 PM" src="https://user-images.githubusercontent.com/45807386/187040952-e47d4d34-e6c2-4502-84d3-6f49ebd437bb.png">
 