### PR TITLE
Adjust SVG icons' stroke color for the dark theme

### DIFF
--- a/src/layouts/ShowcaseLayout.js
+++ b/src/layouts/ShowcaseLayout.js
@@ -154,7 +154,7 @@ export function ShowcaseLayout({ children, slug, meta }) {
                     </div>
                     <div className="absolute -inset-1 md:hidden" />
                     <svg
-                      className="md:hidden w-6 h-6 stroke-slate-900"
+                      className="md:hidden w-6 h-6 stroke-slate-900 dark:stroke-white"
                       fill="none"
                       aria-hidden="true"
                     >
@@ -182,7 +182,7 @@ export function ShowcaseLayout({ children, slug, meta }) {
                     </div>
                     <div className="absolute -inset-1 md:hidden" />
                     <svg
-                      className="md:hidden w-6 h-6 stroke-slate-900"
+                      className="md:hidden w-6 h-6 stroke-slate-900 dark:stroke-white"
                       fill="none"
                       aria-hidden="true"
                     >


### PR DESCRIPTION
The SVG icons blend with the background color when the theme is dark, as shown in the image below. To avoid this, I added `dark:stroke-white` class for those two SVG icons.
![image](https://user-images.githubusercontent.com/75494437/194761522-0d35f4f2-0710-4e1f-a93c-4f1f7b2b6be3.png)

## Why `dark:stroke-white`?
As you can see from `ShowcaseLayout.js`, the title's `div` wrapper contains `text-slate-900 dark:text-white` classes. So, I assume that, in this case, `white` might be the best-suited dark theme variant of `slate-900`.
