### PR TITLE
Document `matchVariant()`

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -458,7 +458,7 @@ module.exports = {
     plugin(function({ addVariant }) {
       addVariant('optional', '&:optional')
       addVariant('hocus', ['&:hover', '&:focus'])
-      addVariant('supports-grid', '@supports (display: grid)')
+      addVariant('inverted-colors', '@media (inverted-colors: inverted)')
     })
   ]
 }
@@ -467,7 +467,7 @@ module.exports = {
 The first argument is the modifier name that users will use in their HTML, so the above example would make it possible to write classes like these:
 
 ```html
-<form class="flex **supports-grid:grid** ...">
+<form class="flex **inverted-colors:outline** ...">
   <input class="**optional:border-gray-300** ..." />
   <button class="bg-blue-500 **hocus:bg-blue-600**">...</button>
 </form>

--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -443,9 +443,11 @@ Since base styles are meant to target bare selectors like `div` or `h1`, they do
 
 ## Adding variants
 
-The `addVariant` function allows you to register your own custom [modifiers](/docs/hover-focus-and-other-states) that can be used just like the built-in hover, focus, active, etc. variants.
+The `addVariant` and `matchVariant` functions allow you to register your own custom [modifiers](/docs/hover-focus-and-other-states) that can be used just like the built-in hover, focus, supports, etc. variants.
 
-To add a new variant, call the `addVariant` function, passing in the name of your custom variant, and a format string that represents how the selector should be modified.
+### Static variants
+
+Use the `addVariant` function for simple custom variants, passing in the name of your custom variant, and a format string that represents how the selector should be modified.
 
 ```js tailwind.config.js
 const plugin = require('tailwindcss/plugin')

--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -473,6 +473,52 @@ The first argument is the modifier name that users will use in their HTML, so th
 </form>
 ```
 
+### Dynamic variants
+
+Use the `matchVariant` function to register new variants with a dynamic portion like the built-in supports, data attribute, aria attribute variants:
+
+```js tailwind.config.js
+const plugin = require('tailwindcss/plugin')
+
+module.exports = {
+  plugins: [
+    plugin(function({ matchVariant }) {
+      matchVariant(
+        'nth',
+        (value) => {
+          return `&:nth-child(${value})`;
+        },
+        {
+          values: {
+            1: '1',
+            2: '2',
+            3: '3',
+          }
+        }
+      );
+    })
+  ]
+}
+```
+
+The variant defined above would give you variants like `nth-1` an `nth-2` but would also support an arbitrary portion in square brackets:
+
+```html
+<div class="**nth-[3n+1]:bg-blue-500** ...">
+  <!-- ... -->
+</div>
+```
+
+When defining custom variants with this API, it’s often important that you have some control over which order the CSS is generated in to make sure each class has the right precedence with respect to other values that come from the same variant. To support this, there’s a sort function you can provide when defining your variant:
+
+```js
+matchVariant("min", (value) => `@media (min-width: ${value})`, {
+  sort(a, z) {
+    return parseInt(a) - parseInt(z);
+  },
+});
+```
+
 ### Parent and sibling states
 
 Your custom modifiers won't automatically work with Tailwind's [parent](/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [sibling](/docs/hover-focus-and-other-states#styling-based-on-sibling-state) state modifiers.

--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -31,7 +31,8 @@ Plugin functions receive a single object argument that can be [destructured](htt
 - `addComponents()`, for registering new static component styles
 - `matchComponents()`, for registering new dynamic component styles
 - `addBase()`, for registering new base styles
-- `addVariant()`, for registering custom variants
+- `addVariant()`, for registering custom static variants
+- `matchVariant()`, for registering custom dynamic variants
 - `theme()`, for looking up values in the user's theme configuration
 - `config()`, for looking up values in the user's Tailwind configuration
 - `corePlugins()`, for checking if a core plugin is enabled


### PR DESCRIPTION
Follow up to #1434 with more comprehensive documentation. Notes:

- In 757e04d, I took the liberty of changing mention of the *active* built-in variant to *supports*, so that this unexhaustive list mentions a dynamic variant.
- In 0ea182b, I thought it would be necessary to change the at-rule example since supports is now a built-in (I have noticed this used in other places too but I presume that would be something for another time). I instead used a "boolean" `@media` rule since this would be the most likely candidate for `addVariant()`, as `@media` rules with more than two values would be more of a candidate for `matchVariant()` instead.
-  In 41c8672:
    - I adapted the example of `matchVariant()` from the v3.2 release blog post, but attempted to use an example that had less context with it, to be more inline with the rest of the documentation style.
    - Lifted the sort function example straight from the v3.2 release blog post – do we need an example that is not from core perhaps?