### PR TITLE
Add a step in Next.js setup guide

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -70,6 +70,27 @@ let steps = [
     },
   },
   {
+    title: 'Import the CSS to your project',
+    body: () => (
+      <p>
+        Make sure that <code>globals.css</code> is imported in <code>_app.js</code>
+      </p>
+    ),
+    code: {
+      name: '_app.js',
+      lang: 'jsx',
+      code: `>   import '../styles/globals.css'
+
+    function MyApp({ Component, pageProps }) {
+      return <Component {...pageProps} />
+    }
+
+    export default MyApp
+
+`,
+    },
+  },
+  {
     title: 'Start your build process',
     body: () => (
       <p>

--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -85,9 +85,7 @@ let steps = [
       return <Component {...pageProps} />
     }
 
-    export default MyApp
-
-`,
+    export default MyApp`,
     },
   },
   {


### PR DESCRIPTION
Sometimes, there is a possibility that one can forget to import the `globals.css` file into `_app.js`, especially if they removed the default CSS files while set-up. This PR adds a step to import the CSS file into `_app.js`.

Page in question: https://tailwindcss.com/docs/guides/nextjs

Preview after changes:
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/66675022/196226355-f31693c6-101e-4359-84ca-676bfbad1829.png">
