### PR TITLE
Removes 0ms customisation examples from transitionDelay and transitionDuration

### DIFF
--- a/src/pages/docs/transition-delay.mdx
+++ b/src/pages/docs/transition-delay.mdx
@@ -64,7 +64,6 @@ By default, Tailwind provides eight general purpose transition-delay utilities. 
     theme: {
       extend: {
 +       transitionDelay: {
-+         '0': '0ms',
 +         '2000': '2000ms',
 +       }
       }

--- a/src/pages/docs/transition-duration.mdx
+++ b/src/pages/docs/transition-duration.mdx
@@ -64,7 +64,6 @@ By default, Tailwind provides eight general purpose transition-duration utilitie
     theme: {
       extend: {
 +       transitionDuration: {
-+         '0': '0ms',
 +         '2000': '2000ms',
 +       }
       }


### PR DESCRIPTION
With the addition of `delay-0` and `duration-0` it is no longer necessary to show the `'0' : ' 0ms'` customisation examples on the `/transition-delay` and '/transition-duration` pages
