### PR TITLE
Highlight content paths

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -50,7 +50,8 @@ Paths are configured as [glob patterns](https://en.wikipedia.org/wiki/Glob_(prog
 
 Tailwind uses the [fast-glob](https://github.com/mrmlnc/fast-glob) library under-the-hood — check out their documentation for other supported pattern features.
 
-Paths are relative to your project root, _not_ your `tailwind.config.js` file, so if your `tailwind.config.js` file is in a custom location, you should still write your paths relative to the root of your project.
+
+> Paths are relative to your project root, _not_ your `tailwind.config.js` file, so if your `tailwind.config.js` file is in a custom location, you should still write your paths relative to the root of your project.
 
 ### Pattern recommendations
 


### PR DESCRIPTION
This is an important information that users need to pay attention to. It might be missed when a user reading the page.