### PR TITLE
Added a missing step in the Vue guide

### DIFF
--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -186,6 +186,24 @@ let tabs = [
         },
       },
       {
+        title: 'Add the Tailwind to postcss plugins config',
+        body: () => (
+          <p>
+            Add the tailwind to the list of postcss plugins in `postcss.config.cjs`
+          </p>
+        ),
+        code: {
+          name: 'postcss.config.cjs',
+          lang: 'js',
+          code: `module.exports = {
+            plugins: {
+                tailwindcss: {},
+                autoprefixer: {},
+            },
+        }`,
+        },
+      },
+      {
         title: 'Start your build process',
         body: () => (
           <p>


### PR DESCRIPTION
I spent hours troubleshooting why my app wasn't picking up tailwind until I noticed that a step was missing in the guide, so I think it might be beneficial to have the step to add the tailwind to the list of postcss plugins and avoid someone else missing this and spend some time banging his head on the keyboard :)