### PR TITLE
Update and simplify the Nuxt 2 guide for the now-included PostCSS 8

### DIFF
--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -29,38 +29,15 @@ let tabs = [
         body: () => (
           <>
             <p>
-              Using npm, install <code>tailwindcss</code> and its peer dependencies, as well as{' '}
-              <code>@nuxt/postcss8</code>, and then run the init command to generate the{' '}
-              <code>tailwind.config.js</code> file.
-            </p>
-            <p className="mt-3 text-xs italic">
-              Using <code>@latest</code> is required because Nuxt installs PostCSS v7 and
-              Autoprefixer v9 by default.
+              Install <code>tailwindcss</code> and its peer dependencies via npm, and then run the
+              init command to generate a <code>tailwind.config.js</code> file.
             </p>
           </>
         ),
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss@latest autoprefixer@latest @nuxt/postcss8\nnpx tailwindcss init',
-        },
-      },
-      {
-        title: 'Enable the Nuxt.js PostCSS plugin',
-        body: () => (
-          <p>
-            In your <code>nuxt.config.js</code> file, enable the <code>@nuxt/postcss8</code> plugin.
-          </p>
-        ),
-        code: {
-          name: 'nuxt.config.js',
-          lang: 'js',
-          code: `  export default {
-    buildModules: [
->     '@nuxt/postcss8',
-      // ...
-    ],
-  }`,
+          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
         },
       },
       {
@@ -77,9 +54,11 @@ let tabs = [
           code: `  export default {
     build: {
 >     postcss: {
->       plugins: {
->         tailwindcss: {},
->         autoprefixer: {},
+>       postcssOptions: {
+>         plugins: {
+>           tailwindcss: {},
+>           autoprefixer: {},
+>         },
 >       },
 >     },
     }


### PR DESCRIPTION
Nuxt v2.16 now includes PostCSS 8 by default and included some breaking-ish changes if you were using the separate PostCSS 8 plugin previously. This updates the guide to account for that and be more consistent with our other guides.

Fixes #1518