### PR TITLE
Documents `justify-stretch` and `justify-normal` under `/justify-content`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "seedrandom": "^3.0.5",
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
-        "tailwindcss": "^0.0.0-insiders.ea10bb9",
+        "tailwindcss": "0.0.0-insiders.bcf983a",
         "tinytime": "^0.2.6",
         "unist-util-visit": "^2.0.3",
         "zustand": "^4.0.0-rc.0"
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -10467,12 +10467,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -10502,6 +10502,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tapable": {
@@ -19006,9 +19018,9 @@
       }
     },
     "tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -19024,12 +19036,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -19046,6 +19058,15 @@
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.11",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+          "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "seedrandom": "^3.0.5",
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
-    "tailwindcss": "^0.0.0-insiders.ea10bb9",
+    "tailwindcss": "0.0.0-insiders.bcf983a",
     "tinytime": "^0.2.6",
     "unist-util-visit": "^2.0.3",
     "zustand": "^4.0.0-rc.0"

--- a/src/pages/docs/justify-content.mdx
+++ b/src/pages/docs/justify-content.mdx
@@ -154,7 +154,7 @@ Use `justify-stretch` to allow content items to fill the available space along t
 
 ### Normal
 
-Use `justify-normal` to pack content items in their default position as if no `justify` value was set.
+Use `justify-normal` to pack content items in their default position as if no `justify-content` value was set:
 
 <Example>
   <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-blue rounded-lg">

--- a/src/pages/docs/justify-content.mdx
+++ b/src/pages/docs/justify-content.mdx
@@ -136,7 +136,7 @@ Use `justify-evenly` to justify items along the container's main axis such that 
 Use `justify-stretch` to allow content items to fill the available space along the container's main axis:
 
 <Example>
-  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-fuchsia rounded-lg">
+  <div class="grid grid-flow-col justify-stretch gap-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-fuchsia rounded-lg">
     <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">01</div>
     <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">02</div>
     <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">03</div>

--- a/src/pages/docs/justify-content.mdx
+++ b/src/pages/docs/justify-content.mdx
@@ -136,10 +136,10 @@ Use `justify-evenly` to justify items along the container's main axis such that 
 Use `justify-stretch` to allow items to fill the available space along the container's main axis:
 
 <Example>
-  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-emerald rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">03</div>
   </div>
 </Example>
 
@@ -154,10 +154,10 @@ Use `justify-stretch` to allow items to fill the available space along the conta
 With `flex` containers `justify-stretch` behaves the same as `justify-start`:
 
 <Example>
-  <div class="flex justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  <div class="flex justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-emerald rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">03</div>
   </div>
 </Example>
 
@@ -174,10 +174,10 @@ With `flex` containers `justify-stretch` behaves the same as `justify-start`:
 Use `justify-normal` to pack items in their default position as if no `justify` value was set. This behaves the same as `justify-stretch` for both `grid` and `flex` containers:
 
 <Example>
-  <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-amber rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">03</div>
   </div>
 </Example>
 

--- a/src/pages/docs/justify-content.mdx
+++ b/src/pages/docs/justify-content.mdx
@@ -131,6 +131,64 @@ Use `justify-evenly` to justify items along the container's main axis such that 
 </div>
 ```
 
+### Stretch
+
+Use `justify-stretch` to allow items to fill the available space along the container's main axis:
+
+<Example>
+  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  </div>
+</Example>
+
+```html
+<div class="grid grid-flow-col **justify-stretch** ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
+</div>
+```
+
+With `flex` containers `justify-stretch` behaves the same as `justify-start`:
+
+<Example>
+  <div class="flex justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  </div>
+</Example>
+
+```html
+<div class="flex **justify-stretch** ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
+</div>
+```
+
+### Normal
+
+Use `justify-normal` to pack items in their default position as if no `justify` value was set. This behaves the same as `justify-stretch` for both `grid` and `flex` containers:
+
+<Example>
+  <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-indigo rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">03</div>
+  </div>
+</Example>
+
+```html
+<div class="flex **justify-normal** ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>

--- a/src/pages/docs/justify-content.mdx
+++ b/src/pages/docs/justify-content.mdx
@@ -133,13 +133,13 @@ Use `justify-evenly` to justify items along the container's main axis such that 
 
 ### Stretch
 
-Use `justify-stretch` to allow items to fill the available space along the container's main axis:
+Use `justify-stretch` to allow content items to fill the available space along the container's main axis:
 
 <Example>
-  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-emerald rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">03</div>
+  <div class="grid grid-flow-col justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-fuchsia rounded-lg">
+    <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">01</div>
+    <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">02</div>
+    <div class="h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">03</div>
   </div>
 </Example>
 
@@ -151,33 +151,16 @@ Use `justify-stretch` to allow items to fill the available space along the conta
 </div>
 ```
 
-With `flex` containers `justify-stretch` behaves the same as `justify-start`:
-
-<Example>
-  <div class="flex justify-stretch space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-emerald rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-emerald-500 shadow-lg">03</div>
-  </div>
-</Example>
-
-```html
-<div class="flex **justify-stretch** ...">
-  <div>01</div>
-  <div>02</div>
-  <div>03</div>
-</div>
-```
 
 ### Normal
 
-Use `justify-normal` to pack items in their default position as if no `justify` value was set. This behaves the same as `justify-stretch` for both `grid` and `flex` containers:
+Use `justify-normal` to pack content items in their default position as if no `justify` value was set.
 
 <Example>
-  <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-amber rounded-lg">
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">01</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">02</div>
-    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-amber-500 shadow-lg">03</div>
+  <div class="flex justify-normal space-x-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-blue rounded-lg">
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">01</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">02</div>
+    <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">03</div>
   </div>
 </Example>
 


### PR DESCRIPTION
A couple notes:
- Because they are less commonly used I've put `justify-stretch` and `justify-normal` below the other utilities. Putting them at the beginning would mean that `justify-start`, `justify-stretch` and `justify-normal` would all display very similar behaviour.
- For `justify-stretch` I've provided different examples for the behaviour with `grid` and `flex` containers.
<img width="790" alt="Screenshot 2023-03-03 at 09 18 27" src="https://user-images.githubusercontent.com/13898607/222681486-85d29b2c-6e65-4279-8971-d4b270e99ffc.png">
- I noticed that the `justify-stretch` and `justify-normal` classes aren't showing up in the quick start section:
<img width="769" alt="Screenshot 2023-03-03 at 09 23 55" src="https://user-images.githubusercontent.com/13898607/222682766-b88d56a3-85e3-413e-97bb-5564bc93d5c0.png">

