### PR TITLE
Add callout to potentially previous mix alias

### DIFF
--- a/src/pages/docs/guides/phoenix.js
+++ b/src/pages/docs/guides/phoenix.js
@@ -61,11 +61,9 @@ let steps = [
   {
     title: 'Update your deployment script',
     body: () => (
-      <div>
-        <p>
-          Configure your <code>assets.deploy</code> alias to build your CSS on deployment.
-        </p>
-      </div>
+      <p>
+        Configure your <code>assets.deploy</code> alias to build your CSS on deployment.
+      </p>
     ),
     code: {
       name: 'mix.exs',

--- a/src/pages/docs/guides/phoenix.js
+++ b/src/pages/docs/guides/phoenix.js
@@ -69,15 +69,14 @@ let steps = [
     ),
     code: {
       name: 'mix.exs',
-      lang: 'diff-elixir',
+      lang: 'elixir',
       code: `  defp aliases do
     [
       setup: ["deps.get", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
--     "assets.deploy": ["esbuild default --minify", "phx.digest"]
-+     "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]
+>     "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]
     ]
   end`,
     },
@@ -93,6 +92,8 @@ let steps = [
       name: 'dev.exs',
       lang: 'elixir',
       code: `  watchers: [
+    # Start the esbuild watcher by calling Esbuild.install_and_run(:default, args)
+    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
 >   tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]`,
     },

--- a/src/pages/docs/guides/phoenix.js
+++ b/src/pages/docs/guides/phoenix.js
@@ -60,7 +60,17 @@ let steps = [
   },
   {
     title: 'Update your deployment script',
-    body: () => <p>Configure an alias to build your CSS on deployment.</p>,
+    body: () => (
+      <div>
+        <p>
+          Configure an alias to build your CSS on deployment.
+        </p>
+        <p>
+          <b>Please note: an <code>assets.deploy</code> alias may already exist depending on your version of Phoenix.</b><br />
+          You should be safe to replace the existing alias or temporarily comment it out if you are unsure.
+        </p>
+      </div>
+    ),
     code: {
       name: 'mix.exs',
       lang: 'elixir',

--- a/src/pages/docs/guides/phoenix.js
+++ b/src/pages/docs/guides/phoenix.js
@@ -63,20 +63,23 @@ let steps = [
     body: () => (
       <div>
         <p>
-          Configure an alias to build your CSS on deployment. If you already have an{' '}
-          <code>assets.deploy</code> alias please be sure <code>tailwind default --minify</code> is
-          at the beginning.
+          Configure your <code>assets.deploy</code> alias to build your CSS on deployment.
         </p>
       </div>
     ),
     code: {
       name: 'mix.exs',
-      lang: 'elixir',
+      lang: 'diff-elixir',
       code: `  defp aliases do
     [
->     "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]
+      setup: ["deps.get", "ecto.setup"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+-     "assets.deploy": ["esbuild default --minify", "phx.digest"]
++     "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]
     ]
-  ]`,
+  end`,
     },
   },
   {

--- a/src/pages/docs/guides/phoenix.js
+++ b/src/pages/docs/guides/phoenix.js
@@ -63,11 +63,9 @@ let steps = [
     body: () => (
       <div>
         <p>
-          Configure an alias to build your CSS on deployment.
-        </p>
-        <p>
-          <b>Please note: an <code>assets.deploy</code> alias may already exist depending on your version of Phoenix.</b><br />
-          You should be safe to replace the existing alias or temporarily comment it out if you are unsure.
+          Configure an alias to build your CSS on deployment. If you already have an{' '}
+          <code>assets.deploy</code> alias please be sure <code>tailwind default --minify</code> is
+          at the beginning.
         </p>
       </div>
     ),


### PR DESCRIPTION
In troubleshooting walking through the guide with a friend who is new to Phoenix, they had errantly added `"assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]` below the existing alias. This had the effect of not building the expected `app.css` even though everything else was configured correctly.

I'm not a huge fan of how splitting this into 2 paragraphs breaks existing convention but I don't know a better way of separating the text or displaying it in a way that conveys the same idea. I figured if this tripped up one newbie it's bound to be a problem for a few others.