### PR TITLE
Add Nuxt Tailwind shortcut to Nuxt.js framework guide

### DIFF
--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -172,6 +172,14 @@ export default function UsingNuxtJS({ code }) {
       title="Install Tailwind CSS with Nuxt.js"
       description="Setting up Tailwind CSS in a Nuxt.js project."
     >
+      <div className="relative z-10 max-w-3xl mb-16 prose prose-slate dark:prose-dark">
+        <p>
+          The quickest way to start using Tailwind CSS in your Nuxt.js project is to use{' '}
+          <a href="https://tailwindcss.nuxtjs.org/">Nuxt Tailwind</a>. This will automatically
+          configure your Tailwind setup. If you'd like to configure Tailwind manually, continue with
+          the rest of this guide.
+        </p>
+      </div>
       <Steps steps={steps} code={code} />
     </FrameworkGuideLayout>
   )

--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -166,7 +166,7 @@ let steps = [
   },
 ]
 
-export default function UsingNextJS({ code }) {
+export default function UsingNuxtJS({ code }) {
   return (
     <FrameworkGuideLayout
       title="Install Tailwind CSS with Nuxt.js"
@@ -187,7 +187,7 @@ export function getStaticProps() {
   }
 }
 
-UsingNextJS.layoutProps = {
+UsingNuxtJS.layoutProps = {
   meta: {
     title: 'Install Tailwind CSS with Nuxt.js',
     section: 'Installation',


### PR DESCRIPTION
The Next.js framework guide introduces a quick way to set up Tailwind CSS so I thought it only fitting to add a similar quick way to the Nuxt.js framework guide as well.