### PR TITLE
Fix typo in v3-3 announcement

### DIFF
--- a/src/pages/blog/tailwindcss-v3-3/index.mdx
+++ b/src/pages/blog/tailwindcss-v3-3/index.mdx
@@ -227,7 +227,7 @@ Here's a full list of all of the new utilities we've added and what they map to:
         <tr>
           <td className="pl-4 sm:pl-0"><code>rounded-e-*</code></td>
           <td><code>border-start-end-radius</code><br /><code>border-end-end-radius</code></td>
-          <td className="pr-4 sm:pr-0"><code>rounded-l-*</code></td>
+          <td className="pr-4 sm:pr-0"><code>rounded-r-*</code></td>
         </tr>
         <tr>
           <td className="pl-4 sm:pl-0"><code>rounded-ss-*</code></td>


### PR DESCRIPTION
In the logical properties section, the Physical counterpart (LTR) of `rounded-e-*` is `rounded-r-*` rather than `rounded-l-*`