### PR TITLE
Add example of CSS variable color with alpha value

### DIFF
--- a/src/pages/docs/customizing-colors.mdx
+++ b/src/pages/docs/customizing-colors.mdx
@@ -410,3 +410,19 @@ When defining your colors this way, make sure that the format of your CSS variab
   }
 }
 ```
+
+To specify a default value for the alpha-channel other than 100%, replace `<alpha-value>` with the value you want, for example:
+
+```js tailwind.config.js
+module.exports = {
+  theme: {
+    colors: {
+      primary: 'rgb(var(--color-primary) / 0.5)',
+      // Can also use a CSS variable to specify the default alpha value
+      secondary: 'rgb(var(--color-secondary) / var(--color-secondary-alpha))',
+    }
+  }
+}
+```
+
+This still supports overriding the alpha channel with the [opacity modifier syntax](/docs/text-color#changing-the-opacity).


### PR DESCRIPTION
I asked about this in https://github.com/tailwindlabs/tailwindcss/discussions/10347 as it wasn't mentioned in the documentation. To avoid others having the same question I've added it to the documentation.