### PR TITLE
fix: add the Tailwind directives to main.css instead of style.css

### DIFF
--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -173,11 +173,11 @@ let tabs = [
         body: () => (
           <p>
             Add the <code>@tailwind</code> directives for each of Tailwind’s layers to your{' '}
-            <code>./src/style.css</code> file.
+            <code>./src/assets/main.css</code> file.
           </p>
         ),
         code: {
-          name: 'style.css',
+          name: 'main.css',
           lang: 'css',
           code: '@tailwind base;\n@tailwind components;\n@tailwind utilities;',
         },


### PR DESCRIPTION
Based on the most recent Vite release, it creates an assets directory in src in Vue apps and requires the import of the Tailwind directives in src/assets/main.css.