### PR TITLE
Add .mdx to tailwind config.content

### DIFF
--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -45,12 +45,12 @@ let steps = [
       code: `  /** @type {import('tailwindcss').Config} */
   module.exports = {
 >   content: [
->     "./app/**/*.{js,ts,jsx,tsx}",
->     "./pages/**/*.{js,ts,jsx,tsx}",
->     "./components/**/*.{js,ts,jsx,tsx}",
+>     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+>     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+>     "./components/**/*.{js,ts,jsx,tsx,mdx}",
 >
 >     // Or if using \`src\` directory:
->     "./src/**/*.{js,ts,jsx,tsx}",
+>     "./src/**/*.{js,ts,jsx,tsx,mdx}",
 >   ],
     theme: {
       extend: {},


### PR DESCRIPTION
Hey Tailwind Team!

Tailwind, Next.js, and MDX are a popular combo. We've had a few reports where folks forgot to configure the content config option and were quite puzzled because 99% of styling is already covered, and the mdx subset of styles is so rare.