### PR TITLE
Update Footer.js links to pop open in a new tab.

### DIFF
--- a/src/components/home/Footer.js
+++ b/src/components/home/Footer.js
@@ -34,8 +34,8 @@ export function Footer() {
                   <ul className="mt-3 space-y-2">
                     {items.map((item) => (
                       <li key={item.href}>
-                        <Link href={item.href}>
-                          <a className="hover:text-slate-900 dark:hover:text-slate-300">
+                        <Link href={item.href} passHref>
+                          <a className="hover:text-slate-900 dark:hover:text-slate-300" target="_blank" rel="noopener noreferrer">
                             {item.title}
                           </a>
                         </Link>


### PR DESCRIPTION
Updated the footer navigation links to pop open external websites in a new tab. This helps users with not losing their place on Tailwindcss.com, while they can explore the other Tailwind resources in another browser window.

I also updated the external urls to use the 'noreferrer' tag so that Tailwind isn't passing valuable SEO page rank to GitHub and Twitter.