### PR TITLE
Fix bg image blocking tab nav

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -11,7 +11,7 @@ export function Steps({ intro, steps, code, level = 2 }) {
 
   return (
     <>
-      <div className="hidden sm:block absolute top-0 left-[15%] -z-10 pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
+      <div className="hidden sm:block absolute -z-10 top-0 left-[15%] pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
         <img
           src={require('@/img/beams/installation.jpg').default.src}
           alt=""

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -11,7 +11,7 @@ export function Steps({ intro, steps, code, level = 2 }) {
 
   return (
     <>
-      <div className="hidden sm:block absolute top-0 left-[15%] pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
+      <div className="hidden sm:block absolute top-0 left-[15%] -z-10 pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
         <img
           src={require('@/img/beams/installation.jpg').default.src}
           alt=""


### PR DESCRIPTION
The bg image in `<Steps>` is blocking clicks to `<TabBar>`.

This pulls the bg image element to `z-index: -10` to prevent click blocking.

<img width="1210" alt="Screenshot 2022-11-27 at 10 35 15 AM" src="https://user-images.githubusercontent.com/22138063/204149090-5399170b-87e3-4932-9098-247aaf130ff8.png">
