### PR TITLE
Fix: Update Postcss Guide to contain valid config

### DIFF
--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -30,10 +30,10 @@ let steps = [
       name: 'postcss.config.js',
       lang: 'js',
       code: `  module.exports = {
-    plugins: {
+    plugins: [
 >     tailwindcss: {},
 >     autoprefixer: {},
-    }
+    ]
   }`,
     },
   },


### PR DESCRIPTION
The "Add Tailwind to your PostCSS configuration" step in the configuration guide contains invaid formating. Updated the postcss.config.js example code to contain proper JSON formatting.