### PR TITLE
Add docs about tailwind.config.js IDE type-hinting

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -468,11 +468,13 @@ fullConfig.theme.boxShadow['2xl']
 
 Note that this will transitively pull in a lot of our build-time dependencies, resulting in bigger bundle client-side size. To avoid this, we recommend using a tool like [babel-plugin-preval](https://github.com/kentcdodds/babel-plugin-preval) to generate a static version of your configuration at build-time.
 
-## First-party TypeScript types
+---
 
-We ship types for all of our JS APIs you work with when using Tailwind, most notably the tailwind.config.js file. This means you get all sorts of useful IDE support, and makes it a lot easier to make changes to your configuration without referencing the documentation quite as much.
+## TypeScript types
 
-To set it up, just add the type annotation above your config definition:
+We ship first-party TypeScript types for the `tailwind.config.js` file which give you all sorts of useful IDE support, and makes it a lot easier to make changes to your configuration without referencing the documentation quite as much.
+
+Configuration files generated with Tailwind CLI include the necessary type annotation by default, but to configure TypeScript types maually, just add the type annotation above your configuration object:
 
 ```js tailwind.config.js
 /** @type {import('tailwindcss').Config} */

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -467,3 +467,22 @@ fullConfig.theme.boxShadow['2xl']
 ```
 
 Note that this will transitively pull in a lot of our build-time dependencies, resulting in bigger bundle client-side size. To avoid this, we recommend using a tool like [babel-plugin-preval](https://github.com/kentcdodds/babel-plugin-preval) to generate a static version of your configuration at build-time.
+
+## First-party TypeScript types
+
+We ship types for all of our JS APIs you work with when using Tailwind, most notably the tailwind.config.js file. This means you get all sorts of useful IDE support, and makes it a lot easier to make changes to your configuration without referencing the documentation quite as much.
+
+To set it up, just add the type annotation above your config definition:
+
+```js tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    // ...
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+```


### PR DESCRIPTION
Copy is taken from the press release for v3.1 https://tailwindcss.com/blog/tailwindcss-v3-1#first-party-type-script-types

<img width="791" alt="Screenshot 2022-08-30 at 18 37 06" src="https://user-images.githubusercontent.com/237556/187505843-c007249e-b6ce-4fae-bea1-6ed1a77e2a82.png">