### PR TITLE
fixed TableOfContents showing over content

### DIFF
--- a/src/layouts/ContentsLayout.js
+++ b/src/layouts/ContentsLayout.js
@@ -244,7 +244,7 @@ export function ContentsLayout({ children, meta, classes, tableOfContents, secti
         </Link>
       </Footer>
 
-      <div className="fixed z-20 top-[3.8125rem] bottom-0 right-[max(0px,calc(50%-45rem))] w-[19.5rem] py-10 overflow-y-auto hidden xl:block">
+      <div className="fixed z-20 top-[3.8125rem] bottom-0 right-0 w-[19.5rem] py-10 overflow-y-auto hidden xl:block">
         {toc.length > 0 && (
           <TableOfContents tableOfContents={toc} currentSection={currentSection} />
         )}


### PR DESCRIPTION
The TableOfContents modal was showing directly over the main content on the xl breakpoint, because of the calculation on the 'right-' attribute. I set right to zero and it looks much better/might be what was intended.