### PR TITLE
[v3.2] Add `break-keep` documentation

### DIFF
--- a/src/pages/docs/word-break.mdx
+++ b/src/pages/docs/word-break.mdx
@@ -65,6 +65,24 @@ Use `break-all` to add line breaks whenever necessary, without trying to preserv
 <p class="**break-all** ...">...</p>
 ```
 
+### Break Keep
+
+Use `break-keep` to prevent word breaks for Chinese, Japanese and Korean (CJK) text. For non-CJK text the behavior is exactly the same as `break-normal`.
+
+<Example p="none">
+  <div class="px-4">
+    <div class="mx-auto max-w-sm bg-white shadow-xl p-8 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+      <p class="break-keep">The longest word in any of the major English language dictionaries is
+      <span class="text-slate-900 font-medium dark:text-slate-200">這是為了演示而從英文轉換為中文的文本,</span>
+      a word that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it is the same as silicosis.</p>
+    </div>
+  </div>
+</Example>
+
+```html
+<p class="**break-keep** ...">...</p>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>


### PR DESCRIPTION
This PR adds docs for the new `break-keep` utility coming to Tailwind CSS v3.2.