### PR TITLE
Documents `hyphens` utilities.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "seedrandom": "^3.0.5",
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
-        "tailwindcss": "^0.0.0-insiders.ea10bb9",
+        "tailwindcss": "0.0.0-insiders.bcf983a",
         "tinytime": "^0.2.6",
         "unist-util-visit": "^2.0.3",
         "zustand": "^4.0.0-rc.0"
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -10467,12 +10467,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -10502,6 +10502,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tapable": {
@@ -19006,9 +19018,9 @@
       }
     },
     "tailwindcss": {
-      "version": "0.0.0-insiders.ea10bb9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.ea10bb9.tgz",
-      "integrity": "sha512-5YFk5g17mKD41fe44rTDmzRduEtCgQ1KCw+AMCMyrIlhVCBTmLAThKX2vkxziZQh03oNvQAthuu6EO11ttxbzg==",
+      "version": "0.0.0-insiders.bcf983a",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-0.0.0-insiders.bcf983a.tgz",
+      "integrity": "sha512-C6o8RoKVrQBI5zzKCKoI+qnN9gHG2JdMFwmbfThiFZWjGeh2EamA/fo91Lo2Dx+YNmoiuv9Dur0JzEtMYUdHEQ==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
@@ -19024,12 +19036,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -19046,6 +19058,15 @@
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.11",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+          "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "seedrandom": "^3.0.5",
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
-    "tailwindcss": "^0.0.0-insiders.ea10bb9",
+    "tailwindcss": "0.0.0-insiders.bcf983a",
     "tinytime": "^0.2.6",
     "unist-util-visit": "^2.0.3",
     "zustand": "^4.0.0-rc.0"

--- a/src/css/prism.css
+++ b/src/css/prism.css
@@ -84,3 +84,8 @@ pre[class^='language-diff-'] {
 pre[class^='language-diff-'] > code {
   @apply flex-none min-w-full;
 }
+
+/* targets the `&shy;` in a code example */
+span.code-highlight.bg-code-highlight:has(> span[title*="\AD"]) {
+  @apply bg-pink-500/10 text-pink-400 mx-[1px];
+}

--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -128,6 +128,7 @@ export const documentationNav = {
     pages['vertical-align'],
     pages['whitespace'],
     pages['word-break'],
+    pages['hyphens'],
     pages['content'],
   ],
   Backgrounds: [

--- a/src/pages/docs/hyphens.mdx
+++ b/src/pages/docs/hyphens.mdx
@@ -10,3 +10,72 @@ import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
 export const classes = { utilities }
 
 ## Basic usage
+
+### None
+Use `hyphens-none` to prevent words from being hyphenated even if the line break suggestion `&shy;` is used:
+
+
+<Example p="none">
+  <div class="overflow-x-scroll sm:overflow-x-visible px-4">
+    <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">  
+      <p class="hyphens-none"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+    </div>
+  </div>
+</Example>
+
+```html
+<p class="**hyphens-none** ...">
+    ... Kraftfahrzeug**&shy;**Haftpflichtversicherung is a ...
+</p>
+```
+
+### Manual
+
+Use `hyphens-manual` to only set hyphenation points where the line break suggestion `&shy;` is used:
+
+
+<Example p="none">
+  <div class="overflow-x-scroll sm:overflow-x-visible px-4">
+    <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+      <p class="hyphens-manual"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+    </div>
+  </div>
+</Example>
+
+```html
+<p class="**hyphens-manual** ...">
+    ... Kraftfahrzeug**&shy;**Haftpflichtversicherung is a ...
+</p>
+```
+
+### Auto
+
+Use `hyphens-auto` to allow the browser to automatically choose hyphenation points based on the language. The line break suggestion `&shy;` will be preferred over automatic hyphenation points.
+
+
+<Example p="none">
+  <div class="overflow-x-scroll sm:overflow-x-visible px-4">
+    <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400 ">
+       <p class="hyphens-auto"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> KraftfahrzeugHaftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+    </div>
+  </div>
+</Example>
+
+```html
+<p class="**hyphens-auto** ..." lang="**de**">
+    ... KraftfahrzeugHaftpflichtversicherung is a ...
+</p>
+```
+
+
+---
+
+## <Heading ignore>Applying conditionally</Heading>
+
+### <Heading ignore>Hover, focus, and other states</Heading>
+
+<HoverFocusAndOtherStates defaultClass="hyphens-none" featuredClass="hyphens-auto" element="p" />
+
+### <Heading ignore>Breakpoints and media queries</Heading>
+
+<BreakpointsAndMediaQueries defaultClass="hyphens-none" featuredClass="hyphens-auto" element="p" />

--- a/src/pages/docs/hyphens.mdx
+++ b/src/pages/docs/hyphens.mdx
@@ -18,7 +18,7 @@ Use `hyphens-none` to prevent words from being hyphenated even if the line break
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">  
-      <p class="hyphens-none"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+      <p class="hyphens-none">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
@@ -37,7 +37,7 @@ Use `hyphens-manual` to only set hyphenation points where the line break suggest
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-      <p class="hyphens-manual"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+      <p class="hyphens-manual">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
@@ -56,13 +56,13 @@ Use `hyphens-auto` to allow the browser to automatically choose hyphenation poin
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400 ">
-       <p class="hyphens-auto"> Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> KraftfahrzeugHaftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+       <p class="hyphens-auto">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> KraftfahrzeugHaftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
 
 ```html
-<p class="**hyphens-auto** ..." lang="**de**">
+<p class="**hyphens-auto** ..." **lang**="de">
     ... KraftfahrzeugHaftpflichtversicherung is a ...
 </p>
 ```

--- a/src/pages/docs/hyphens.mdx
+++ b/src/pages/docs/hyphens.mdx
@@ -1,0 +1,12 @@
+---
+title: "Hyphens"
+description: "Utilities for controlling how words should be hyphenated."
+---
+
+import utilities from 'utilities?plugin=hyphens'
+import { BreakpointsAndMediaQueries } from '@/components/BreakpointsAndMediaQueries'
+import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
+
+export const classes = { utilities }
+
+## Basic usage


### PR DESCRIPTION
Adds a new page `/hyphens` under the `typography` section.

<img width="1079" alt="Screenshot 2023-03-03 at 09 28 17" src="https://user-images.githubusercontent.com/13898607/222683661-1e53629b-f7f1-45e6-8cf2-451c656f0971.png">

I noticed that `hyphens` aren't showing up in search. Does this indexing only happen on the production site?