### PR TITLE
Make `max-width` customization example consistent

### DIFF
--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -110,9 +110,11 @@ You can customize your `max-width` scale by editing `theme.maxWidth` or `theme.e
 ```diff-js tailwind.config.js
   module.exports = {
     theme: {
-+     maxWidth: {
-+       '1/2': '50%',
-+     }
+      extend: {
++       maxWidth: {
++         '1/2': '50%',
++       }
+      }
     }
   }
 ```


### PR DESCRIPTION
The example given for how to edit `tailwind.config.js` is not consistent with other pages, such as the page for [`width`](https://github.com/tailwindlabs/tailwindcss.com/blob/master/src/pages/docs/width.mdx?plain=1#L151-L161).
("extend" is missing here)