### PR TITLE
Add Svelte section to Vite framework guide

### DIFF
--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -208,6 +208,103 @@ let tabs = [
       },
     ],
   },
+  {
+    name: 'Using Svelte',
+    href: '#svelte',
+    steps: [
+      {
+        title: 'Create your project',
+        body: () => (
+          <p>
+            Start by creating a new Vite project if you don’t have one set up already. The most
+            common approach is to use{' '}
+            <a href="https://vitejs.dev/guide/#scaffolding-your-first-vite-project">Create Vite</a>.
+          </p>
+        ),
+        code: {
+          name: 'Terminal',
+          lang: 'terminal',
+          code: 'npm create vite@latest my-project -- --template svelte\ncd my-project',
+        },
+      },
+      {
+        title: 'Install Tailwind CSS',
+        body: () => (
+          <p>
+            Install <code>tailwindcss</code> and its peer dependencies, then generate your{' '}
+            <code>tailwind.config.js</code> and <code>postcss.config.js</code> files.
+          </p>
+        ),
+        code: {
+          name: 'Terminal',
+          lang: 'terminal',
+          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+        },
+      },
+      {
+        title: 'Configure your template paths',
+        body: () => (
+          <p>
+            Add the paths to all of your template files in your <code>tailwind.config.js</code>{' '}
+            file.
+          </p>
+        ),
+        code: {
+          name: 'tailwind.config.js',
+          lang: 'js',
+          code: `  /** @type {import('tailwindcss').Config} */
+  export default {
+>   content: [
+>     "./index.html",
+>     "./src/**/*.{svelte,js,ts,jsx,tsx}",
+>   ],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+  }`,
+        },
+      },
+      {
+        title: 'Add the Tailwind directives to your CSS',
+        body: () => (
+          <p>
+            Add the <code>@tailwind</code> directives for each of Tailwind’s layers to your{' '}
+            <code>./src/app.css</code> file.
+          </p>
+        ),
+        code: {
+          name: 'app.css',
+          lang: 'css',
+          code: '@tailwind base;\n@tailwind components;\n@tailwind utilities;',
+        },
+      },
+      {
+        title: 'Start your build process',
+        body: () => (
+          <p>
+            Run your build process with <code>npm run dev</code>.
+          </p>
+        ),
+        code: {
+          name: 'Terminal',
+          lang: 'terminal',
+          code: 'npm run dev',
+        },
+      },
+      {
+        title: 'Start using Tailwind in your project',
+        body: () => <p>Start using Tailwind’s utility classes to style your content.</p>,
+        code: {
+          name: 'App.svelte',
+          lang: 'html',
+          code: `<h1 class="text-3xl font-bold underline">
+  Hello world!
+</h1>`,
+        },
+      },
+    ],
+  },
 ]
 
 export default function UsingVite({ code }) {


### PR DESCRIPTION
Adds a Svelte section to the Vite framework guide, alongside React and Vue.

Direct preview link: https://tailwindcss-com-git-fork-lukemartin-guide-v-24e21b-tailwindlabs.vercel.app/docs/guides/vite#svelte