### PR TITLE
added commas in RGB colors

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -345,8 +345,8 @@ If you'd like to define your colors as CSS variables, you'll need to define thos
 
   @layer base {
     :root {
->     --color-primary: 255 115 179;
->     --color-secondary: 111 114 185;
+>     --color-primary: 255, 115, 179;
+>     --color-secondary: 111, 114, 185;
       /* ... */
     }
   }
@@ -361,8 +361,8 @@ If you'd like to define your colors as CSS variables, you'll need to define thos
 
   @layer base {
     :root {
->     --color-primary: rgb(255 115 179);
->     --color-secondary: rgb(111 114 185);
+>     --color-primary: rgb(255, 115, 179);
+>     --color-secondary: rgb(111, 114, 185);
       /* ... */
     }
   }
@@ -399,8 +399,8 @@ When defining your colors this way, make sure that the format of your CSS variab
 
 @layer base {
   :root {
-    /* For rgb(255 115 179 / <alpha-value>) */
-    --color-primary: 255 115 179;
+    /* For rgb(255, 115, 179 / <alpha-value>) */
+    --color-primary: 255, 115, 179;
 
     /* For hsl(198deg 93% 60% / <alpha-value>) */
     --color-primary: 198deg 93% 60%;


### PR DESCRIPTION
RGB color codes are not effective without commas,
I added these commas to avoid any further confusion