### PR TITLE
Documents content-normal and content-stretch

### DIFF
--- a/src/pages/docs/align-content.mdx
+++ b/src/pages/docs/align-content.mdx
@@ -170,7 +170,7 @@ Use `content-evenly` to distribute rows in a container such that there is an equ
 
 ### Stretch
 
-Use `content-stretch` to allow auto-sized items to fill the available space along the container’s cross axis:
+Use `content-stretch` to allow content items to fill the available space along the container’s cross axis:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
@@ -196,7 +196,7 @@ Use `content-stretch` to allow auto-sized items to fill the available space alon
 
 ### Normal
 
-Use `content-normal` to pack items in their default position as if no `align-content` value was set:
+Use `content-normal` to pack content items in their default position as if no `align-content` value was set:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/align-content.mdx
+++ b/src/pages/docs/align-content.mdx
@@ -168,6 +168,59 @@ Use `content-evenly` to distribute rows in a container such that there is an equ
 </div>
 ```
 
+### Stretch
+
+Use `content-stretch` to auto-sized items to fill the available space along the container’s cross axis:
+
+<Example>
+  <div class="font-mono text-white text-sm font-bold leading-6">
+    <div class="grid grid-cols-3 gap-4 content-stretch w-full rounded-lg bg-stripes-emerald text-center h-56">
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">01</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">02</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">03</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">04</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">05</div>
+    </div>
+  </div>
+</Example>
+
+```html
+<div class="h-56 grid grid-cols-3 gap-4 **content-stretch** ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
+  <div>04</div>
+  <div>05</div>
+</div>
+```
+
+### Normal
+
+Use `content-normal` to allow auto-sized items to fill the available space along the container’s cross axis in the same way as `content-stretch`:
+
+<Example>
+  <div class="font-mono text-white text-sm font-bold leading-6">
+    <div class="grid grid-cols-3 gap-4 content-normal w-full rounded-lg bg-stripes-amber text-center h-56">
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">01</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">02</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">03</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">04</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">05</div>
+    </div>
+  </div>
+</Example>
+
+
+```html
+<div class="h-56 grid grid-cols-3 gap-4 **content-normal** ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
+  <div>04</div>
+  <div>05</div>
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>

--- a/src/pages/docs/align-content.mdx
+++ b/src/pages/docs/align-content.mdx
@@ -196,7 +196,7 @@ Use `content-stretch` to allow auto-sized items to fill the available space alon
 
 ### Normal
 
-Use `content-normal` to pack items in their default position as if no `content` value was set. This behaves the same as `content-stretch` and is mostly useful for resetting `content` at different screen sizes:
+Use `content-normal` to pack items in their default position as if no `align-content` value was set:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/align-content.mdx
+++ b/src/pages/docs/align-content.mdx
@@ -170,7 +170,7 @@ Use `content-evenly` to distribute rows in a container such that there is an equ
 
 ### Stretch
 
-Use `content-stretch` to auto-sized items to fill the available space along the container’s cross axis:
+Use `content-stretch` to allow auto-sized items to fill the available space along the container’s cross axis:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/align-content.mdx
+++ b/src/pages/docs/align-content.mdx
@@ -174,12 +174,12 @@ Use `content-stretch` to allow auto-sized items to fill the available space alon
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
-    <div class="grid grid-cols-3 gap-4 content-stretch w-full rounded-lg bg-stripes-emerald text-center h-56">
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">01</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">02</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">03</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">04</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-emerald-500">05</div>
+    <div class="grid grid-cols-3 gap-4 content-stretch w-full rounded-lg bg-stripes-fuchsia text-center h-56">
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-fuchsia-500">01</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-fuchsia-500">02</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-fuchsia-500">03</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-fuchsia-500">04</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-fuchsia-500">05</div>
     </div>
   </div>
 </Example>
@@ -196,16 +196,16 @@ Use `content-stretch` to allow auto-sized items to fill the available space alon
 
 ### Normal
 
-Use `content-normal` to allow auto-sized items to fill the available space along the container’s cross axis in the same way as `content-stretch`:
+Use `content-normal` to pack items in their default position as if no `content` value was set. This behaves the same as `content-stretch` and is mostly useful for resetting `content` at different screen sizes:
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
-    <div class="grid grid-cols-3 gap-4 content-normal w-full rounded-lg bg-stripes-amber text-center h-56">
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">01</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">02</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">03</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">04</div>
-      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-amber-500">05</div>
+    <div class="grid grid-cols-3 gap-4 w-full rounded-lg bg-stripes-indigo text-center h-56">
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-indigo-500">01</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-indigo-500">02</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-indigo-500">03</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-indigo-500">04</div>
+      <div class="p-4 flex justify-center items-center shadow-lg rounded-lg bg-indigo-500">05</div>
     </div>
   </div>
 </Example>


### PR DESCRIPTION
Adds documentation for `align-content: stretch` and `align-content: normal`.

<img width="799" alt="Screenshot 2023-03-06 at 08 43 08" src="https://user-images.githubusercontent.com/13898607/223060048-bee66e81-7d2d-4183-82d8-0b31a227b88a.png">


~~One weird thing: there is supposed to be a difference in behaviour between `align-content: stretch` and `align-content: normal`~~ 

_I'm an idiot._
