### PR TITLE
Add new optional app directory for module.exports

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -65,6 +65,7 @@ let tabs = [
   module.exports = {
 >   content: [
 >     "./pages/**/*.{js,ts,jsx,tsx}",
+>     "./app/**/*.{js,ts,jsx,tsx}",
 >     "./components/**/*.{js,ts,jsx,tsx}",
 >   ],
     theme: {


### PR DESCRIPTION
NextJS 13 released a new experimental feature: "app directory", where developers can put everything (pages, components...) inside `/app`.

Using the previous configuration, pages inside `/app` won't be picked up by tailwind, but with this pull request they will work with the new `/app` directory.

A potential change might be to instead of including both `/pages`, `/components` and `/app`, we could include one for when using the new `/app` directory and one for using the non-experimental `/pages` & `/components` directory.