### PR TITLE
Add arbitrary-variants section in arbitrary-values

### DIFF
--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -4,6 +4,7 @@ description: Best practices for adding your own custom styles to Tailwind.
 ---
 
 import { TipGood, TipBad, TipCompat, TipInfo } from '@/components/Tip'
+import { SnippetGroup } from '@/components/SnippetGroup'
 
 Often the biggest challenge when working with a framework is figuring out what you're supposed to do when there's something you need that the framework doesn't handle for you.
 
@@ -118,11 +119,34 @@ This can be useful for things like CSS variables as well, especially when they n
 
 ### Arbitrary variants
 
-In the same vein as arbitrary values, **arbitrary variants** allow you to write custom CSS selector modifiers, please refer to [arbitrary variants](/docs/hover-focus-and-other-states#using-arbitrary-variants).
+Arbitrary _variants_ are like arbitrary values but for doing on-the-fly selector modification, like you can with built-in pseudo-class variants like `hover:{utility}` or responsive variants `md:{utility}` but using square bracket notation directly in your HTML.
+
+<SnippetGroup>
+
+```html HTML
+<ul role="list">
+  {#each items as item}
+    <li class="**lg:[&:nth-child(3)]:hover:underline**">{item}</li>
+  {/each}
+</ul>
+```
+
+```css Generated CSS
+/* https://media.giphy.com/media/Sd3cd0SrUKZEyWmAlM/giphy.gif */
+@media (min-width: 1024px) {
+  .lg\:\[\&\:nth-child\(3\)\]\:hover\:underline:hover:nth-child(3) {
+    text-decoration-line: underline;
+  }
+}
+```
+
+</SnippetGroup>
+
+Learn more in the [arbitrary variants](/docs/hover-focus-and-other-states#using-arbitrary-variants) documentation.
 
 ### Handling whitespace
 
-When an arbitrary value or an arbitrary variant needs to contain a space, use an underscore (`_`) instead and Tailwind will automatically convert it to a space at build-time:
+When an arbitrary value needs to contain a space, use an underscore (`_`) instead and Tailwind will automatically convert it to a space at build-time:
 
 ```html
 <div class="grid **grid-cols-[1fr_500px_2fr]**">

--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -116,9 +116,13 @@ This can be useful for things like CSS variables as well, especially when they n
 </div>
 ```
 
+### Arbitrary variants
+
+In the same vein as arbitrary values, **arbitrary variants** allow you to write custom CSS selector modifiers, please refer to [arbitrary variants](/docs/hover-focus-and-other-states#using-arbitrary-variants).
+
 ### Handling whitespace
 
-When an arbitrary value needs to contain a space, use an underscore (`_`) instead and Tailwind will automatically convert it to a space at build-time:
+When an arbitrary value or an arbitrary variant needs to contain a space, use an underscore (`_`) instead and Tailwind will automatically convert it to a space at build-time:
 
 ```html
 <div class="grid **grid-cols-[1fr_500px_2fr]**">


### PR DESCRIPTION
When reading the section on `arbitrary variants` it is difficult to know that there are documents for `arbitrary variants`, which are very relevant. `arbitrary variants` are a little hidden, under a title that doesn't mention anything about CSS selectors, therefore this PR: Adds a link to the related content.

I added this right after `### Arbitrary properties` because it is almost as essential, and I added it before `### Handling whitespace` given that white space is a CSS selector and the order of question tends to be:
1. How do I add a custom selector?
2. How do I add the specific white space (descendant) selector?