### PR TITLE
Update SvelteKit guide for 1.0

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -18,7 +18,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm init svelte@next my-app\ncd my-app',
+      code: 'npm init svelte@latest my-app\ncd my-app',
     },
   },
   {


### PR DESCRIPTION
We will soon be releasing SvelteKit 1.0. The `latest` tag will work now with the latest betas / RCs and will continue to work after 1.0. The `next` tag will only work until 1.0 is released