### PR TITLE
Fixed spelling error in preflight.mdx

### DIFF
--- a/src/pages/docs/preflight.mdx
+++ b/src/pages/docs/preflight.mdx
@@ -70,7 +70,7 @@ h6 {
 
 The reason for this is two-fold:
 
-- **It helps you avoid accidentally deviating from your type scale**. By default, the browsers assigns sizes to headings that don't exist in Tailwind's default type scale, and aren't guaranteed to exist in your own type scale.
+- **It helps you avoid accidentally deviating from your type scale**. By default, browsers assign sizes to headings that don't exist in Tailwind's default type scale, and aren't guaranteed to exist in your own type scale.
 - **In UI development, headings should often be visually de-emphasized**. Making headings unstyled by default means any styling you apply to headings happens consciously and deliberately.
 
 You can always add default header styles to your project by [adding your own base styles](/docs/adding-base-styles).


### PR DESCRIPTION
It should either be "the browser assigns" or "browsers assign", but in the context of highlighting that different browsers might have different behaviors, it makes sense to talk about it in plural.