### PR TITLE
Fix building on newer versions of Node

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,7 +54,7 @@ module.exports = withBundleAnalyzer({
           loader: 'file-loader',
           options: {
             publicPath: '/_next',
-            name: 'static/media/[name].[hash].[ext]',
+            name: 'static/media/[name].[sha1:hash].[ext]',
           },
         },
       ],
@@ -112,7 +112,7 @@ module.exports = withBundleAnalyzer({
           loader: 'file-loader',
           options: {
             publicPath: '/_next',
-            name: 'static/media/[name].[hash].[ext]',
+            name: 'static/media/[name].[sha1:hash].[ext]',
           },
         },
       ],


### PR DESCRIPTION
This fixes building on Node >= 17.

We really should swap out file-loader for webpack's Asset Resources instead but that requires a bit more work. This is a good stop-gap measure until that gets done.