### PR TITLE
Documents `break-keep` utility

### DIFF
--- a/src/pages/docs/word-break.mdx
+++ b/src/pages/docs/word-break.mdx
@@ -67,7 +67,7 @@ Use `break-all` to add line breaks whenever necessary, without trying to preserv
 
 ### Break Keep
 
-Use `break-keep` to prevent line breaks being applied to Chinese/Japanese/Korean (CJK) text. For non-CJK text `break-keep` has the same behavior as `break-normal`:
+Use `break-keep` to prevent line breaks from being applied to Chinese/Japanese/Korean (CJK) text. For non-CJK text `break-keep` has the same behavior as `break-normal`.
 
 <Example p="none">
   <div class="px-4">

--- a/src/pages/docs/word-break.mdx
+++ b/src/pages/docs/word-break.mdx
@@ -72,9 +72,7 @@ Use `break-keep` to prevent line breaks being applied to Chinese/Japanese/Korean
 <Example p="none">
   <div class="px-4">
     <div class="mx-auto max-w-sm bg-white shadow-xl p-8 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-      <p class="break-keep">The longest word in any of the major English language dictionaries is
-      <span class="text-slate-900 font-medium dark:text-slate-200">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
-      a word that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it is the same as silicosis.</p>
+      <p class="break-keep">无价之宝”是一个中文成语，意为无法用金钱衡量的宝贵之物。<span class="text-slate-900 font-medium dark:text-slate-200">这个成语强调了珍贵的物品或品质不仅不能用金钱来衡量,</span>而且也不能被取代或替代。这个成语反映了中国人的高度重视和尊重，对非物质文化遗产、人际关系和个人品质视为“无价之宝”，强调了这些宝贵品质和文化遗产在中国文化中的重要地位，以及人们对它们的保护和传承的认识和责任感.</p>
     </div>
   </div>
 </Example>

--- a/src/pages/docs/word-break.mdx
+++ b/src/pages/docs/word-break.mdx
@@ -72,7 +72,7 @@ Use `break-keep` to prevent line breaks being applied to Chinese/Japanese/Korean
 <Example p="none">
   <div class="px-4">
     <div class="mx-auto max-w-sm bg-white shadow-xl p-8 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-      <p class="break-keep">无价之宝”是一个中文成语，意为无法用金钱衡量的宝贵之物。<span class="text-slate-900 font-medium dark:text-slate-200">这个成语强调了珍贵的物品或品质不仅不能用金钱来衡量,</span>而且也不能被取代或替代。这个成语反映了中国人的高度重视和尊重，对非物质文化遗产、人际关系和个人品质视为“无价之宝”，强调了这些宝贵品质和文化遗产在中国文化中的重要地位，以及人们对它们的保护和传承的认识和责任感.</p>
+      <p class="break-keep">抗衡不屈不挠 (kànghéng bùqū bùnáo) 这是一个长词，意思是不畏强暴，奋勇抗争，坚定不移，永不放弃。<span class="text-slate-900 font-medium dark:text-slate-200">这个词通常用来描述那些在面对困难和挑战时坚持自己信念的人，</span> 他们克服一切困难，不屈不挠地追求自己的目标。无论遇到多大的挑战，他们都能够坚持到底，不放弃，最终获得胜利。</p>
     </div>
   </div>
 </Example>

--- a/src/pages/docs/word-break.mdx
+++ b/src/pages/docs/word-break.mdx
@@ -65,6 +65,24 @@ Use `break-all` to add line breaks whenever necessary, without trying to preserv
 <p class="**break-all** ...">...</p>
 ```
 
+### Break Keep
+
+Use `break-keep` to prevent line breaks being applied to Chinese/Japanese/Korean (CJK) text. For non-CJK text `break-keep` has the same behavior as `break-normal`:
+
+<Example p="none">
+  <div class="px-4">
+    <div class="mx-auto max-w-sm bg-white shadow-xl p-8 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+      <p class="break-keep">The longest word in any of the major English language dictionaries is
+      <span class="text-slate-900 font-medium dark:text-slate-200">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+      a word that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it is the same as silicosis.</p>
+    </div>
+  </div>
+</Example>
+
+```html
+<p class="**break-keep** ...">...</p>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>


### PR DESCRIPTION
I noticed that `break-keep` wasn't documented on the `/word-break` page so I added it. Feel free to discard if this was intentional. 

<img width="790" alt="Screenshot 2023-03-03 at 09 10 12" src="https://user-images.githubusercontent.com/13898607/222679544-1f1eaa5c-a5e7-4167-8564-464170527fca.png">
