### PR TITLE
Document new line-height modifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "seedrandom": "^3.0.5",
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
-        "tailwindcss": "^3.2.4",
+        "tailwindcss": "^0.0.0-insiders.ea10bb9",
         "tinytime": "^0.2.6",
         "unist-util-visit": "^2.0.3",
         "zustand": "^4.0.0-rc.0"
@@ -8769,9 +8769,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/postcss": {
-      "version": "8.4.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "0.0.0-insiders.ea10bb9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
+      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -10467,7 +10467,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.19",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
@@ -17785,9 +17785,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -19006,9 +19006,9 @@
       }
     },
     "tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "0.0.0-insiders.ea10bb9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
+      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -19024,7 +19024,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.19",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "seedrandom": "^3.0.5",
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
-    "tailwindcss": "^3.2.4",
+    "tailwindcss": "^0.0.0-insiders.ea10bb9",
     "tinytime": "^0.2.6",
     "unist-util-visit": "^2.0.3",
     "zustand": "^4.0.0-rc.0"

--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -59,6 +59,46 @@ Control the font size of an element using the `text-{size}` utilities.
 <p class="**text-2xl** ...">The quick brown fox ...</p>
 ```
 
+### Setting the line-height
+
+Set an element's line-height at the same time you set the font size by adding a line-height modifier to any font size utility. For example, use `text-xl/8` to set a font size of `1.25rem` with a line-height of `2rem`.
+
+<Example>
+  <div class="flex flex-col gap-8">
+    <div>
+      <span class="font-medium text-sm text-slate-500 font-mono mb-3 dark:text-slate-400">text-base/6</span>
+      <p class="text-base/6 text-slate-900 dark:text-slate-200">
+        So I started to walk into the water. I won't lie to you boys, I was terrified. But I pressed on, and as I made my way past the breakers a strange calm came over me. I don't know if it was divine intervention or the kinship of all living things but I tell you Jerry at that moment, I <em>was</em> a marine biologist.
+      </p>
+    </div>
+    <div>
+      <span class="font-medium text-sm text-slate-500 font-mono mb-3 dark:text-slate-400">text-base/7</span>
+      <p class="text-base/7 text-slate-900 dark:text-slate-200">
+        So I started to walk into the water. I won't lie to you boys, I was terrified. But I pressed on, and as I made my way past the breakers a strange calm came over me. I don't know if it was divine intervention or the kinship of all living things but I tell you Jerry at that moment, I <em>was</em> a marine biologist.
+      </p>
+    </div>
+    <div>
+      <span class="font-medium text-sm text-slate-500 font-mono mb-3 dark:text-slate-400">text-base/8</span>
+      <p class="text-base/8 text-slate-900 dark:text-slate-200">
+        So I started to walk into the water. I won't lie to you boys, I was terrified. But I pressed on, and as I made my way past the breakers a strange calm came over me. I don't know if it was divine intervention or the kinship of all living things but I tell you Jerry at that moment, I <em>was</em> a marine biologist.
+      </p>
+    </div>
+  </div>
+</Example>
+
+
+```html
+<p class="**text-base/6** ...">So I started to walk into the water...</p>
+<p class="**text-base/7** ...">So I started to walk into the water...</p>
+<p class="**text-base/8** ...">So I started to walk into the water...</p>
+```
+
+You can use any value defined in your [line-height scale](/docs/line-height), or use arbitrary values if you need to deviate from your design tokens.
+
+```html
+<p class="text-sm**/[17px]** ..."></p>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>


### PR DESCRIPTION
This PR adds documentation for the new line-height modifier for font-size utilities introduced in https://github.com/tailwindlabs/tailwindcss/pull/9875.