### PR TITLE
Add `app` directory to content for Next.js

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -45,6 +45,7 @@ let steps = [
       code: `  /** @type {import('tailwindcss').Config} */
   module.exports = {
 >   content: [
+>     "./app/**/*.{js,ts,jsx,tsx}",
 >     "./pages/**/*.{js,ts,jsx,tsx}",
 >     "./components/**/*.{js,ts,jsx,tsx}",
 >   ],


### PR DESCRIPTION
Ensures tailwind is compatible with https://nextjs.org/blog/layouts-rfc when it becomes available.
