### PR TITLE
[v3.2] Add `@config` documentation

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -4,6 +4,7 @@ description: A guide to configuring and customizing your Tailwind installation.
 ---
 
 import { CorePluginReference } from '@/components/CorePluginReference'
+import { SnippetGroup } from '@/components/SnippetGroup'
 
 Because Tailwind is a framework for building bespoke user interfaces, it has been designed from the ground up with customization in mind.
 
@@ -453,6 +454,36 @@ module.exports = {
 Here's a list of every core plugin for reference:
 
 <CorePluginReference />
+
+---
+
+## Using multiple configurations
+
+Sometimes projects require multiple Tailwind config files and CSS entry points. For example, a project that has both a public website and admin control panel that each have their own Tailwind config and CSS.
+
+In these situations, the `@config` directive is useful, as it allows you to specify which config file Tailwind should use for each CSS entry point.
+
+<SnippetGroup>
+
+```css site.css
+@config "./tailwind.site.config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+```css admin.css
+@config "./tailwind.admin.config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+</SnippetGroup>
+
+Learn more about the `@config` directive in the [Functions & Directives](/docs/functions-and-directives#config) documentation.
 
 ---
 

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -89,6 +89,18 @@ module.exports = {
 }
 ```
 
+Alternatively, you can specify your custom configuration path using the `@config` directive:
+
+```css site.css
+@config "./tailwindcss-config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+Learn more about the `@config` directive in the [Functions & Directives](/docs/functions-and-directives#config) documentation.
+
 ### Generating a PostCSS configuration file
 
 Use the `-p` flag if you'd like to also generate a basic `postcss.config.js` file alongside your `tailwind.config.js` file:

--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -92,7 +92,7 @@ module.exports = {
 
 Alternatively, you can specify your custom configuration path using the `@config` directive:
 
-```css site.css
+```css
 @config "./tailwindcss-config.js";
 
 @tailwind base;
@@ -459,9 +459,7 @@ Here's a list of every core plugin for reference:
 
 ## Using multiple configurations
 
-Sometimes projects require multiple Tailwind config files and CSS entry points. For example, a project that has both a public website and admin control panel that each have their own Tailwind config and CSS.
-
-In these situations, the `@config` directive is useful, as it allows you to specify which config file Tailwind should use for each CSS entry point.
+For projects that need to generate multiple CSS files using different Tailwind configurations, use the `@config` directive to specify which config file should be used for each CSS entry point:
 
 <SnippetGroup>
 

--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -4,6 +4,7 @@ description: A reference for the custom functions and directives Tailwind expose
 ---
 
 import { TipGood, TipBad } from '@/components/Tip'
+import { SnippetGroup } from '@/components/SnippetGroup'
 
 ## Directives
 
@@ -213,6 +214,32 @@ module.exports = {
 This way any file processed by Tailwind that uses this config file will have access to those styles.
 
 Honestly though the best solution is to just not do weird stuff like this at all. Use Tailwind's utilities directly in your markup the way they are intended to be used, and don't abuse the `@apply` feature to do things like this and you will have a much better experience.
+
+### @config
+
+Use the `@config` directive to specify which config file Tailwind should use for that CSS file. This is useful for projects that have multiple Tailwind config files for different CSS entry points.
+
+<SnippetGroup>
+
+```css site.css
+@config "./tailwind.site.config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+```css admin.css
+@config "./tailwind.admin.config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+</SnippetGroup>
+
+The path set using the `@config` directive is relative to the CSS file it's in, and will take precedence over a path defined in your PostCSS configuration or in the Tailwind CLI.
 
 ---
 

--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -217,7 +217,7 @@ Honestly though the best solution is to just not do weird stuff like this at all
 
 ### @config
 
-Use the `@config` directive to specify which config file Tailwind should use for that CSS file. This is useful for projects that have multiple Tailwind config files for different CSS entry points.
+Use the `@config` directive to specify which config file Tailwind should use when compiling CSS file. This is useful for projects that need to use different configuration files for different CSS entry points.
 
 <SnippetGroup>
 
@@ -239,7 +239,7 @@ Use the `@config` directive to specify which config file Tailwind should use for
 
 </SnippetGroup>
 
-The path set using the `@config` directive is relative to the CSS file it's in, and will take precedence over a path defined in your PostCSS configuration or in the Tailwind CLI.
+The path you provide to the `@config` directive is relative to that CSS file, and will take precedence over a path defined in your PostCSS configuration or in the Tailwind CLI.
 
 ---
 


### PR DESCRIPTION
This PR adds documentation for the new `@config` directive to the "Functions & Directives" and "Configuration" pages.