### PR TITLE
Correct German spelling of example in Blogpost v3.3

### DIFF
--- a/src/pages/blog/tailwindcss-v3-3/index.mdx
+++ b/src/pages/blog/tailwindcss-v3-3/index.mdx
@@ -522,14 +522,14 @@ Using `hyphens-manual` and a carefully placed `&shy;`, you can tell the browser 
 <Example p="none">
   <div class="overflow-x-scroll sm:overflow-x-visible px-4">
     <div class="mx-auto max-w-xs bg-white shadow-xl p-12 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-       <p class="hyphens-manual">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;Haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
+       <p class="hyphens-manual">Officially recognized by the Duden dictionary as the longest word in German, <span class="text-slate-900 font-medium dark:text-slate-200" lang="de"> Kraftfahrzeug&shy;haftpflichtversicherung</span> is a 36 letter word for motor vehicle liability insurance.</p>
     </div>
   </div>
 </Example>
 
 ```html
 <p class="**hyphens-manual** ...">
-    ... Kraftfahrzeug**&shy;**Haftpflichtversicherung is a ...
+    ... Kraftfahrzeug**&shy;**haftpflichtversicherung is a ...
 </p>
 ```
 


### PR DESCRIPTION
After a hyphen the word continues with lowercase letters in German, so if `Kraftfahrzeughaftpflichtversicherung` needs to be splitted into two parts it will look like this
> Kraftfahrzeug-
> haftpflichtversicherung