### PR TITLE
Fix minor typo in the Presets documentation.

### DIFF
--- a/src/pages/docs/presets.mdx
+++ b/src/pages/docs/presets.mdx
@@ -249,7 +249,7 @@ module.exports = {
 ```js {{ filename: 'tailwind.config.js' }}
 module.exports = {
   presets: [
-    require('./example-preset.js')
+    require('./my-preset.js')
   ],
   // ...
 }


### PR DESCRIPTION
Under the "Disabling the default configuration section", the last example should have the same filename in the tailwind.config.js file as the filename of the preset file shown right above it, which is _my-preset.js_