### PR TITLE
Added `scrollMargin` and `scrollPadding` to core plugins list for spacing customization

### DIFF
--- a/src/pages/docs/customizing-spacing.mdx
+++ b/src/pages/docs/customizing-spacing.mdx
@@ -23,7 +23,7 @@ module.exports = {
 }
 ```
 
-By default the spacing scale is inherited by the `padding`, `margin`, `width`, `height`, `maxHeight`, `gap`, `inset`, `space`, and `translate` core plugins.
+By default the spacing scale is inherited by the `padding`, `margin`, `width`, `height`, `maxHeight`, `gap`, `inset`, `space`, `translate`, `scrollMargin` and `scrollPadding` core plugins.
 
 ---
 

--- a/src/pages/docs/customizing-spacing.mdx
+++ b/src/pages/docs/customizing-spacing.mdx
@@ -23,7 +23,7 @@ module.exports = {
 }
 ```
 
-By default the spacing scale is inherited by the `padding`, `margin`, `width`, `height`, `maxHeight`, `gap`, `inset`, `space`, `translate`, `scrollMargin` and `scrollPadding` core plugins.
+By default the spacing scale is inherited by the `padding`, `margin`, `width`, `height`, `maxHeight`, `gap`, `inset`, `space`, `translate`, `scrollMargin`, and `scrollPadding` core plugins.
 
 ---
 


### PR DESCRIPTION
The pages for [`scrollPadding`](https://tailwindcss.com/docs/scroll-padding#customizing-your-theme) and [`scrollMargin`](https://tailwindcss.com/docs/scroll-margin#customizing-your-theme) mention using the spacing scale. Unfortunately these plugins are currently not listed on the [Customize Spacing](https://tailwindcss.com/docs/customizing-spacing) page.

I have not checked if any other plugins are missing in the list.