### PR TITLE
Update link to Next.js + Tailwind CSS Example

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -108,7 +108,7 @@ export default function UsingNextJS({ code }) {
       <div className="relative z-10 max-w-3xl mb-16 prose prose-slate dark:prose-dark">
         <p>
           The quickest way to start using Tailwind CSS in your Next.js project is to use the{' '}
-          <a href="https://github.com/vercel/next.js/tree/4d4f3093019179b1928ec07c16f38882241c0375/examples/with-tailwindcss">
+          <a href="https://github.com/vercel/next.js/tree/c3e5caf1109a2eb42801de23fc78e42a08e5da6e/examples/with-tailwindcss">
             Next.js + Tailwind CSS Example
           </a>
           . This will automatically configure your Tailwind setup based on the official Next.js


### PR DESCRIPTION
The previous link points to an old version of the Next.js + Tailwind CSS Example. With this old version it is not possible to simply one click copy the commands for each package manager (npm, yarn and pnpm), therefore I updated the link to the current (Sep 2022) version.