### PR TITLE
Typo in `place-items.mdx`

### DIFF
--- a/src/pages/docs/place-items.mdx
+++ b/src/pages/docs/place-items.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Start
 
-Use `place-items-start` to place grid items on the start of their grid areas on both axis:
+Use `place-items-start` to place grid items on the start of their grid areas on both axes:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">


### PR DESCRIPTION
Corrects a typo on line 16: the plural of “axis” is “axes”.