### PR TITLE
[v3.2] Add `data-*` modifier documentation

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1286,6 +1286,7 @@ A quick reference table of every single modifier included in Tailwind by default
 | <a href="#prefers-contrast" className="whitespace-nowrap">contrast-less</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media (prefers-contrast: less)</code> |
 | <a href="#print-styles" className="whitespace-nowrap">print</a> | <code className="whitespace-nowrap before:content-none after:content-none">@media print</code> |
 | <a href="#supports" className="whitespace-nowrap">supports-[<span className="text-slate-400">...</span>]</a> | <code className="whitespace-nowrap before:content-none after:content-none">@supports (<span className="text-slate-400">...</span>)</code> |
+| <a href="#data-attributes" className="whitespace-nowrap">data-[<span className="text-slate-400">...</span>]</a> | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-slate-400">&</span>[data-<span className="text-slate-400">...</span>]</code> |
 | <a href="#rtl-support" className="whitespace-nowrap">rtl</a> | <code className="whitespace-nowrap before:content-none after:content-none">[dir="rtl"] <span className="text-slate-400">&</span></code> |
 | <a href="#rtl-support" className="whitespace-nowrap">ltr</a> | <code className="whitespace-nowrap before:content-none after:content-none">[dir="ltr"] <span className="text-slate-400">&</span></code> |
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -957,8 +957,7 @@ module.exports = {
       checked: 'ui~="checked"',
     },
   },
-  // ...
-};
+}
 ```
 
 You can then use these custom `data-*` modifiers in your project:

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -304,7 +304,7 @@ Style form elements in different states using modifiers like `required`, `invali
 <form>
   <label class="block">
     <span class="block text-sm font-medium text-slate-700">Username</span>
-    <!-- Using form state modifers, the classes can be identical for every input -->
+    <!-- Using form state modifiers, the classes can be identical for every input -->
     <input type="text" value="tbone" disabled class="mt-1 block w-full px-3 py-2 bg-white border border-slate-300 rounded-md text-sm shadow-sm placeholder-slate-400
       focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500
       **disabled:bg-slate-50** **disabled:text-slate-500** **disabled:border-slate-200** **disabled:shadow-none**
@@ -878,6 +878,45 @@ For terseness, if you only need to check if a property is supported (and not a s
 ---
 
 ## Attribute selectors
+
+### Data attributes
+
+Use the `data-*` modifier to conditionally apply styles based on [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).
+
+Since there are no standard `data-*` attributes by definition, by default we only support arbitrary values out of the box, for example:
+
+```html
+<!-- Will apply -->
+<div data-size="large" class="**data-[size=large]:p-8**">
+  <!-- ... -->
+</div>
+
+<!-- Will not apply -->
+<div data-size="medium" class="**data-[size=large]:p-8**">
+  <!-- ... -->
+</div>
+```
+
+You can configure shortcuts for common data attribute selectors you're using in your project in the `theme.data` section of your `tailwind.config.js` file:
+
+```js tailwind.config.js
+module.exports = {
+  theme: {
+    data: {
+      checked: 'ui~="checked"',
+    },
+  },
+  // ...
+};
+```
+
+You can then use these custom `data-*` modifiers in your project:
+
+```html
+<div data-ui="checked active" class="**data-checked:underline**">
+  <!-- ... -->
+</div>
+```
 
 ### RTL support
 


### PR DESCRIPTION
This PR adds a new "Data attributes" section to the "Handling Hover, Focus, and Other States" page for the new `data-[]` modifier coming in Tailwind CSS v3.2.

I added it to the "Attribute selectors" section. It should come after the new ARIA modifiers (#1391).

I also added it to the "Quick reference" section.