### PR TITLE
Implement custom id syntax on headings

### DIFF
--- a/remark/withTableOfContents.mjs
+++ b/remark/withTableOfContents.mjs
@@ -18,13 +18,18 @@ export const withTableOfContents = () => {
         )
         let slug = slugify(title)
 
+        if (node.children[node.children.length - 1].type === 'mdxTextExpression') {
+          slug = node.children.pop().value
+          slug = slug.slice(2, slug.length - 2)
+        }
+
         let allOtherSlugs = contents.flatMap((entry) => [
           entry.slug,
           ...entry.children.map(({ slug }) => slug),
         ])
         let slugIndex = 1
         while (allOtherSlugs.indexOf(slug) > -1) {
-          slug = `${slugify(title)}-${slugIndex}`
+          slug = `${slug}-${slugIndex}`
           slugIndex++
         }
 


### PR DESCRIPTION
I'm now trying to create Japanese documentation by forking this repository. It is to let more people in Japan use my favorite Tailwinscss :)

In translating to other languages, I need a custom id attribute in Heading. It is to maintain existing links.
It is possible to achieve this only in my environment forked, but this is very useful, so I created a PR.

Usage
```
## Heading {/*heading-id*/}

=> <h2 id="heading-id" ...><a href="#heading-id" ...>Heading</a></h2>
```

This is also accomplished in the React documentation, and the implementation was based on that.
https://github.com/reactjs/react.dev/blob/main/plugins/remark-header-custom-ids.js


Please let me know if you can already achieve this in other ways.
Thanks for your maintenance.