### PR TITLE
Mention `matchVariant()`

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -32,6 +32,7 @@ Plugin functions receive a single object argument that can be [destructured](htt
 - `matchComponents()`, for registering new dynamic component styles
 - `addBase()`, for registering new base styles
 - `addVariant()`, for registering custom variants
+- `matchVariant()`, for registering custom dynamic variants
 - `theme()`, for looking up values in the user's theme configuration
 - `config()`, for looking up values in the user's Tailwind configuration
 - `corePlugins()`, for checking if a core plugin is enabled


### PR DESCRIPTION
Mentions `matchVariant()` in the list of helper functions that are passed to plugins to try to keep the list current and exhaustive.
