### PR TITLE
Document caption-side utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "seedrandom": "^3.0.5",
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
-        "tailwindcss": "^0.0.0-insiders.ea10bb9",
+        "tailwindcss": "0.0.0-insiders.bcf983a",
         "tinytime": "^0.2.6",
         "unist-util-visit": "^2.0.3",
         "zustand": "^4.0.0-rc.0"
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -10467,12 +10467,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -10502,6 +10502,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tapable": {
@@ -19006,9 +19018,9 @@
       }
     },
     "tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -19024,12 +19036,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -19046,6 +19058,15 @@
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.11",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+          "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "seedrandom": "^3.0.5",
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
-    "tailwindcss": "^0.0.0-insiders.ea10bb9",
+    "tailwindcss": "0.0.0-insiders.bcf983a",
     "tinytime": "^0.2.6",
     "unist-util-visit": "^2.0.3",
     "zustand": "^4.0.0-rc.0"

--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -185,7 +185,12 @@ export const documentationNav = {
     pages['backdrop-saturate'],
     pages['backdrop-sepia'],
   ],
-  Tables: [pages['border-collapse'], pages['border-spacing'], pages['table-layout']],
+  Tables: [
+    pages['border-collapse'],
+    pages['border-spacing'],
+    pages['table-layout'],
+    pages['caption-side'],
+  ],
   'Transitions & Animation': [
     pages['transition-property'],
     pages['transition-duration'],

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -12,36 +12,32 @@ import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
 ## Basic usage
 
 ### Top
-Use `caption-top` to align a caption to the top of a table.
+Use `caption-top` to align a caption element to the top of a table.
 
 <Example p="none">
-    <div class="shadow-sm overflow-hidden ">
-        <table class="border-collapse table-auto w-full text-sm caption-top">
-        <caption class="dark:bg-cyan-600/20 bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
-            This caption is above the table.
+    <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
+        <table class=" table-auto w-full text-sm caption-top">
+        <caption class="border-b-0 border border-slate-400 dark:border-slate-600 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
+            Pokémon and their types.
         </caption>
         <thead >
             <tr>
-            <th class="border-y dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Song</th>
-            <th class="border-y dark:border-slate-600 font-medium p-4 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Artist</th>
-            <th class="border-y dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Year</th>
+            <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Name</th>
+            <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Type</th>
             </tr>
         </thead>
         <tbody class="bg-white dark:bg-slate-800">
             <tr>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Sliding Mr. Bones (Next Stop, Pottersville)</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Malcolm Lockyer</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1961</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Charmeleon</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">🔥 Fire</td>
             </tr>
             <tr>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Witchy Woman</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">The Eagles</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1972</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Wartortle</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">💦 Water</td>
             </tr>
             <tr>
-            <td class="p-4 pl-8 text-slate-500 dark:text-slate-400">Shining Star</td>
-            <td class="p-4 text-slate-500 dark:text-slate-400">Earth, Wind, and Fire</td>
-            <td class="p-4 pr-8 text-slate-500 dark:text-slate-400">1975</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Pikachu</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">⚡ Electric</td>
             </tr>
         </tbody>
         </table>
@@ -50,67 +46,59 @@ Use `caption-top` to align a caption to the top of a table.
 
 ```html
 <table class="**caption-top**">
-    <caption>
-        This caption is above the table.
-    </caption>
+  <caption>
+    This caption is above the table.
+  </caption>
   <thead>
     <tr>
-      <th>Song</th>
-      <th>Artist</th>
-      <th>Year</th>
+      <th>Name</th>
+      <th>Type</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>The Sliding Mr. Bones (Next Stop, Pottersville)</td>
-      <td>Malcolm Lockyer</td>
-      <td>1961</td>
+      <td>Charmeleon</td>
+      <td>🔥 Fire</td>
     </tr>
     <tr>
-      <td>Witchy Woman</td>
-      <td>The Eagles</td>
-      <td>1972</td>
+      <td>Wartortle</td>
+      <td>💦 Water</td>
     </tr>
     <tr>
-      <td>Shining Star</td>
-      <td>Earth, Wind, and Fire</td>
-      <td>1975</td>
+      <td>Pikachu</td>
+      <td>⚡ Electric</td>
     </tr>
   </tbody>
 </table>
 ```
 
 ### Bottom
-Use `caption-bottom` to align a caption to the bottom of a table.
+Use `caption-bottom` to align a caption element to the bottom of a table.
 
 <Example p="none">
-    <div class="shadow-sm overflow-hidden ">
-        <table class="border-collapse table-auto w-full text-sm caption-bottom">
-        <caption class="dark:bg-cyan-600/20 bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
-            This caption is below the table.
+    <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
+        <table class="border-collapse border border-slate-400 dark:border-slate-600 table-auto w-full text-sm caption-bottom">
+        <caption class="border-t-0 border border-slate-100 dark:border-slate-700 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
+            Pokémon and their types.
         </caption>
         <thead >
             <tr>
-            <th class="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Song</th>
-            <th class="border-b dark:border-slate-600 font-medium p-4 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Artist</th>
-            <th class="border-b dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Year</th>
+            <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Name</th>
+            <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Type</th>
             </tr>
         </thead>
         <tbody class="bg-white dark:bg-slate-800">
             <tr>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Sliding Mr. Bones (Next Stop, Pottersville)</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Malcolm Lockyer</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1961</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Charmeleon</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">🔥 Fire</td>
             </tr>
             <tr>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Witchy Woman</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">The Eagles</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1972</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Wartortle</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">💦 Water</td>
             </tr>
             <tr>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Shining Star</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Earth, Wind, and Fire</td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1975</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Pikachu</td>
+            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">⚡ Electric</td>
             </tr>
         </tbody>
         </table>
@@ -119,31 +107,27 @@ Use `caption-bottom` to align a caption to the bottom of a table.
 
 ```html
 <table class="**caption-bottom**">
-    <caption>
-        This caption is above the table.
-    </caption>
+  <caption>
+    This caption is above the table.
+  </caption>
   <thead>
     <tr>
-      <th>Song</th>
-      <th>Artist</th>
-      <th>Year</th>
+      <th>Name</th>
+      <th>Type</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>The Sliding Mr. Bones (Next Stop, Pottersville)</td>
-      <td>Malcolm Lockyer</td>
-      <td>1961</td>
+      <td>Charmeleon</td>
+      <td>🔥 Fire</td>
     </tr>
     <tr>
-      <td>Witchy Woman</td>
-      <td>The Eagles</td>
-      <td>1972</td>
+      <td>Wartortle</td>
+      <td>💦 Water</td>
     </tr>
     <tr>
-      <td>Shining Star</td>
-      <td>Earth, Wind, and Fire</td>
-      <td>1975</td>
+      <td>Pikachu</td>
+      <td>⚡ Electric</td>
     </tr>
   </tbody>
 </table>

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -16,59 +16,59 @@ export const classes = { utilities }
 Use `caption-top` to position a caption element at the top of a table.
 
 <Example p="none">
-    <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse table-auto w-full text-sm">
-          <caption class="text-slate-500 dark:text-slate-400 pb-4 text-xs caption-top">
-              Table 3. WWE superstars and their signature moves.
-          </caption>
-          <thead >
-              <tr>
-              <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
-              <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
-              </tr>
-          </thead>
-          <tbody class="bg-white dark:bg-slate-800">
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
-              </tr>
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
-              </tr>
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
-              </tr>
-          </tbody>
-        </table>
-    </div>
+  <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
+    <table class="border-collapse table-auto w-full text-sm">
+      <caption class="text-slate-500 dark:text-slate-400 pb-4 text-xs caption-top">
+          Table 3.1: Professional wrestlers and their signature moves.
+      </caption>
+      <thead>
+        <tr>
+          <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
+          <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white dark:bg-slate-800">
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">"Stone Cold" Steve Austin</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Stone Cold Stunner, Lou Thesz Press</td>
+        </tr>
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Bret "The Hitman" Hart</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">The Sharpshooter</td>
+        </tr>
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Razor Ramon</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Razor's Edge, Fallaway Slam</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </Example>
 
 ```html
 <table>
   <caption class="**caption-top**">
-     Table 3. WWE superstars and their signature moves.
+    Table 3.1: Professional wrestlers and their signature moves.
   </caption>
   <thead >
-      <tr>
-        <th>Wrestler</th>
-        <th>Signature Move(s)</th>
-      </tr>
+    <tr>
+      <th>Wrestler</th>
+      <th>Signature Move(s)</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td>Batista</td>
-        <td>Batista Bomb, Batista Bite</td>
-      </tr>
-      <tr>
-        <td>The Big Show</td>
-        <td >WMD, Chokeslam, Colossal Clutch</td>
-      </tr>
-      <tr>
-        <td>Edge</td>
-        <td>Downward Spiral, Spear</td>
-      </tr>
+    <tr>
+      <td>"Stone Cold" Steve Austin</td>
+      <td>Stone Cold Stunner, Lou Thesz Press</td>
+    </tr>
+    <tr>
+      <td>Bret "The Hitman" Hart</td>
+      <td >The Sharpshooter</td>
+    </tr>
+    <tr>
+      <td>Razor Ramon</td>
+      <td>Razor's Edge, Fallaway Slam</td>
+    </tr>
   </tbody>
 </table>
 ```
@@ -77,59 +77,59 @@ Use `caption-top` to position a caption element at the top of a table.
 Use `caption-bottom` to position a caption element at the bottom of a table.
 
 <Example p="none">
-    <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse table-auto w-full text-sm">
-          <caption class="text-slate-500 dark:text-slate-400 pt-4 text-xs caption-bottom">
-               Table 3. WWE superstars and their signature moves.
-          </caption>
-          <thead >
-              <tr>
-              <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
-              <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
-              </tr>
-          </thead>
-          <tbody class="bg-white dark:bg-slate-800">
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
-              </tr>
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
-              </tr>
-              <tr>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
-                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
-              </tr>
-          </tbody>
-        </table>
-    </div>
+  <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
+    <table class="border-collapse table-auto w-full text-sm">
+      <caption class="text-slate-500 dark:text-slate-400 pt-4 text-xs caption-bottom">
+          Table 3.1: Professional wrestlers and their signature moves.
+      </caption>
+      <thead>
+        <tr>
+          <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
+          <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white dark:bg-slate-800">
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">"Stone Cold" Steve Austin</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Stone Cold Stunner, Lou Thesz Press</td>
+        </tr>
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Bret "The Hitman" Hart</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">The Sharpshooter</td>
+        </tr>
+        <tr>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Razor Ramon</td>
+          <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Razor's Edge, Fallaway Slam</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </Example>
 
 ```html
 <table>
   <caption class="**caption-bottom**">
-      Table 3. WWE superstars and their signature moves.
+    Table 3.1: Professional wrestlers and their signature moves.
   </caption>
   <thead >
-      <tr>
-        <th>Wrestler</th>
-        <th>Signature Move(s)</th>
-      </tr>
+    <tr>
+      <th>Wrestler</th>
+      <th>Signature Move(s)</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td>Batista</td>
-        <td>Batista Bomb, Batista Bite</td>
-      </tr>
-      <tr>
-        <td>The Big Show</td>
-        <td >WMD, Chokeslam, Colossal Clutch</td>
-      </tr>
-      <tr>
-        <td>Edge</td>
-        <td>Downward Spiral, Spear</td>
-      </tr>
+    <tr>
+      <td>"Stone Cold" Steve Austin</td>
+      <td>Stone Cold Stunner, Lou Thesz Press</td>
+    </tr>
+    <tr>
+      <td>Bret "The Hitman" Hart</td>
+      <td >The Sharpshooter</td>
+    </tr>
+    <tr>
+      <td>Razor Ramon</td>
+      <td>Razor's Edge, Fallaway Slam</td>
+    </tr>
   </tbody>
 </table>
 ```

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -13,123 +13,123 @@ export const classes = { utilities }
 ## Basic usage
 
 ### Top
-Use `caption-top` to align a caption element to the top of a table.
+Use `caption-top` to position a caption element at the top of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="table-auto w-full text-sm caption-top">
-        <caption class="border-b-0 border dark:border-slate-600 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
-            Pokémon and their types.
-        </caption>
-        <thead >
-            <tr>
-            <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Name</th>
-            <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Type</th>
-            </tr>
-        </thead>
-        <tbody class="bg-white dark:bg-slate-800">
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Charmeleon</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">🔥 Fire</td>
-            </tr>
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Wartortle</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">💦 Water</td>
-            </tr>
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Pikachu</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">⚡ Electric</td>
-            </tr>
-        </tbody>
+        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm">
+          <caption class="text-slate-500 dark:text-slate-400 pb-4 text-xs caption-top">
+              WWE Superstars and their signature moves.
+          </caption>
+          <thead >
+              <tr>
+              <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
+              <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
+              </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-slate-800">
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
+              </tr>
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
+              </tr>
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
+              </tr>
+          </tbody>
         </table>
     </div>
 </Example>
 
 ```html
-<table class="**caption-top**">
-  <caption>
-    This caption is above the table.
+<table>
+  <caption class="**caption-top**">
+      WWE Superstars and their signature moves.
   </caption>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-    </tr>
+  <thead >
+      <tr>
+        <th>Wrestler</th>
+        <th>Signature Move(s)</th>
+      </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>Charmeleon</td>
-      <td>🔥 Fire</td>
-    </tr>
-    <tr>
-      <td>Wartortle</td>
-      <td>💦 Water</td>
-    </tr>
-    <tr>
-      <td>Pikachu</td>
-      <td>⚡ Electric</td>
-    </tr>
+      <tr>
+        <td>Batista</td>
+        <td>Batista Bomb, Batista Bite</td>
+      </tr>
+      <tr>
+        <td>The Big Show</td>
+        <td >WMD, Chokeslam, Colossal Clutch</td>
+      </tr>
+      <tr>
+        <td>Edge</td>
+        <td>Downward Spiral, Spear</td>
+      </tr>
   </tbody>
 </table>
 ```
 
 ### Bottom
-Use `caption-bottom` to align a caption element to the bottom of a table.
+Use `caption-bottom` to position a caption element at the bottom of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm caption-bottom">
-        <caption class="border-t-0 border border-slate-100 dark:border-slate-700 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
-            Pokémon and their types.
-        </caption>
-        <thead >
-            <tr>
-            <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Name</th>
-            <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Type</th>
-            </tr>
-        </thead>
-        <tbody class="bg-white dark:bg-slate-800">
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Charmeleon</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">🔥 Fire</td>
-            </tr>
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Wartortle</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">💦 Water</td>
-            </tr>
-            <tr>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Pikachu</td>
-            <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">⚡ Electric</td>
-            </tr>
-        </tbody>
+        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm">
+          <caption class="text-slate-500 dark:text-slate-400 pt-4 text-xs caption-bottom">
+              WWE Superstars and their signature moves.
+          </caption>
+          <thead >
+              <tr>
+              <th class="border dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Wrestler</th>
+              <th class="border dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Signature Move(s)</th>
+              </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-slate-800">
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
+              </tr>
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
+              </tr>
+              <tr>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
+                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
+              </tr>
+          </tbody>
         </table>
     </div>
 </Example>
 
 ```html
-<table class="**caption-bottom**">
-  <caption>
-    This caption is above the table.
+<table>
+  <caption class="**caption-bottom**">
+      WWE Superstars and their signature moves.
   </caption>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-    </tr>
+  <thead >
+      <tr>
+        <th>Wrestler</th>
+        <th>Signature Move(s)</th>
+      </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>Charmeleon</td>
-      <td>🔥 Fire</td>
-    </tr>
-    <tr>
-      <td>Wartortle</td>
-      <td>💦 Water</td>
-    </tr>
-    <tr>
-      <td>Pikachu</td>
-      <td>⚡ Electric</td>
-    </tr>
+      <tr>
+        <td>Batista</td>
+        <td>Batista Bomb, Batista Bite</td>
+      </tr>
+      <tr>
+        <td>The Big Show</td>
+        <td >WMD, Chokeslam, Colossal Clutch</td>
+      </tr>
+      <tr>
+        <td>Edge</td>
+        <td>Downward Spiral, Spear</td>
+      </tr>
   </tbody>
 </table>
 ```
@@ -140,10 +140,10 @@ Use `caption-bottom` to align a caption element to the bottom of a table.
 
 ### <Heading ignore>Hover, focus, and other states</Heading>
 
-<HoverFocusAndOtherStates featuredClass="caption-bottom" element="table" />
+<HoverFocusAndOtherStates defaultClass="caption-top" featuredClass="caption-bottom" element="table" />
 
 ### <Heading ignore>Breakpoints and media queries</Heading>
 
-<BreakpointsAndMediaQueries  featuredClass="caption-bottom" element="table" />
+<BreakpointsAndMediaQueries defaultClass="caption-top" featuredClass="caption-bottom" element="table" />
 
 ---

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -16,8 +16,8 @@ Use `caption-top` to align a caption element to the top of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class=" table-auto w-full text-sm caption-top">
-        <caption class="border-b-0 border border-slate-400 dark:border-slate-600 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
+        <table class="table-auto w-full text-sm caption-top">
+        <caption class="border-b-0 border dark:border-slate-600 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
             Pokémon and their types.
         </caption>
         <thead >
@@ -77,7 +77,7 @@ Use `caption-bottom` to align a caption element to the bottom of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse border border-slate-400 dark:border-slate-600 table-auto w-full text-sm caption-bottom">
+        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm caption-bottom">
         <caption class="border-t-0 border border-slate-100 dark:border-slate-700 dark:bg-cyan-600/20  bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
             Pokémon and their types.
         </caption>

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -8,6 +8,7 @@ import { ArbitraryValues } from '@/components/ArbitraryValues'
 import { BreakpointsAndMediaQueries } from '@/components/BreakpointsAndMediaQueries'
 import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
 
+export const classes = { utilities }
 
 ## Basic usage
 

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -1,0 +1,164 @@
+---
+title: "Caption Side"
+description: "Utilities for controlling the alignment of a table caption."
+---
+
+import utilities from 'utilities?plugin=captionSide'
+import { ArbitraryValues } from '@/components/ArbitraryValues'
+import { BreakpointsAndMediaQueries } from '@/components/BreakpointsAndMediaQueries'
+import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
+
+
+## Basic usage
+
+### Top
+Use `caption-top` to align a caption to the top of a table.
+
+<Example p="none">
+    <div class="shadow-sm overflow-hidden ">
+        <table class="border-collapse table-auto w-full text-sm caption-top">
+        <caption class="dark:bg-cyan-600/20 bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
+            This caption is above the table.
+        </caption>
+        <thead >
+            <tr>
+            <th class="border-y dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Song</th>
+            <th class="border-y dark:border-slate-600 font-medium p-4 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Artist</th>
+            <th class="border-y dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Year</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-slate-800">
+            <tr>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Sliding Mr. Bones (Next Stop, Pottersville)</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Malcolm Lockyer</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1961</td>
+            </tr>
+            <tr>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Witchy Woman</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">The Eagles</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1972</td>
+            </tr>
+            <tr>
+            <td class="p-4 pl-8 text-slate-500 dark:text-slate-400">Shining Star</td>
+            <td class="p-4 text-slate-500 dark:text-slate-400">Earth, Wind, and Fire</td>
+            <td class="p-4 pr-8 text-slate-500 dark:text-slate-400">1975</td>
+            </tr>
+        </tbody>
+        </table>
+    </div>
+</Example>
+
+```html
+<table class="**caption-top**">
+    <caption>
+        This caption is above the table.
+    </caption>
+  <thead>
+    <tr>
+      <th>Song</th>
+      <th>Artist</th>
+      <th>Year</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>The Sliding Mr. Bones (Next Stop, Pottersville)</td>
+      <td>Malcolm Lockyer</td>
+      <td>1961</td>
+    </tr>
+    <tr>
+      <td>Witchy Woman</td>
+      <td>The Eagles</td>
+      <td>1972</td>
+    </tr>
+    <tr>
+      <td>Shining Star</td>
+      <td>Earth, Wind, and Fire</td>
+      <td>1975</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Bottom
+Use `caption-bottom` to align a caption to the bottom of a table.
+
+<Example p="none">
+    <div class="shadow-sm overflow-hidden ">
+        <table class="border-collapse table-auto w-full text-sm caption-bottom">
+        <caption class="dark:bg-cyan-600/20 bg-cyan-50 bg-none text-slate-500 dark:text-slate-400 py-4  text-xs">
+            This caption is below the table.
+        </caption>
+        <thead >
+            <tr>
+            <th class="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Song</th>
+            <th class="border-b dark:border-slate-600 font-medium p-4 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Artist</th>
+            <th class="border-b dark:border-slate-600 font-medium p-4 pr-8 pt-3 pb-3 text-slate-400 dark:text-slate-200 text-left">Year</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-slate-800">
+            <tr>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Sliding Mr. Bones (Next Stop, Pottersville)</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Malcolm Lockyer</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1961</td>
+            </tr>
+            <tr>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Witchy Woman</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">The Eagles</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1972</td>
+            </tr>
+            <tr>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Shining Star</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 text-slate-500 dark:text-slate-400">Earth, Wind, and Fire</td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">1975</td>
+            </tr>
+        </tbody>
+        </table>
+    </div>
+</Example>
+
+```html
+<table class="**caption-bottom**">
+    <caption>
+        This caption is above the table.
+    </caption>
+  <thead>
+    <tr>
+      <th>Song</th>
+      <th>Artist</th>
+      <th>Year</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>The Sliding Mr. Bones (Next Stop, Pottersville)</td>
+      <td>Malcolm Lockyer</td>
+      <td>1961</td>
+    </tr>
+    <tr>
+      <td>Witchy Woman</td>
+      <td>The Eagles</td>
+      <td>1972</td>
+    </tr>
+    <tr>
+      <td>Shining Star</td>
+      <td>Earth, Wind, and Fire</td>
+      <td>1975</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+---
+
+## <Heading ignore>Applying conditionally</Heading>
+
+### <Heading ignore>Hover, focus, and other states</Heading>
+
+<HoverFocusAndOtherStates featuredClass="caption-bottom" element="table" />
+
+### <Heading ignore>Breakpoints and media queries</Heading>
+
+<BreakpointsAndMediaQueries  featuredClass="caption-bottom" element="table" />
+
+---

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Caption Side"
-description: "Utilities for controlling the alignment of a table caption."
+description: "Utilities for controlling the alignment of a caption element inside of a table."
 ---
 
 import utilities from 'utilities?plugin=captionSide'

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -19,7 +19,7 @@ Use `caption-top` to position a caption element at the top of a table.
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
         <table class="border-collapse table-auto w-full text-sm">
           <caption class="text-slate-500 dark:text-slate-400 pb-4 text-xs caption-top">
-              WWE superstars and their signature moves.
+              Table 3. WWE superstars and their signature moves.
           </caption>
           <thead >
               <tr>
@@ -48,7 +48,7 @@ Use `caption-top` to position a caption element at the top of a table.
 ```html
 <table>
   <caption class="**caption-top**">
-      WWE superstars and their signature moves.
+     Table 3. WWE superstars and their signature moves.
   </caption>
   <thead >
       <tr>
@@ -80,7 +80,7 @@ Use `caption-bottom` to position a caption element at the bottom of a table.
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
         <table class="border-collapse table-auto w-full text-sm">
           <caption class="text-slate-500 dark:text-slate-400 pt-4 text-xs caption-bottom">
-              WWE superstars and their signature moves.
+               Table 3. WWE superstars and their signature moves.
           </caption>
           <thead >
               <tr>
@@ -109,7 +109,7 @@ Use `caption-bottom` to position a caption element at the bottom of a table.
 ```html
 <table>
   <caption class="**caption-bottom**">
-      WWE superstars and their signature moves.
+      Table 3. WWE superstars and their signature moves.
   </caption>
   <thead >
       <tr>

--- a/src/pages/docs/caption-side.mdx
+++ b/src/pages/docs/caption-side.mdx
@@ -17,9 +17,9 @@ Use `caption-top` to position a caption element at the top of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm">
+        <table class="border-collapse table-auto w-full text-sm">
           <caption class="text-slate-500 dark:text-slate-400 pb-4 text-xs caption-top">
-              WWE Superstars and their signature moves.
+              WWE superstars and their signature moves.
           </caption>
           <thead >
               <tr>
@@ -29,16 +29,16 @@ Use `caption-top` to position a caption element at the top of a table.
           </thead>
           <tbody class="bg-white dark:bg-slate-800">
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
               </tr>
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
               </tr>
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
               </tr>
           </tbody>
         </table>
@@ -48,7 +48,7 @@ Use `caption-top` to position a caption element at the top of a table.
 ```html
 <table>
   <caption class="**caption-top**">
-      WWE Superstars and their signature moves.
+      WWE superstars and their signature moves.
   </caption>
   <thead >
       <tr>
@@ -78,9 +78,9 @@ Use `caption-bottom` to position a caption element at the bottom of a table.
 
 <Example p="none">
     <div class="shadow-sm overflow-hidden px-4 py-8 sm:px-8">
-        <table class="border-collapse border dark:border-slate-600 table-auto w-full text-sm">
+        <table class="border-collapse table-auto w-full text-sm">
           <caption class="text-slate-500 dark:text-slate-400 pt-4 text-xs caption-bottom">
-              WWE Superstars and their signature moves.
+              WWE superstars and their signature moves.
           </caption>
           <thead >
               <tr>
@@ -90,16 +90,16 @@ Use `caption-bottom` to position a caption element at the bottom of a table.
           </thead>
           <tbody class="bg-white dark:bg-slate-800">
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Batista</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Batista Bomb, Batista Bite</td>
               </tr>
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">The Big Show</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">WMD, Chokeslam, Colossal Clutch</td>
               </tr>
               <tr>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
-                <td class="border border-slate-100 dark:border-slate-700 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pl-8 text-slate-500 dark:text-slate-400">Edge</td>
+                <td class="border border-slate-200 dark:border-slate-600 p-4 pr-8 text-slate-500 dark:text-slate-400">Downward Spiral, Spear</td>
               </tr>
           </tbody>
         </table>
@@ -109,7 +109,7 @@ Use `caption-bottom` to position a caption element at the bottom of a table.
 ```html
 <table>
   <caption class="**caption-bottom**">
-      WWE Superstars and their signature moves.
+      WWE superstars and their signature moves.
   </caption>
   <thead >
       <tr>


### PR DESCRIPTION
This PR adds documentation for `caption-side` utilities and introduces a new page `/caption-side` under the `Table` heading.

Note: not sure what the insiders build should be. I've pinned it at `bcf983a` here.

<img width="1098" alt="Screenshot 2023-03-03 at 08 50 34" src="https://user-images.githubusercontent.com/13898607/222675269-e0ca077b-6f10-4dd2-b171-a5ade947c66e.png">
