### PR TITLE
[v3.2] Add `collapse` documentation

### DIFF
--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -31,26 +31,6 @@ Use `invisible` to hide an element, but still maintain its place in the DOM, aff
 </div>
 ```
 
-### Making elements visible
-
-Use `visible` to make an element visible. This is mostly useful for undoing the `invisible` utility at different screen sizes.
-
-<Example>
-  <div class="grid grid-cols-3 gap-4 font-mono text-white text-sm font-bold leading-6">
-    <div class="p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">01</div>
-    <div class="visible p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">02</div>
-    <div class="p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">03</div>
-  </div>
-</Example>
-
-```html
-<div class="grid grid-cols-3 gap-4">
-  <div>01</div>
-  <div class="**visible** ...">02</div>
-  <div>03</div>
-</div>
-```
-
 ### Making table elements invisible
 
 Use `collapse` to hide table rows, row groups, columns, and column groups without impacting the size of other rows and columns.
@@ -75,6 +55,26 @@ For other elements, `collapse` behaves exactly the same as `hidden`.
     <td>03</td>
   <tr>
 </table>
+```
+
+### Making elements visible
+
+Use `visible` to make an element visible. This is mostly useful for undoing the `invisible` utility at different screen sizes.
+
+<Example>
+  <div class="grid grid-cols-3 gap-4 font-mono text-white text-sm font-bold leading-6">
+    <div class="p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">01</div>
+    <div class="visible p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">02</div>
+    <div class="p-4 flex items-center justify-center bg-fuchsia-500 shadow-lg rounded-lg">03</div>
+  </div>
+</Example>
+
+```html
+<div class="grid grid-cols-3 gap-4">
+  <div>01</div>
+  <div class="**visible** ...">02</div>
+  <div>03</div>
+</div>
 ```
 
 ---

--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -31,29 +31,124 @@ Use `invisible` to hide an element, but still maintain its place in the DOM, aff
 </div>
 ```
 
-### Making table elements invisible
+### Collapsing table rows and columns
 
-Use `collapse` to hide table rows, row groups, columns, and column groups without impacting the size of other rows and columns.
+Use `collapse` to hide table rows, row groups, columns, and column groups as if they were set to `display: none`, but without impacting the size of other rows and columns.
 
-For other elements, `collapse` behaves exactly the same as `hidden`.
+This makes it possible to dynamically toggle rows and columns without affecting the table layout.
 
-<Example>
-  <table class="w-full">
-    <tr class="font-mono text-white text-sm font-bold leading-6 text-center">
-      <td class="p-4 bg-blue-500 shadow-lg rounded-lg">01</td>
-      <td class="collapse p-4 bg-blue-500 shadow-lg rounded-lg">02</td>
-      <td class="p-4 bg-blue-500 shadow-lg rounded-lg">03</td>
-    </tr>
-  </table>
+<Example p="none">
+  <div class="py-8">
+    <div class="mb-3 pl-4 text-sm font-medium text-slate-500 dark:text-slate-400">Showing all rows</div>
+    <table class="border-collapse w-full border-y border-slate-400 dark:border-slate-500 bg-white dark:bg-slate-800 text-sm shadow-sm">
+      <thead class="bg-slate-50 dark:bg-slate-700">
+        <tr>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Invoice #</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Client</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#100</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Pendant Publishing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$2,000.00</td>
+        </tr>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#101</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Kruger Industrial Smoothing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$545.00</td>
+        </tr>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#102</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">J. Peterman</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$10,000.25</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="mt-10 mb-3 pl-4 text-sm font-medium text-slate-500 dark:text-slate-400">Hiding a row using <code class="text-xs text-slate-700 dark:text-slate-300">`collapse`</code></div>
+    <table class="border-collapse w-full border-y border-slate-400 dark:border-slate-500 bg-white dark:bg-slate-800 text-sm shadow-sm">
+      <thead class="bg-slate-50 dark:bg-slate-700">
+        <tr>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Invoice #</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Client</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#100</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Pendant Publishing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$2,000.00</td>
+        </tr>
+        <tr class="collapse">
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#101</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Kruger Industrial Smoothing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$545.00</td>
+        </tr>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#102</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">J. Peterman</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$10,000.25</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="mt-10 mb-3 pl-4 text-sm font-medium text-slate-500 dark:text-slate-400">Hiding a row using <code class="text-xs text-slate-700 dark:text-slate-300">`hidden`</code></div>
+    <table class="border-collapse w-full border-y border-slate-400 dark:border-slate-500 bg-white dark:bg-slate-800 text-sm shadow-sm">
+      <thead class="bg-slate-50 dark:bg-slate-700">
+        <tr>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Invoice #</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Client</th>
+          <th class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-600 font-semibold px-4 py-3 text-slate-900 dark:text-slate-200 text-left">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#100</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Pendant Publishing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$2,000.00</td>
+        </tr>
+        <tr class="hidden">
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#101</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">Kruger Industrial Smoothing</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$545.00</td>
+        </tr>
+        <tr>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">#102</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">J. Peterman</td>
+          <td class="border first:border-l-0 last:border-r-0 border-slate-300 dark:border-slate-700 px-4 py-3 text-slate-500 dark:text-slate-400">$10,000.25</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </Example>
 
 ```html
