### PR TITLE
docs/justify-self: Fixed typos

### DIFF
--- a/src/pages/docs/justify-self.mdx
+++ b/src/pages/docs/justify-self.mdx
@@ -39,7 +39,7 @@ Use `justify-self-auto` to align an item based on the value of the grid's `justi
 
 ### Start
 
-Use `justify-self-start` to align a grid item to the start its inline axis:
+Use `justify-self-start` to align a grid item to the start of its inline axis:
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 justify-items-stretch auto-rows-fr font-mono text-white text-sm font-bold leading-6 text-center">
@@ -67,7 +67,7 @@ Use `justify-self-start` to align a grid item to the start its inline axis:
 
 ### Center
 
-Use `justify-self-center` to align a grid item along the center its inline axis:
+Use `justify-self-center` to align a grid item along the center of its inline axis:
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 justify-items-stretch auto-rows-fr font-mono text-white text-sm font-bold leading-6 text-center">
@@ -95,7 +95,7 @@ Use `justify-self-center` to align a grid item along the center its inline axis:
 
 ### End
 
-Use `justify-self-end` to align a grid item to the end its inline axis:
+Use `justify-self-end` to align a grid item to the end of its inline axis:
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 justify-items-stretch auto-rows-fr font-mono text-white text-sm font-bold leading-6 text-center">


### PR DESCRIPTION
Title says it all. Fixed a few typos in docs/justify-self.