### PR TITLE
[v3.2] Document `supports-foo` configuration

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1077,6 +1077,26 @@ For terseness, if you only need to check if a property is supported (and not a s
 </div>
 ```
 
+You can configure shortcuts for common supports rules you're using in your project in the `theme.supports` section of your `tailwind.config.js` file:
+
+```js tailwind.config.js
+module.exports = {
+  theme: {
+    supports: {
+      grid: 'display: grid',
+    },
+  },
+}
+```
+
+You can then use these custom `supports-*` modifiers in your project:
+
+```html
+<div class="**supports-grid:grid**">
+  <!-- ... -->
+</div>
+```
+
 ---
 
 ## Attribute selectors

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1077,7 +1077,7 @@ For terseness, if you only need to check if a property is supported (and not a s
 </div>
 ```
 
-You can configure shortcuts for common supports rules you're using in your project in the `theme.supports` section of your `tailwind.config.js` file:
+You can configure shortcuts for common `@supports` rules you're using in your project in the `theme.supports` section of your `tailwind.config.js` file:
 
 ```js tailwind.config.js
 module.exports = {


### PR DESCRIPTION
This PR adds documentation for the `supports-foo` case where `foo` is coming from your
`tailwind.config.js` file.


Saved you a few clicks: https://tailwindcss-com-git-feat-document-supports-config-tailwindlabs.vercel.app/docs/hover-focus-and-other-states#supports-rules