### PR TITLE
Fix ping animation html code example

### DIFF
--- a/src/pages/docs/animation.mdx
+++ b/src/pages/docs/animation.mdx
@@ -154,7 +154,7 @@ Add the `animate-ping` utility to make an element scale and fade like a radar pi
 </Example>
 
 ```html
-<span class="flex h-3 w-3">
+<span class="relative flex h-3 w-3">
   <span class="**animate-ping** absolute inline-flex h-full w-full rounded-full bg-sky-400 opacity-75"></span>
   <span class="relative inline-flex rounded-full h-3 w-3 bg-sky-500"></span>
 </span>


### PR DESCRIPTION
Hello, small fix so people can copy and paste the html and have the exact same result as the one in displayed in the documentation.

Without the `relative` in the parent, the ping animation is fixated to the body of the website, and not the parent `span`.

Thanks, have a great day