### PR TITLE
Documents `font-variation-settings`

### DIFF
--- a/src/pages/docs/font-family.mdx
+++ b/src/pages/docs/font-family.mdx
@@ -108,42 +108,9 @@ Note that **Tailwind does not automatically escape font names** for you. If you'
 
 Learn more about customizing the default theme in the [theme customization](/docs/theme#customizing-the-default-theme) documentation.
 
-#### Providing default font-feature-settings
-
-You can optionally provide default [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontFeatureSettings }]` when configuring custom fonts.
-
-```diff-js tailwind.config.js
-  module.exports = {
-    theme: {
-      fontFamily: {
-        sans: [
-          "Inter var, sans-serif",
-+         { fontFeatureSettings: '"cv11", "ss01"' },
-        ],
-      },
-    },
-  }
-```
-
-#### Providing default font-variation-settings
-
-Similarly, you can provide default [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontVariationSettings }]` when configuring custom fonts.
-
-```diff-js tailwind.config.js
-  module.exports = {
-    theme: {
-      fontFamily: {
-        sans: [
-          "Inter var, sans-serif",
-+         { fontVariationSettings: '"opsz" 32', },
-        ],
-      },
-    },
-  }
-```
 
 #### Providing default font settings
-You can optionally provide default [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) and [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontFeatureSettings }, { fontVariationSettings }]` when configuring custom fonts.
+You can optionally provide default [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) and [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontFeatureSettings, fontVariationSettings }]` when configuring custom fonts.
 
 ```diff-js tailwind.config.js
   module.exports = {
@@ -151,8 +118,10 @@ You can optionally provide default [font-feature-settings](https://developer.moz
       fontFamily: {
         sans: [
           "Inter var, sans-serif",
-+         { fontFeatureSettings: '"cv11", "ss01"' },
-+         { fontVariationSettings: '"opsz" 32', },
++         { 
++           fontFeatureSettings: '"cv11", "ss01"',
++           fontVariationSettings: '"opsz" 32'
++         },
         ],
       },
     },

--- a/src/pages/docs/font-family.mdx
+++ b/src/pages/docs/font-family.mdx
@@ -125,6 +125,40 @@ You can optionally provide default [font-feature-settings](https://developer.moz
   }
 ```
 
+#### Providing default font-variation-settings
+
+Similarly, you can provide default [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontVariationSettings }]` when configuring custom fonts.
+
+```diff-js tailwind.config.js
+  module.exports = {
+    theme: {
+      fontFamily: {
+        sans: [
+          "Inter var, sans-serif",
++         { fontVariationSettings: '"opsz" 32', },
+        ],
+      },
+    },
+  }
+```
+
+#### Providing default font settings
+You can optionally provide default [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) and [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings) for each font in your project using a tuple of the form `[fontFamilies, { fontFeatureSettings }, { fontVariationSettings }]` when configuring custom fonts.
+
+```diff-js tailwind.config.js
+  module.exports = {
+    theme: {
+      fontFamily: {
+        sans: [
+          "Inter var, sans-serif",
++         { fontFeatureSettings: '"cv11", "ss01"' },
++         { fontVariationSettings: '"opsz" 32', },
+        ],
+      },
+    },
+  }
+```
+
 ### Arbitrary values
 
 <ArbitraryValues property="font-family" featuredClass="font-['Open_Sans']" element="p" />


### PR DESCRIPTION
Adds documentation for customising `font-variation-settings` on the `/font-family` page. 

I combined it with `font-feature-settings` and renamed the section to "Providing default font settings"
<img width="756" alt="Screenshot 2023-03-03 at 09 38 00" src="https://user-images.githubusercontent.com/13898607/222685796-cdcbc45d-0f1a-48e5-bfe8-c58fed9ef822.png">
