### PR TITLE
add arbitrary example for bg-position

### DIFF
--- a/src/pages/docs/background-size.mdx
+++ b/src/pages/docs/background-size.mdx
@@ -99,3 +99,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 ### Arbitrary values
 
 <ArbitraryValues property="background-size" featuredClass="bg-[length:200px_100px]" />
+<ArbitraryValues property="background-position" featuredClass="bg-[position:right_100px_bottom_-2rem]" />


### PR DESCRIPTION
I spent too long figuring out how to set/use the arbitrary values for `background-position` for background, especially helpful when trying to set this for multiple backgrounds. So I thought it should make an excellent addition to the docs. Likely to be helpful for others landing here with similar issues.