### PR TITLE
Fix broken anchor link

### DIFF
--- a/src/pages/docs/screens.mdx
+++ b/src/pages/docs/screens.mdx
@@ -153,7 +153,7 @@ Your responsive modifiers will reflect these custom screen names, so using them 
 
 ## Advanced configuration
 
-By default, breakpoints are min-width to encourage a [mobile-first](/docs/responsive-design#mobile-first) workflow. If you need more control over your media queries, you can also define them using an object syntax that lets you specify explicit min-width and max-width values.
+By default, breakpoints are min-width to encourage a [mobile-first](/docs/responsive-design#working-mobile-first) workflow. If you need more control over your media queries, you can also define them using an object syntax that lets you specify explicit min-width and max-width values.
 
 ### Max-width breakpoints
 


### PR DESCRIPTION
The "mobile-first" link in Screens docs doesn't properly link to the "Working mobile-first" section of the Responsive Design docs, this fixes it.