### PR TITLE
remix-guide-updates

### DIFF
--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -85,7 +85,7 @@ let steps = [
     title: 'Import the CSS file',
     body: () => (
       <p>
-        Import the compiled <code>./app/styles/app.css</code> file in your{' '}
+        Import the newly-created <code>./app/tailwind.css</code> file in your{' '}
         <code>./app/root.jsx</code> file.
       </p>
     ),


### PR DESCRIPTION
PR for docs updates. Remix first-class support for TailwindCSS just came out in v1.13.0 (https://github.com/remix-run/remix/releases/tag/remix%401.13.0) and we needed to update the docs. It looked like a PR was already merged to change most of it -- however, I found a slight bug that this PR fixes: https://github.com/tailwindlabs/tailwindcss.com/issues/1515. 

## Before:
<img width="429" alt="Screen Shot 2023-02-19 at 11 44 14 AM" src="https://user-images.githubusercontent.com/68653294/219962486-bf9b270e-d3ec-40db-a74f-289e860bd4c4.png">

## After: 
<img width="460" alt="Screen Shot 2023-02-19 at 11 44 08 AM" src="https://user-images.githubusercontent.com/68653294/219962477-d16776ef-0985-4b5c-bd9d-c700a55b9310.png">
