### PR TITLE
Updates `line-height` example on `/font-size` to include relative `line-height` class.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "seedrandom": "^3.0.5",
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
-        "tailwindcss": "^0.0.0-insiders.ea10bb9",
+        "tailwindcss": "0.0.0-insiders.bcf983a",
         "tinytime": "^0.2.6",
         "unist-util-visit": "^2.0.3",
         "zustand": "^4.0.0-rc.0"
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -10467,12 +10467,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -10502,6 +10502,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tapable": {
@@ -19006,9 +19018,9 @@
       }
     },
     "tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -19024,12 +19036,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -19046,6 +19058,15 @@
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.11",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+          "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "seedrandom": "^3.0.5",
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
-    "tailwindcss": "^0.0.0-insiders.ea10bb9",
+    "tailwindcss": "0.0.0-insiders.bcf983a",
     "tinytime": "^0.2.6",
     "unist-util-visit": "^2.0.3",
     "zustand": "^4.0.0-rc.0"

--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -90,7 +90,7 @@ Set an element's line-height at the same time you set the font size by adding a 
 ```html
 <p class="**text-base/6** ...">So I started to walk into the water...</p>
 <p class="**text-base/7** ...">So I started to walk into the water...</p>
-<p class="text-base**/loose** ...">So I started to walk into the water...</p>
+<p class="**text-base/loose** ...">So I started to walk into the water...</p>
 ```
 
 You can use any value defined in your [line-height scale](/docs/line-height), or use arbitrary values if you need to deviate from your design tokens.

--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -78,8 +78,8 @@ Set an element's line-height at the same time you set the font size by adding a 
       </p>
     </div>
     <div>
-      <span class="font-medium text-sm text-slate-500 font-mono mb-3 dark:text-slate-400">text-base/8</span>
-      <p class="text-base/8 text-slate-900 dark:text-slate-200">
+      <span class="font-medium text-sm text-slate-500 font-mono mb-3 dark:text-slate-400">text-base/loose</span>
+      <p class="text-base/loose text-slate-900 dark:text-slate-200">
         So I started to walk into the water. I won't lie to you boys, I was terrified. But I pressed on, and as I made my way past the breakers a strange calm came over me. I don't know if it was divine intervention or the kinship of all living things but I tell you Jerry at that moment, I <em>was</em> a marine biologist.
       </p>
     </div>
@@ -90,7 +90,7 @@ Set an element's line-height at the same time you set the font size by adding a 
 ```html
 <p class="**text-base/6** ...">So I started to walk into the water...</p>
 <p class="**text-base/7** ...">So I started to walk into the water...</p>
-<p class="**text-base/8** ...">So I started to walk into the water...</p>
+<p class="text-base**/loose** ...">So I started to walk into the water...</p>
 ```
 
 You can use any value defined in your [line-height scale](/docs/line-height), or use arbitrary values if you need to deviate from your design tokens.


### PR DESCRIPTION
Added `text-base/loose` to the `line-height` modifier example. 

It wasn't clear to me initially that these relative `line-height` classes would also work so thought it would help to clarify that. Feel free to discard if you disagree.

<img width="787" alt="Screenshot 2023-03-03 at 09 06 54" src="https://user-images.githubusercontent.com/13898607/222678800-e4b1f8fe-ddc2-43e8-9be8-b022616aec6e.png">
