### PR TITLE
Fix german spelling in hyphens.mdx

### DIFF
--- a/src/pages/docs/hyphens.mdx
+++ b/src/pages/docs/hyphens.mdx
@@ -18,14 +18,14 @@ Use `hyphens-none` to prevent words from being hyphenated even if the line break
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-      <p class="hyphens-none">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+      <p class="hyphens-none">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
 
 ```html
 <p class="**hyphens-none** ...">
-  ... Kraftfahrzeug**&shy;**Haftpflichtversicherung is a ...
+  ... Kraftfahrzeug**&shy;**haftpflichtversicherung is a ...
 </p>
 ```
 
@@ -36,14 +36,14 @@ Use `hyphens-manual` to only set hyphenation points where the line break suggest
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-      <p class="hyphens-manual">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+      <p class="hyphens-manual">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
 
 ```html
 <p class="**hyphens-manual** ...">
-  ... Kraftfahrzeug**&shy;**Haftpflichtversicherung is a ...
+  ... Kraftfahrzeug**&shy;**haftpflichtversicherung is a ...
 </p>
 ```
 
@@ -54,14 +54,14 @@ Use `hyphens-auto` to allow the browser to automatically choose hyphenation poin
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-       <p class="hyphens-auto">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> KraftfahrzeugHaftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+       <p class="hyphens-auto">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeughaftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
 
 ```html
 <p class="**hyphens-auto** ..." **lang**="de">
-  ... KraftfahrzeugHaftpflichtversicherung is a ...
+  ... Kraftfahrzeughaftpflichtversicherung is a ...
 </p>
 ```
 


### PR DESCRIPTION
In german we don’t use Pascal case for words, even this really long ones.