### PR TITLE
docs(guides/remix): update Remix guide

### DIFF
--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -18,12 +18,12 @@ let steps = [
     },
   },
   {
-    title: 'Enable built-in support',
+    title: 'Enable built-in Tailwind CSS support in Remix',
     body: () => (
-      <p>Enable the <code>unstable_tailwind</code> flag in your <code>remix.config.js</code> file.</p>
+      <p>Set the <code>unstable_tailwind</code> feature flag in your <code>remix.config.js</code> file. Eventually this will become stable and won't be necessary.</p>
     ),
     code: {
-      name: 'tailwind.config.js',
+      name: 'remix.config.js',
       lang: 'js',
       code: `  /** @type {import('@remix-run/dev').AppConfig} */
   module.exports = {

--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -18,17 +18,33 @@ let steps = [
     },
   },
   {
+    title: 'Enable built-in support',
+    body: () => (
+      <p>Enable the <code>unstable_tailwind</code> flag in your <code>remix.config.js</code> file.</p>
+    ),
+    code: {
+      name: 'tailwind.config.js',
+      lang: 'js',
+      code: `  /** @type {import('@remix-run/dev').AppConfig} */
+  module.exports = {
+>   future: {
+>     unstable_tailwind: true,
+>   },
+  }`,
+    },
+  },
+  {
     title: 'Install Tailwind CSS',
     body: () => (
       <p>
-        Install <code>tailwindcss</code> and <code>concurrently</code> via npm, and then run the
+        Install <code>tailwindcss</code> via npm, and then run the
         init command to generate a <code>tailwind.config.js</code> file.
       </p>
     ),
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss concurrently\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss\nnpx tailwindcss init',
     },
   },
   {
@@ -43,9 +59,7 @@ let steps = [
       lang: 'js',
       code: `  /** @type {import('tailwindcss').Config} */
   module.exports = {
->   content: [
->     "./app/**/*.{js,ts,jsx,tsx}",
->   ],
+>   content: ["./app/**/*.{js,jsx,ts,tsx}"],
     theme: {
       extend: {},
     },
@@ -54,36 +68,15 @@ let steps = [
     },
   },
   {
-    title: 'Update your package.json scripts',
-    body: () => (
-      <p>
-        Update the scripts in your <code>package.json</code> file to build both your development and
-        production CSS.
-      </p>
-    ),
-    code: {
-      name: 'package.json',
-      lang: 'json5',
-      code: `  {
-    "scripts": {
->     "build": "npm run build:css && remix build",
->     "build:css": "tailwindcss -m -i ./styles/app.css -o app/styles/app.css",
->     "dev": "concurrently \\\"npm run dev:css\\\" \\\"remix dev\\\"",
->     "dev:css": "tailwindcss -w -i ./styles/app.css -o app/styles/app.css"
-    }
-  }`,
-    },
-  },
-  {
     title: 'Add the Tailwind directives to your CSS',
     body: () => (
       <p>
-        Create a <code>./styles/app.css</code> file and add the <code>@tailwind</code> directives
+        Create a <code>./app/tailwind.css</code> file and add the <code>@tailwind</code> directives
         for each of Tailwind’s layers.
       </p>
     ),
     code: {
-      name: 'app.css',
+      name: 'app/tailwind.css',
       lang: 'css',
       code: '@tailwind base;\n@tailwind components;\n@tailwind utilities;',
     },
@@ -97,13 +90,13 @@ let steps = [
       </p>
     ),
     code: {
-      name: 'root.jsx',
-      lang: 'js',
-      code: `import styles from "./styles/app.css"
+      name: 'root.tsx',
+      lang: 'tsx',
+      code: `import stylesheet from "~/tailwind.css";
 
-export function links() {
-  return [{ rel: "stylesheet", href: styles }]
-}`,
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];`,
     },
   },
   {
@@ -123,8 +116,8 @@ export function links() {
     title: 'Start using Tailwind in your project',
     body: () => <p>Start using Tailwind’s utility classes to style your content.</p>,
     code: {
-      name: 'index.jsx',
-      lang: 'jsx',
+      name: 'index.tsx',
+      lang: 'tsx',
       code: `  export default function Index() {
     return (
 >     <h1 className="text-3xl font-bold underline">


### PR DESCRIPTION
This way it's in line with what we have in the `examples` repo (see https://github.com/remix-run/examples/pull/156): https://github.com/remix-run/examples/tree/main/tailwindcss