### PR TITLE
Fix illegible guide tab bar code text in dark mode

### DIFF
--- a/src/components/Guides/TabBar.jsx
+++ b/src/components/Guides/TabBar.jsx
@@ -21,7 +21,7 @@ export function TabBar({ tabs, selectedTabIndex }) {
                       'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b-2 -mb-px',
                       tabIndex === selectedTabIndex
                         ? 'text-sky-500 border-current [&_code]:bg-sky-50'
-                        : 'text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700 [&_code]:bg-slate-100'
+                        : 'text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700 [&_code]:bg-slate-100 dark:[&_code]:bg-slate-800'
                     )}
                   >
                     {tab.name}


### PR DESCRIPTION
Fixes illegible `<code>` tags in dark mode for inactive tabs used in the Framework Guides Installation section. Example, `/docs/guides/nextjs`:

### Before
![image](https://user-images.githubusercontent.com/11310624/202817422-d1f6bc75-80ec-4e7a-848a-9604f461f5dd.png)

### After
![image](https://user-images.githubusercontent.com/11310624/202817443-bafb1761-b46a-466f-81f1-e89777d37251.png)
