### PR TITLE
Fix: add single quotes to code example in font sizes

### DIFF
--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -86,10 +86,10 @@ You can configure your own custom set of font size utilities using the `theme.fo
 +       sm: '0.8rem',
 +       base: '1rem',
 +       xl: '1.25rem',
-+       2xl: '1.563rem',
-+       3xl: '1.953rem',
-+       4xl: '2.441rem',
-+       5xl: '3.052rem',
++       '2xl': '1.563rem',
++       '3xl': '1.953rem',
++       '4xl': '2.441rem',
++       '5xl': '3.052rem',
 +     }
     }
   }


### PR DESCRIPTION
Font sizes greater than `xl` require to be wrapped in single quotes