### PR TITLE
Update using PostCSS option documentation with `-p` flag for automatic PostCSS config generation

### DIFF
--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {


### PR DESCRIPTION
Hi, made a quick update to the TailwindCSS documentation, I have added the info about the `-p` flag for using PostCSS option while setuping up TailwindCSS so users can simply run `npx tailwindcss init -p` to auto-generate the PostCSS config file.
