### PR TITLE
Update nuxtjs.js: Nuxt Config link

### DIFF
--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -199,7 +199,7 @@ let tabs = [
         code: {
           name: 'nuxt.config.js',
           lang: 'js',
-          code: `  // https://v3.nuxtjs.org/api/configuration/nuxt.config
+          code: `  // https://nuxt.com/docs/api/configuration/nuxt-config
   export default defineNuxtConfig({
 >   postcss: {
 >     plugins: {
@@ -263,7 +263,7 @@ let tabs = [
         code: {
           name: 'nuxt.config.js',
           lang: 'js',
-          code: `  // https://v3.nuxtjs.org/api/configuration/nuxt.config
+          code: `  // https://nuxt.com/docs/api/configuration/nuxt-config
   export default defineNuxtConfig({
 >   css: ['~/assets/css/main.css'],
     postcss: {


### PR DESCRIPTION
The current URL in the tailwind docs redirects to nuxt.com but finally gives a 404.
Setting the correct final URL here. That's the one mentioned in `nuxt.config.ts` after a fresh `nuxi init`.