### PR TITLE
Remove inaccurate statements on inline styles

### DIFF
--- a/src/pages/docs/utility-first.mdx
+++ b/src/pages/docs/utility-first.mdx
@@ -126,11 +126,7 @@ When you realize how productive you can be working exclusively in HTML with pred
 
 A common reaction to this approach is wondering, "isn't this just inline styles?" and in some ways it is — you're applying styles directly to elements instead of assigning them a class name and then styling that class.
 
-But using utility classes has a few important advantages over inline styles:
-
-- **Designing with constraints**. Using inline styles, every value is a magic number. With utilities, you're choosing styles from a predefined [design system](/docs/theme), which makes it much easier to build visually consistent UIs.
-- **Responsive design**. You can't use media queries in inline styles, but you can use Tailwind's [responsive utilities](/docs/responsive-design) to build fully responsive interfaces easily.
-- **Hover, focus, and other states**. Inline styles can't target states like hover or focus, but Tailwind's [state variants](/docs/hover-focus-and-other-states) make it easy to style those states with utility classes.
+But using utility classes has some advantages over inline styles.
 
 This component is fully responsive and includes a button with hover and focus styles, and is built entirely with utility classes:
 


### PR DESCRIPTION
The moment CSS variables arrived on the scene, the `style=` attribute gained superpowers. The information currently on the Tailwind website is ~4 years out of date.

> Using inline styles, every value is a magic number

Not true. If you want, every value you put in an inline style can be a CSS variable and utilize a full design system. Not magic at all.

> You can't use media queries in inline styles

No, but the CSS variables you use can themselves be redefined by media queries. And you can also build things like fluid sizes and fluid typography out of CSS variables.

> Inline styles can't target states like hover or focus

Again, not true. With CSS variables you can redefine the value of the variable based on any state possible in a stylesheet, including hover or focus states.

This PR removes the inaccurate statements. I'm not sure what you would replace them with, but hopefully it would not contain information ~4 years out of date.