### PR TITLE
Added a note about ESM modules

### DIFF
--- a/src/pages/docs/installation/index.js
+++ b/src/pages/docs/installation/index.js
@@ -22,7 +22,8 @@ let steps = [
     title: 'Configure your template paths',
     body: () => (
       <p>
-        Add the paths to all of your template files in your <code>tailwind.config.js</code> file.
+        Add the paths to all of your template files in your <code>tailwind.config.js</code> file. 
+        Note: You will need to change the configuration file extension to <code>tailwind.config.cjs</code> if you use ES modules.
       </p>
     ),
     code: {


### PR DESCRIPTION
tailwindcss CLI silently fails if the node.js project is configured for ES Modules (i.e. `"type": "module"` in `package.json`). There is an explicit error message, but it is only displayed if you explicitly specify the configuration file with `--config` flag: 

`Error [ERR_REQUIRE_ESM]: require() of ES Module [...]/tailwind.config.js from [...] not supported. tailwind.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules. Instead rename tailwind.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in [...]package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).`

This should be explicitly noted in the documentation as ES Module adoption grows. There are no errors if the user follows the instructions in the current version of the guide.