### PR TITLE
Removed duplicate gap class

### DIFF
--- a/src/pages/docs/place-items.mdx
+++ b/src/pages/docs/place-items.mdx
@@ -17,7 +17,7 @@ Use `place-items-start` to place grid items on the start of their grid areas on 
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
-    <div class="grid grid-cols-3 gap-4 h-56 gap-4">
+    <div class="grid grid-cols-3 h-56 gap-4">
       <div class="bg-stripes-cyan grid place-items-start rounded-lg">
         <div class="p-4 w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-cyan-500">01</div>
       </div>
@@ -57,7 +57,7 @@ Use `place-items-end` to place grid items on the end of their grid areas on both
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
-    <div class="grid grid-cols-3 gap-4 h-56 gap-4">
+    <div class="grid grid-cols-3 h-56 gap-4">
       <div class="bg-stripes-violet grid place-items-end rounded-lg">
         <div class="p-4 w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-violet-500">01</div>
       </div>
@@ -97,7 +97,7 @@ Use `place-items-center` to place grid items on the center of their grid areas o
 
 <Example>
   <div class="font-mono text-white text-sm font-bold leading-6">
-    <div class="grid grid-cols-3 gap-4 h-56 gap-4">
+    <div class="grid grid-cols-3 h-56 gap-4">
       <div class="bg-stripes-pink grid place-items-center rounded-lg">
         <div class="p-4 w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-pink-500">01</div>
       </div>


### PR DESCRIPTION
Spotted a couple of duplicate classes when I was working through some of the examples in the docs site.