### PR TITLE
Add prettier-plugin-tailwindcss to editor-setup

### DIFF
--- a/src/pages/docs/editor-setup.mdx
+++ b/src/pages/docs/editor-setup.mdx
@@ -31,9 +31,9 @@ JetBrains IDEs like WebStorm, PhpStorm, and others include support for intellige
 
 [Learn more about Tailwind CSS support in JetBrains IDEs &rarr;](https://www.jetbrains.com/help/webstorm/tailwind-css.html)
 
-## Automatic Class Sorting with Prettier
+## Automatic class sorting with Prettier
 
-We recommend using the [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) for [Prettier](https://prettier.io/) that scans your templates for class attributes containing Tailwind CSS classes, and then sorts those classes automatically following our [recommended class order](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted).
+We maintain an official [Prettier plugin](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) for Tailwind CSS that automatically sorts your classes following our [recommended class order](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted).
 
 It works seamlessly with custom Tailwind configurations, and because it’s just a Prettier plugin, it works anywhere Prettier works — including every popular editor and IDE, and of course on the command line.
 
@@ -45,4 +45,4 @@ It works seamlessly with custom Tailwind configurations, and because it’s just
 <button class="bg-sky-700 px-4 py-2 text-white hover:bg-sky-800 sm:px-8 sm:py-3">...</button>
 ```
 
-Check out the plugin [on GitHub](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) or read our [blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) to get started.
+Check out the plugin [on GitHub](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) learn more and get started.

--- a/src/pages/docs/editor-setup.mdx
+++ b/src/pages/docs/editor-setup.mdx
@@ -30,3 +30,19 @@ Check out the project [on GitHub](https://github.com/tailwindcss/intellisense) t
 JetBrains IDEs like WebStorm, PhpStorm, and others include support for intelligent Tailwind CSS completions in your HTML and when using `@apply`.
 
 [Learn more about Tailwind CSS support in JetBrains IDEs &rarr;](https://www.jetbrains.com/help/webstorm/tailwind-css.html)
+
+## Automatic Class Sorting with Prettier
+
+We recommend using the [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) for [Prettier](https://prettier.io/) that scans your templates for class attributes containing Tailwind CSS classes, and then sorts those classes automatically following our [recommended class order](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted).
+
+It works seamlessly with custom Tailwind configurations, and because it’s just a Prettier plugin, it works anywhere Prettier works — including every popular editor and IDE, and of course on the command line.
+
+```html
+<!-- Before -->
+<button class="text-white px-4 sm:px-8 py-2 sm:py-3 bg-sky-700 hover:bg-sky-800">...</button>
+
+<!-- After -->
+<button class="bg-sky-700 px-4 py-2 text-white hover:bg-sky-800 sm:px-8 sm:py-3">...</button>
+```
+
+Check out the plugin [on GitHub](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) or read our [blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) to get started.


### PR DESCRIPTION
Added a section about the prettier-plugin-tailwindcss to the editor-setup page. Focused on keeping it short & concise and link to the repo and blog post for more details and instructions.

The reasoning behind adding this to the docs is based on the discussion here on Twitter: https://twitter.com/t3dotgg/status/1575334522056372225