### PR TITLE
update sveltekit guide to prevent svelte language extension errors

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -48,12 +48,21 @@ let steps = [
       lang: 'js',
       code: `  import adapter from '@sveltejs/adapter-auto';
 > import { vitePreprocess } from '@sveltejs/kit/vite';
+> import { dirname, join } from 'path';
+> import { fileURLToPath } from 'url';
+> const __dirname = dirname(fileURLToPath(import.meta.url));
   /** @type {import('@sveltejs/kit').Config} */
   const config = {
     kit: {
       adapter: adapter()
     },
->   preprocess: vitePreprocess()
+>   preprocess: vitePreprocess({
+>      style: {
+>        css: {
+>          postcss: join(__dirname, 'postcss.config.js')
+>        }
+>      }
+>    })
   };
   export default config;`,
     },


### PR DESCRIPTION
The existing framework guide for svelte does not add the necessary svelte.config settings to prevent the vscode svelte language extension from showing errors when using postcss.  Currently, the Hello World example in the guide will cause errors.  These changes fix them.

Please see https://github.com/sveltejs/language-tools/issues/2094 for more info.