### PR TITLE
Refactor the Combobox Component for performance and readability

### DIFF
--- a/src/components/blog/ComboboxDemo.js
+++ b/src/components/blog/ComboboxDemo.js
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useState, useMemo } from 'react'
 import { Combobox, Transition } from '@headlessui/react'
 import { Example } from '@/components/Example'
 
@@ -15,7 +15,7 @@ export default function Demo() {
   const [selected, setSelected] = useState(people[3])
   const [query, setQuery] = useState('')
 
-  const filteredPeople =
+  const filteredPeople = useMemo(() =>
     query === ''
       ? people
       : people.filter((person) =>
@@ -24,6 +24,7 @@ export default function Demo() {
             .replace(/\s+/g, '')
             .includes(query.toLowerCase().replace(/\s+/g, ''))
         )
+  , [query]);
 
   return (
     <Example className="h-96 flex items-start justify-center pt-12">


### PR DESCRIPTION
This PR includes the useMemo hook for the filteredPeople variable. Before this change, the filtering operation was being performed on every render of the component, which is unnecessary especially when the people list or the query does not change. By using useMemo, the filtering operation only takes place when people or query changes, thereby slightly optimizing the performance of this component, probably not too much on this small demo, but more when dealing with large datasets.