### PR TITLE
Fix: utility class names mismatch issue

### DIFF
--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -162,7 +162,7 @@ For more control over the gradient color stop positions, combine the `from-{posi
 </Example>
 
 ```html
-<div class="bg-gradient-to-r from-indigo-500 **from-10%** via-purple-500 **via-30%** to-pink-500 **to-90%** ..."></div>
+<div class="bg-gradient-to-r from-indigo-500 **from-10%** via-sky-500 **via-30%** to-emerald-500 **to-90%** ..."></div>
 ```
 
 ### Fading to transparent


### PR DESCRIPTION
I have found a class names mismatch issue [in this page](https://tailwindcss.com/docs/gradient-color-stops#specifying-stop-positions)

```html
<div class="bg-gradient-to-r from-indigo-500 from-10% via-purple-500 via-30% to-pink-500 to-90% ..."></div>
```

The class names in the code snippet differ from those shown in the example. Specifically, while the example uses colors ranging from sky-500 to emerald-500, the code snippet instead uses colors ranging from purple-500 to pink-500, which is incorrect.