### PR TITLE
Update sveltekit.js

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -120,7 +120,7 @@ let steps = [
 
 > <style lang="postcss">
     :global(html) {
-      background-color: theme(colors.gray.100);
+      background-color: theme("colors.gray.100");
     }
   </style>`,
     },


### PR DESCRIPTION
Without the quotes, sveltekit will throw this error:
```jsx
/src/routes/+layout.svelte:13:40 ")" is expected
/src/routes/+layout.svelte:13:40
11 |  <style lang="postcss">
 12 |    :global(html) {
 13 |            background-color: theme(colors.gray.100);
                                               ^
 14 |      }
 15 |   *{}</style>
```