### PR TITLE
Update guide for appDir feature

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -66,6 +66,7 @@ let tabs = [
 >   content: [
 >     "./pages/**/*.{js,ts,jsx,tsx}",
 >     "./components/**/*.{js,ts,jsx,tsx}",
+>     "./app/**/*.{js,ts,jsx,tsx}",
 >   ],
     theme: {
       extend: {},


### PR DESCRIPTION
Following the instructions does not work if using NextJS's experimental `appDir` feature.