-<table class="w-full">
-  <tr>
-    <td>01</td>
-    <td class="**collapse** ...">02</td>
-    <td>03</td>
-  <tr>
+<table>
+  <thead>
+    <tr>
+      <th>Invoice #</th>
+      <th>Client</th>
+      <th>Amount</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>#100</td>
+      <td>Pendant Publishing</td>
+      <td>$2,000.00</td>
+    </tr>
+    <tr class="**collapse**">
+      <td>#101</td>
+      <td>Kruger Industrial Smoothing</td>
+      <td>$545.00</td>
+    </tr>
+    <tr>
+      <td>#102</td>
+      <td>J. Peterman</td>
+      <td>$10,000.25</td>
+    </tr>
+  </tbody>
 </table>
 ```
 

--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -51,6 +51,32 @@ Use `visible` to make an element visible. This is mostly useful for undoing the 
 </div>
 ```
 
+### Making table elements invisible
+
+Use `collapse` to hide table rows, row groups, columns, and column groups without impacting the size of other rows and columns.
+
+For other elements, `collapse` behaves exactly the same as `hidden`.
+
+<Example>
+  <table class="w-full">
+    <tr class="font-mono text-white text-sm font-bold leading-6 text-center">
+      <td class="p-4 bg-fuchsia-500 shadow-lg rounded-lg">01</td>
+      <td class="collapse p-4 bg-fuchsia-500 shadow-lg rounded-lg">02</td>
+      <td class="p-4 bg-fuchsia-500 shadow-lg rounded-lg">03</td>
+    </tr>
+  </table>
+</Example>
+
+```html
+<table class="w-full">
+  <tr>
+    <td>01</td>
+    <td class="**collapse** ...">02</td>
+    <td>03</td>
+  <tr>
+</table>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>

--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -31,7 +31,7 @@ Use `invisible` to hide an element, but still maintain its place in the DOM, aff
 </div>
 ```
 
-### Collapsing table rows and columns
+### Collapsing elements
 
 Use `collapse` to hide table rows, row groups, columns, and column groups as if they were set to `display: none`, but without impacting the size of other rows and columns.
 

--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -40,9 +40,9 @@ For other elements, `collapse` behaves exactly the same as `hidden`.
 <Example>
   <table class="w-full">
     <tr class="font-mono text-white text-sm font-bold leading-6 text-center">
-      <td class="p-4 bg-fuchsia-500 shadow-lg rounded-lg">01</td>
-      <td class="collapse p-4 bg-fuchsia-500 shadow-lg rounded-lg">02</td>
-      <td class="p-4 bg-fuchsia-500 shadow-lg rounded-lg">03</td>
+      <td class="p-4 bg-blue-500 shadow-lg rounded-lg">01</td>
+      <td class="collapse p-4 bg-blue-500 shadow-lg rounded-lg">02</td>
+      <td class="p-4 bg-blue-500 shadow-lg rounded-lg">03</td>
     </tr>
   </table>
 </Example>


### PR DESCRIPTION
This PR adds docs for the new `collapse` utility coming to Tailwind CSS v3.2.