### PR TITLE
Doc page for forms plugin added

### DIFF
--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -221,10 +221,7 @@ export const documentationNav = {
   Accessibility: [pages['screen-readers']],
   'Official Plugins': [
     pages['typography-plugin'],
-    {
-      title: 'Forms',
-      href: 'https://github.com/tailwindlabs/tailwindcss-forms',
-    },
+    pages['forms-plugin'],
     {
       title: 'Aspect Ratio',
       href: 'https://github.com/tailwindlabs/tailwindcss-aspect-ratio',

--- a/src/pages/docs/forms-plugin.mdx
+++ b/src/pages/docs/forms-plugin.mdx
@@ -1,0 +1,127 @@
+---
+title: '@tailwindcss/forms'
+shortTitle: Forms
+description: A plugin that provides a basic reset for form styles that makes form elements easy to override with utilities.
+repo: https://github.com/tailwindlabs/tailwindcss-forms
+---
+
+import { TipGood, TipBad, TipInfo } from '@/components/Tip'
+
+## Installation
+
+Install the plugin from npm:
+
+```shell
+npm install -D @tailwindcss/forms
+```
+
+Then add the plugin to your `tailwind.config.js` file:
+
+```js tailwind.config.js
+module.exports = {
+  theme: {
+    // ...
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    // ...
+  ],
+}
+```
+
+To see what it looks like in action, check out our [live demo](https://play.tailwindcss.com/j1aeoqNL8f?layout=preview) on Tailwind Play.
+
+---
+
+## Basic usage
+
+All of the basic form elements you use will now have some simple default styles that are easy to override with utilities.
+
+Currently we add basic utility-friendly form styles for the following form element types:
+
+- `input[type='text']`
+- `input[type='password']`
+- `input[type='email']`
+- `input[type='number']`
+- `input[type='url']`
+- `input[type='date']`
+- `input[type='datetime-local']`
+- `input[type='month']`
+- `input[type='week']`
+- `input[type='time']`
+- `input[type='search']`
+- `input[type='tel']`
+- `input[type='checkbox']`
+- `input[type='radio']`
+- `select`
+- `select[multiple]`
+- `textarea`
+
+**Note that for text inputs, you must add the `type="text"` attribute for these styles to take effect.** This is a necessary trade-off to avoid relying on the overly greedy `input` selector and unintentionally styling elements we don't have solutions for yet, like `input[type="range"]` for example.
+
+Every element has been normalized/reset to a simple visually consistent style that is easy to customize with utilities, even elements like `<select>` or `<input type="checkbox">` that normally need to be reset with `appearance: none` and customized using custom CSS:
+
+```html
+<!-- You can actually customize padding on a select element now: -->
+<select class="px-4 py-3 rounded-full">
+  <!-- ... -->
+</select>
+
+<!-- Or change a checkbox color using text color utilities: -->
+<input type="checkbox" class="rounded text-pink-500" />
+```
+
+### Using classes to style
+
+In addition to the global styles, we also generate a set of corresponding classes which can be used to explicitly apply the form styles to an element. This can be useful in situations where you need to make a non-form element, such as a `<div>`, look like a form element.
+
+```html
+<input type="email" class="form-input px-4 py-3 rounded-full">
+
+<select class="form-select px-4 py-3 rounded-full">
+  <!-- ... -->
+</select>
+
+<input type="checkbox" class="form-checkbox rounded text-pink-500" />
+```
+
+Here is a complete table of the provided `form-*` classes for reference:
+
+| Base                      | Class            |
+| ------------------------- | ---------------- |
+| `[type='text']`           | form-input       |
+| `[type='email']`          | form-input       |
+| `[type='url']`            | form-input       |
+| `[type='password']`       | form-input       |
+| `[type='number']`         | form-input       |
+| `[type='date']`           | form-input       |
+| `[type='datetime-local']` | form-input       |
+| `[type='month']`          | form-input       |
+| `[type='search']`         | form-input       |
+| `[type='tel']`            | form-input       |
+| `[type='time']`           | form-input       |
+| `[type='week']`           | form-input       |
+| `textarea`                | form-textarea    |
+| `select`                  | form-select      |
+| `select[multiple]`        | form-multiselect |
+| `[type='checkbox']`       | form-checkbox    |
+| `[type='radio']`          | form-radio       |
+
+### Using only global styles or only classes
+
+Although we recommend thinking of this plugin as a "form reset" rather than a collection of form component styles, in some cases our default approach may be too heavy-handed, especially when integrating this plugin into existing projects.
+
+If generating both the global (base) styles and classes doesn't work well with your project, you can use the `strategy` option to limit the plugin to just one of these approaches.
+
+```js tailwind.config.js
+plugins: [
+  require("@tailwindcss/forms")({
+    strategy: 'base', // only generate global styles
+    strategy: 'class', // only generate classes
+  }),
+],
+```
+
+When using the `base` strategy, form elements are styled globally, and no `form-{name}` classes are generated.
+
+When using the `class` strategy, form elements are not styled globally, and instead must be styled using the generated `form-{name}` classes.

--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -94,7 +94,7 @@ The `@tailwindcss/forms` plugin adds an opinionated form reset layer that makes 
 <input type="checkbox" class="rounded text-pink-500" />
 ```
 
-[Learn more about the forms plugin &rarr;](https://github.com/tailwindlabs/tailwindcss-forms)
+[Learn more about the forms plugin &rarr;](/docs/forms-plugin)
 
 ### Line-clamp
 


### PR DESCRIPTION
I like how Typography plugin has its own page in docs, so I created one for Forms. It's my first contribution to docs, so feel free to point out any issues with this pull request.

Also, page on TailwindPlay is part of this (but logo is not SVG as with Typography demo page) - https://play.tailwindcss.com/j1aeoqNL8f?layout=preview

