### PR TITLE
Update functions-and-directives.mdx

### DIFF
--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -77,11 +77,11 @@ Use the `@layer` directive to tell Tailwind which "bucket" a set of custom style
 }
 ```
 
-Tailwind will automatically move any CSS within a `@layer` directive to the same place as the corresponding `@tailwind` rule, so you don't have to worry about authoring your CSS in a specific order to avoid specificity issues.
+Tailwind will automatically move any CSS within an `@layer` directive to the same place as the corresponding `@tailwind` rule, so you don't have to worry about authoring your CSS in a specific order to avoid specificity issues.
 
 Any custom CSS added to a layer will only be included in the final build if that CSS is actually used in your HTML, just like all of the classes built in to Tailwind by default.
 
-Wrapping any custom CSS in a `@layer` directive also makes it possible to use modifiers with those rules, like `hover:` and `focus:` or responsive modifiers like `md:` and `lg:`.
+Wrapping any custom CSS in an `@layer` directive also makes it possible to use modifiers with those rules, like `hover:` and `focus:` or responsive modifiers like `md:` and `lg:`.
 
 ### @apply
 


### PR DESCRIPTION
Based upon the phonetic (sound) quality of the first letter in @layer (at-layer) I'd expect 'an' here rather than 'a'. Maybe the @ is supposed to be silent, but this is how I'd expect most people to read this.