### PR TITLE
Update framework-guides.js

### DIFF
--- a/src/pages/docs/installation/framework-guides.js
+++ b/src/pages/docs/installation/framework-guides.js
@@ -127,12 +127,12 @@ export default function FrameworkGuides() {
             description: 'The full stack JavaScript framework for developing cross-platform apps.',
             logo: MeteorLogo,
           },
-          {
-            name: 'Create React App',
-            slug: 'create-react-app',
-            description: 'CLI tool for scaffolding a new single-page React application.',
-            logo: CraLogo,
-          },
+//           {
+//             name: 'Create React App',
+//             slug: 'create-react-app',
+//             description: 'CLI tool for scaffolding a new single-page React application.',
+//             logo: CraLogo,
+//           },
           {
             name: 'AdonisJS',
             slug: 'adonisjs',


### PR DESCRIPTION
Remove create-react-app installation guide, since react core team have kind of deprecated this method.

https://react.dev/learn/start-a-new-react-project