### PR TITLE
Fix 404 Editor Tools image

### DIFF
--- a/src/components/home/EditorTools.js
+++ b/src/components/home/EditorTools.js
@@ -336,7 +336,7 @@ export function EditorTools() {
           <div className="relative">
             <img
               decoding="async"
-              src={require('@/img/beams/overlay.webp').default}
+              src={require('@/img/beams/overlay.webp').default.src}
               alt=""
               className="absolute z-10 bottom-0 -left-80 w-[45.0625rem] pointer-events-none dark:hidden"
             />


### PR DESCRIPTION
Fixes a 404 error for an image on the homepage:
![image](https://user-images.githubusercontent.com/11310624/200434089-da6a23dc-fd10-4cb0-b35f-f5fe9c32e7a6.png)

## Before:
![image](https://user-images.githubusercontent.com/11310624/200434220-0f155767-dd0f-4be1-b35f-5a86a7fa21df.png)

## After:
![image](https://user-images.githubusercontent.com/11310624/200434201-0b214dce-2f9d-4412-85a2-3b7900a8bac3.png)

---

Perhaps we could also consider adding `loading="lazy"` so the image is not requested at all in dark mode (since it has `dark:hidden` on it anyway)?