### PR TITLE
[v3.2] Add `supports-[]` modifier documentation

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -838,6 +838,26 @@ Use the `portrait` and `landscape` modifiers to conditionally add styles when th
 </div>
 ```
 
+### Supports
+
+Use the `supports-[...]` modifier to style things based on whether a certain feature is supported in the user's browser.
+
+```html
+<div class="flex **supports-[display:grid]:grid** ...">
+  <!-- ... -->
+</div>
+```
+
+Under the hood the `supports-[...]` modifier generates [`@supports rules`](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) and takes anything you’d use with `@supports (...)` between the square brackets, like a property/value pair, and even expressions using `and` and `or`.
+
+For terseness, if you only need to check if a property is supported (and not a specific value), you can just specify the property name:
+
+```html
+<div class="bg-black/75 **supports-[backdrop-filter]:bg-black/25** **supports-[backdrop-filter]:backdrop-blur** ...">
+  <!-- ... -->
+</div>
+```
+
 ### Print styles
 
 Use the `print` modifier to conditionally add styles that only apply when the document is being printed:

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -838,6 +838,23 @@ Use the `portrait` and `landscape` modifiers to conditionally add styles when th
 </div>
 ```
 
+### Print styles
+
+Use the `print` modifier to conditionally add styles that only apply when the document is being printed:
+
+```html
+<div>
+  <article class="**print:hidden**">
+    <h1>My Secret Pizza Recipe</h1>
+    <p>This recipe is a secret, and must not be shared with anyone</p>
+    <!-- ... -->
+  </article>
+  <div class="hidden **print:block**">
+    Are you seriously trying to print this? It's secret!
+  </div>
+</div>
+```
+
 ### Supports
 
 Use the `supports-[...]` modifier to style things based on whether a certain feature is supported in the user's browser.
@@ -855,23 +872,6 @@ For terseness, if you only need to check if a property is supported (and not a s
 ```html
 <div class="bg-black/75 **supports-[backdrop-filter]:bg-black/25** **supports-[backdrop-filter]:backdrop-blur** ...">
   <!-- ... -->
-</div>
-```
-
-### Print styles
-
-Use the `print` modifier to conditionally add styles that only apply when the document is being printed:
-
-```html
-<div>
-  <article class="**print:hidden**">
-    <h1>My Secret Pizza Recipe</h1>
-    <p>This recipe is a secret, and must not be shared with anyone</p>
-    <!-- ... -->
-  </article>
-  <div class="hidden **print:block**">
-    Are you seriously trying to print this? It's secret!
-  </div>
 </div>
 ```
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1246,6 +1246,7 @@ A quick reference table of every single modifier included in Tailwind by default
 | <a href="#prefers-contrast" className="whitespace-nowrap">contrast-more</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media (prefers-contrast: more)</code> |
 | <a href="#prefers-contrast" className="whitespace-nowrap">contrast-less</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media (prefers-contrast: less)</code> |
 | <a href="#print-styles" className="whitespace-nowrap">print</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media print</code> |
+| <a href="#supports" className="whitespace-nowrap">supports-[<span className="text-slate-400">...</span>]</a> | <code className="whitespace-nowrap before:content-none after:content-none">@supports (<span className="text-slate-400">...</span>)</code> |
 | <a href="#rtl-support" className="whitespace-nowrap">rtl</a> | <code className="whitespace-nowrap before:content-none after:content-none">[dir="rtl"] <span className="text-slate-400">&</span></code> |
 | <a href="#rtl-support" className="whitespace-nowrap">ltr</a> | <code className="whitespace-nowrap before:content-none after:content-none">[dir="ltr"] <span className="text-slate-400">&</span></code> |
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -672,7 +672,7 @@ If you're using native `<dialog>` elements in your project, you may also want to
 
 ---
 
-## Media queries
+## Media and feature queries
 
 ### Responsive breakpoints
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -855,7 +855,7 @@ Use the `print` modifier to conditionally add styles that only apply when the do
 </div>
 ```
 
-### Supports
+### Supports rules
 
 Use the `supports-[...]` modifier to style things based on whether a certain feature is supported in the user's browser.
 


### PR DESCRIPTION
This PR adds a new "Supports rules" section to the "Handling Hover, Focus, and Other States" page for the new `supports-[]` modifier coming in Tailwind CSS v3.2.

I added it to the end of the "Media queries" section, and renamed this section to "Media and feature queries".

I also added `supports-[…]` to the "Quick reference" section.