### PR TITLE
docs: fix typo

### DIFF
--- a/src/pages/docs/overflow.mdx
+++ b/src/pages/docs/overflow.mdx
@@ -49,7 +49,7 @@ Use `overflow-hidden` to clip any content within an element that overflows the b
 
 ### Scrolling if needed
 
-Use `overflow-auto` to add scrollbars to an element in the event that its content overflows the bounds of that element. Unlike `.overflow-scroll`, which always shows scrollbars, this utility will only show them if scrolling is necessary.
+Use `overflow-auto` to add scrollbars to an element in the event that its content overflows the bounds of that element. Unlike `overflow-scroll`, which always shows scrollbars, this utility will only show them if scrolling is necessary.
 
 <Example>
   <div class="overflow-auto h-72 relative max-w-sm mx-auto bg-white dark:bg-slate-800 dark:highlight-white/5 shadow-lg ring-1 ring-black/5 rounded-xl flex flex-col divide-y dark:divide-slate-200/5">
@@ -274,7 +274,7 @@ Use `overflow-y-scroll` to allow vertical scrolling and always show scrollbars u
 
 ### Scrolling in all directions
 
-Use `overflow-scroll` to add scrollbars to an element. Unlike `.overflow-auto`, which only shows scrollbars if they are necessary, this utility always shows them. Note that some operating systems (like macOS) hide unnecessary scrollbars regardless of this setting.
+Use `overflow-scroll` to add scrollbars to an element. Unlike `overflow-auto`, which only shows scrollbars if they are necessary, this utility always shows them. Note that some operating systems (like macOS) hide unnecessary scrollbars regardless of this setting.
 
 <Example p="none">
   <div class="mx-4 bg-white dark:bg-slate-800 shadow-xl overflow-hidden">


### PR DESCRIPTION
Remove strange dots from Tailwind classes

I haven’t checked other files, so there might be more.