### PR TITLE
State `safelist` is replaced in preset merging

### DIFF
--- a/src/pages/docs/presets.mdx
+++ b/src/pages/docs/presets.mdx
@@ -130,6 +130,7 @@ The following options in `tailwind.config.js` simply **replace** the same option
 - `important`
 - `variantOrder`
 - `separator`
+- `safelist`
 
 The remaining options are each carefully merged in the way that makes the most sense for that option, explained in more detail below.
 


### PR DESCRIPTION
[`safelist` seems to follow the replacing logic](https://play.tailwindcss.com/mk3pUMOM6K?file=config) like other options, such as `darkMode`, `important`, etc. – let's be explicit here and let users know this!