### PR TITLE
Provide an example of custom size

### DIFF
--- a/src/pages/docs/margin.mdx
+++ b/src/pages/docs/margin.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Add margin to a single side
 
-Control the margin on one side of an element using the `m{t|r|b|l}-{size}` utilities.
+Control the margin on one side of an element using the `m{t|r|b|l}-{size}` utilities (example ml-[1.6rem]).
 
 For example, `mt-6` would add `1.5rem` of margin to the top of an element, `mr-4` would add `1rem` of margin to the right of an element, `mb-8` would add `2rem` of margin to the bottom of an element, and `ml-2` would add `0.5rem` of margin to the left of an element.
 


### PR DESCRIPTION
The documentation shows using curly bracket for the size portion which I tried to do and it does not work you need a bracket instead. This might be explained else were in the documentation but it would be good to have at least one example on the page that uses a custom size everywhere on the website that `-{size}` is mentioned.