### PR TITLE
Add Click-to-Copy to ClassTable classes 

### DIFF
--- a/src/components/ClassTable.js
+++ b/src/components/ClassTable.js
@@ -3,6 +3,7 @@ import { isObject } from '@/utils/isObject'
 import { castArray } from '@/utils/castArray'
 import clsx from 'clsx'
 import { Heading } from '@/components/Heading'
+import { CopyButton } from '@/components/CopyButton'
 
 function renderProperties(
   properties,
@@ -130,13 +131,17 @@ export const ClassTable = memo(
                         <td
                           translate="no"
                           className={clsx(
-                            'py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400',
+                            'py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400 align-middle',
                             {
                               'border-t border-slate-100 dark:border-slate-400/10': i !== 0,
                             }
                           )}
                         >
-                          {transformSelector(selector)}
+                          <div className="flex items-center -my-1">
+                            <CopyButton code={transformSelector(selector)} position="right" />
+                            &nbsp;
+                            {transformSelector(selector)}
+                          </div>
                         </td>
                         <td
                           translate="no"

--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -4,7 +4,7 @@ import redent from 'redent'
 import Alert from '@reach/alert'
 import { Transition } from '@headlessui/react'
 
-export function CopyButton({ code }) {
+export function CopyButton({ code, position = 'top' }) {
   let [{ state, i }, setState] = useState({ state: 'idle', i: 0 })
 
   useEffect(() => {
@@ -46,7 +46,11 @@ export function CopyButton({ code }) {
         </svg>
       </button>
       <Transition
-        className="absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2"
+        className={clsx({
+          absolute: true,
+          'translate-x-1/2 ml-2 mt-1': position === 'right',
+          'bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2': position === 'top',
+        })}
         show={state === 'copied'}
         enter="transform ease-out duration-200 transition origin-bottom"
         enterFrom="scale-95 translate-y-0.5 opacity-0"
@@ -57,20 +61,22 @@ export function CopyButton({ code }) {
       >
         <Alert className="relative bg-sky-500 text-white font-mono text-[0.625rem] leading-6 font-medium px-1.5 rounded-lg">
           Copied
-          <svg
-            aria-hidden="true"
-            width="16"
-            height="6"
-            viewBox="0 0 16 6"
-            className="text-sky-500 absolute top-full left-1/2 -mt-px -ml-2"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M15 0H1V1.00366V1.00366V1.00371H1.01672C2.72058 1.0147 4.24225 2.74704 5.42685 4.72928C6.42941 6.40691 9.57154 6.4069 10.5741 4.72926C11.7587 2.74703 13.2803 1.0147 14.9841 1.00371H15V0Z"
-              fill="currentColor"
-            />
-          </svg>
+          {position === 'top' ? (
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="6"
+              viewBox="0 0 16 6"
+              className="text-sky-500 absolute top-full left-1/2 -mt-px -ml-2"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M15 0H1V1.00366V1.00366V1.00371H1.01672C2.72058 1.0147 4.24225 2.74704 5.42685 4.72928C6.42941 6.40691 9.57154 6.4069 10.5741 4.72926C11.7587 2.74703 13.2803 1.0147 14.9841 1.00371H15V0Z"
+                fill="currentColor"
+              />
+            </svg>
+          ) : null}
         </Alert>
       </Transition>
     </div>

--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import redent from 'redent'
+import Alert from '@reach/alert'
+import { Transition } from '@headlessui/react'
+
+export function CopyButton({ code }) {
+  let [{ state, i }, setState] = useState({ state: 'idle', i: 0 })
+
+  useEffect(() => {
+    if (state === 'copied') {
+      let handle = window.setTimeout(() => {
+        setState({ state: 'idle', i: i + 1 })
+      }, 1500)
+      return () => {
+        window.clearTimeout(handle)
+      }
+    }
+  }, [state, i])
+
+  return (
+    <div className="relative flex -mr-2">
+      <button
+        type="button"
+        className={clsx({
+          'text-slate-500 hover:text-slate-400': state === 'idle',
+          'text-sky-400': state === 'copied',
+        })}
+        onClick={() => {
+          navigator.clipboard.writeText(redent(code.replace(/^[+>-]/gm, ' '))).then(() => {
+            setState({ state: 'copied', i: i + 1 })
+          })
+        }}
+      >
+        <svg
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className="w-8 h-8"
+        >
+          <path d="M13 10.75h-1.25a2 2 0 0 0-2 2v8.5a2 2 0 0 0 2 2h8.5a2 2 0 0 0 2-2v-8.5a2 2 0 0 0-2-2H19" />
+          <path d="M18 12.25h-4a1 1 0 0 1-1-1v-1.5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1.5a1 1 0 0 1-1 1ZM13.75 16.25h4.5M13.75 19.25h4.5" />
+        </svg>
+      </button>
+      <Transition
+        className="absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2"
+        show={state === 'copied'}
+        enter="transform ease-out duration-200 transition origin-bottom"
+        enterFrom="scale-95 translate-y-0.5 opacity-0"
+        enterTo="scale-100 translate-y-0 opacity-100"
+        leave="transition ease-in duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <Alert className="relative bg-sky-500 text-white font-mono text-[0.625rem] leading-6 font-medium px-1.5 rounded-lg">
+          Copied
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="6"
+            viewBox="0 0 16 6"
+            className="text-sky-500 absolute top-full left-1/2 -mt-px -ml-2"
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M15 0H1V1.00366V1.00366V1.00371H1.01672C2.72058 1.0147 4.24225 2.74704 5.42685 4.72928C6.42941 6.40691 9.57154 6.4069 10.5741 4.72926C11.7587 2.74703 13.2803 1.0147 14.9841 1.00371H15V0Z"
+              fill="currentColor"
+            />
+          </svg>
+        </Alert>
+      </Transition>
+    </div>
+  )
+}

--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import redent from 'redent'
 import Alert from '@reach/alert'

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -1,10 +1,7 @@
 import clsx from 'clsx'
-import { useEffect, useState } from 'react'
-import redent from 'redent'
-import Alert from '@reach/alert'
 import { SnippetGroup } from '@/components/SnippetGroup'
 import { Editor } from '@/components/Editor'
-import { Transition } from '@headlessui/react'
+import { CopyButton } from '@/components/CopyButton'
 
 export function Steps({ intro, steps, code, level = 2 }) {
   let StepHeading = `h${level}`
@@ -48,79 +45,6 @@ export function Steps({ intro, steps, code, level = 2 }) {
         ))}
       </ol>
     </>
-  )
-}
-
-function CopyButton({ code }) {
-  let [{ state, i }, setState] = useState({ state: 'idle', i: 0 })
-
-  useEffect(() => {
-    if (state === 'copied') {
-      let handle = window.setTimeout(() => {
-        setState({ state: 'idle', i: i + 1 })
-      }, 1500)
-      return () => {
-        window.clearTimeout(handle)
-      }
-    }
-  }, [state, i])
-
-  return (
-    <div className="relative flex -mr-2">
-      <button
-        type="button"
-        className={clsx({
-          'text-slate-500 hover:text-slate-400': state === 'idle',
-          'text-sky-400': state === 'copied',
-        })}
-        onClick={() => {
-          navigator.clipboard.writeText(redent(code.replace(/^[+>-]/gm, ' '))).then(() => {
-            setState({ state: 'copied', i: i + 1 })
-          })
-        }}
-      >
-        <svg
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-          className="w-8 h-8"
-        >
-          <path d="M13 10.75h-1.25a2 2 0 0 0-2 2v8.5a2 2 0 0 0 2 2h8.5a2 2 0 0 0 2-2v-8.5a2 2 0 0 0-2-2H19" />
-          <path d="M18 12.25h-4a1 1 0 0 1-1-1v-1.5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1.5a1 1 0 0 1-1 1ZM13.75 16.25h4.5M13.75 19.25h4.5" />
-        </svg>
-      </button>
-      <Transition
-        className="absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2"
-        show={state === 'copied'}
-        enter="transform ease-out duration-200 transition origin-bottom"
-        enterFrom="scale-95 translate-y-0.5 opacity-0"
-        enterTo="scale-100 translate-y-0 opacity-100"
-        leave="transition ease-in duration-100"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <Alert className="relative bg-sky-500 text-white font-mono text-[0.625rem] leading-6 font-medium px-1.5 rounded-lg">
-          Copied
-          <svg
-            aria-hidden="true"
-            width="16"
-            height="6"
-            viewBox="0 0 16 6"
-            className="text-sky-500 absolute top-full left-1/2 -mt-px -ml-2"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M15 0H1V1.00366V1.00366V1.00371H1.01672C2.72058 1.0147 4.24225 2.74704 5.42685 4.72928C6.42941 6.40691 9.57154 6.4069 10.5741 4.72926C11.7587 2.74703 13.2803 1.0147 14.9841 1.00371H15V0Z"
-              fill="currentColor"
-            />
-          </svg>
-        </Alert>
-      </Transition>
-    </div>
   )
 }
 


### PR DESCRIPTION
A common flow is to open the docs, see the class you're looking for, copy it, and paste it into your editor of choice. This usually means a triple-click to select the text (or single click + dragging your cursor), followed by a quick `Control/Command + C`. Yes it works, but it may also result in silent tears of inefficiency. 😢 

What if there was a 1-click solution to it all?! What if we could turn 3 clicks (or 1 click + drag) and a keyboard combo into a single click! 😱 💥 🔥 

This PR breaks `CopyButton` out into its own component (from `Steps.js`) and adds it to `ClassTable`, enabling our one-click copying dream! 😍 

An open question is if this should be implemented via the `CopyButton` or if adding a custom button + hover states to the classnames as a "click to copy" variation would be cleaner from a UX perspective. Happy to make any changes, just want to save as many clicks as possible. 🖱️ Thanks!  

<img width="541" alt="image" src="https://user-images.githubusercontent.com/3053339/203619540-ee840c70-706a-49ae-9574-d36c280ff608.png">
