### PR TITLE
Fix theme update

### DIFF
--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -10,14 +10,15 @@ const useSetting = create((set) => ({
 }))
 
 function update() {
+  document.documentElement.classList.add('changing-theme')
   if (
     localStorage.theme === 'dark' ||
     (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
   ) {
-    document.documentElement.classList.add('dark', 'changing-theme')
+    document.documentElement.classList.add('dark')
     document.querySelector('meta[name="theme-color"]').setAttribute('content', '#0B1120')
   } else {
-    document.documentElement.classList.remove('dark', 'changing-theme')
+    document.documentElement.classList.remove('dark')
     document.querySelector('meta[name="theme-color"]').setAttribute('content', '#f8fafc')
   }
   window.setTimeout(() => {


### PR DESCRIPTION
In the theme `update` function, instead of adding `changing-theme` class, it was being removed when going from `dark` to `light`.