### PR TITLE
Add section for TypeScript monorepo configuration

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -331,6 +331,21 @@ If you're working in a monorepo with workspaces, you may need to use `require.re
   }
 ```
 
+If you're working in a _TypeScript_ monorepo with workspaces, you may need to point to your source files for Hot Module Replacement to work.
+
+```js tailwind.config.js
+  const path = require('path');
+
+  module.exports = {
+    content: [
+      './components/**/*.{html,js}',
+      './pages/**/*.{html,js}',
+>     path.join(path.dirname(require.resolve('@my-company/tailwind-components')), '../src/**/*.{ts,tsx}'),
+    ],
+    // ...
+  }
+```
+
 ### Using relative paths
 
 By default Tailwind resolves non-absolute content paths relative to the current working directory, not the `tailwind.config.js` file. This can lead to unexpected results if you run Tailwind from a different directory.


### PR DESCRIPTION
Hey! New user of Tailwind and already it's so much better than the css I was writing before. I have probably written these lines thousands of times:

```css
.container {
  display: flex;
  flex-direction: column;
}
```

Anyway, when trying to set up tailwind in our vite+typescript monorepo, it immediately broke HMR (every change caused a full reload). I was able to fix this by change `content` in `tailwind.config.js` to point to our source TS files, instead of the generated JS files.

This PR includes an update to the docs, to save other people the effort to figure this out.