### PR TITLE
Add 'select-all' to ClassTable

### DIFF
--- a/src/components/ClassTable.js
+++ b/src/components/ClassTable.js
@@ -132,7 +132,7 @@ export const ClassTable = memo(
                         <td
                           translate="no"
                           className={clsx(
-                            'py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400',
+                            'py-2 pr-2 font-mono font-medium text-xs leading-6 text-sky-500 whitespace-nowrap dark:text-sky-400 select-all',
                             {
                               'border-t border-slate-100 dark:border-slate-400/10': i !== 0,
                             }


### PR DESCRIPTION
This PR adds the `select-all` class to the class names displayed in the ClassTable component.

Why?

#1439 was closed for future design consideration in November.  I'm sadly still triple-clicking to select classes I want to copy in the docs. 

This PR reduces it to a single click (a savings of 66%!) before the mighty `Command + C` is invoked.

Also happy to implement this as "DoubleClick => Class Copied to Clipboard" but figuring this was a safer initial approach. Please let me know!
