### PR TITLE
Improve heading anchor links

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -35,11 +35,8 @@ export function Heading({
       data-docsearch-ignore={ignore ? '' : undefined}
       {...props}
     >
-      <a
-        className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')}
-        href={`#${id}`}
-      >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 lg:flex">
+      <a className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')} href={`#${id}`}>
           &#8203;
           <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
             <svg width="12" height="12" fill="none" aria-hidden="true">

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -35,7 +35,10 @@ export function Heading({
       data-docsearch-ignore={ignore ? '' : undefined}
       {...props}
     >
-      <a className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')} href={`#${id}`}>
+      <a
+        className={clsx('group relative border-none', hidden ? 'sr-only' : 'lg:-ml-2 lg:pl-2')}
+        href={`#${id}`}
+      >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 group-focus:opacity-100 lg:flex">
           &#8203;
           <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -6,8 +6,6 @@ export function Heading({
   level,
   id,
   children,
-  number,
-  badge,
   className = '',
   hidden = false,
   ignore = false,
@@ -28,8 +26,7 @@ export function Heading({
 
   return (
     <Component
-      className={clsx('group flex whitespace-pre-wrap', className, {
-        '-ml-4 pl-4': !hidden,
+      className={clsx('flex whitespace-pre-wrap not-prose', className, {
         'mb-2 text-sm leading-6 text-sky-500 font-semibold tracking-normal dark:text-sky-400':
           level === 2 && nextElement?.type === 'heading' && nextElement?.depth === 3,
       })}
@@ -38,14 +35,14 @@ export function Heading({
       data-docsearch-ignore={ignore ? '' : undefined}
       {...props}
     >
-      {!hidden && (
-        <a
-          href={`#${id}`}
-          className="absolute -ml-10 flex items-center opacity-0 border-0 group-hover:opacity-100"
-          aria-label="Anchor"
-        >
+      <a
+        className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')}
+        href={`#${id}`}
+        aria-label="Anchor"
+      >
+        <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 lg:flex">
           &#8203;
-          <div className="w-6 h-6 text-slate-400 ring-1 ring-slate-900/5 rounded-md shadow-sm flex items-center justify-center hover:ring-slate-900/10 hover:shadow hover:text-slate-700 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
+          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
             <svg width="12" height="12" fill="none" aria-hidden="true">
               <path
                 d="M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10"
@@ -55,19 +52,9 @@ export function Heading({
               />
             </svg>
           </div>
-        </a>
-      )}
-      {number && (
-        <span className="bg-cyan-100 w-8 h-8 inline-flex items-center justify-center rounded-full text-cyan-700 text-xl mr-3 flex-none">
-          {number}
-        </span>
-      )}
-      <span className={hidden ? 'sr-only' : undefined}>{children}</span>
-      {badge && (
-        <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-green-150 text-green-900">
-          {badge}
-        </span>
-      )}
+        </div>
+        {children}
+      </a>
     </Component>
   )
 }

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -35,8 +35,8 @@ export function Heading({
       data-docsearch-ignore={ignore ? '' : undefined}
       {...props}
     >
-        <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 lg:flex">
       <a className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')} href={`#${id}`}>
+        <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 group-focus:opacity-100 lg:flex">
           &#8203;
           <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
             <svg width="12" height="12" fill="none" aria-hidden="true">

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -38,7 +38,6 @@ export function Heading({
       <a
         className={clsx('group relative', hidden ? 'sr-only' : '-ml-2 pl-2')}
         href={`#${id}`}
-        aria-label="Anchor"
       >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 lg:flex">
           &#8203;

--- a/src/layouts/SidebarLayout.js
+++ b/src/layouts/SidebarLayout.js
@@ -521,7 +521,7 @@ export function SidebarLayout({
     <SidebarContext.Provider value={{ nav, navIsOpen, setNavIsOpen }}>
       <Wrapper allowOverflow={allowOverflow}>
         <div className="max-w-8xl mx-auto px-4 sm:px-6 md:px-8">
-          <div className="hidden lg:block fixed z-20 inset-0 top-[3.8125rem] left-[max(0px,calc(50%-45rem))] right-auto w-[19.5rem] pb-10 px-8 overflow-y-auto">
+          <div className="hidden lg:block fixed z-20 inset-0 top-[3.8125rem] left-[max(0px,calc(50%-45rem))] right-auto w-[19rem] pb-10 pl-8 pr-6 overflow-y-auto">
             <Nav nav={nav} fallbackHref={fallbackHref}>
               {sidebar}
             </Nav>


### PR DESCRIPTION
Resolves #1644

This PR improves the heading anchor links.

## Fixed anchor icon interfering with scrollbar

First, I tweaked the position of the sidebar navigation scrollbar so it's more to the left giving a little more space for the anchor link icon, and also moved the icon slightly to the right, so that the icon doesn't land on top of the scrollbar:

| Before | After |
|--------|--------|
| <img width="474" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/1d978b40-bfae-40f6-a7ef-2e5bc198f891"> | <img width="515" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/603996a1-a150-46c5-984f-92d1aa3d776a"> | 

## Removed anchor icon on mobile

Next, I removed the anchor link icon entirely on mobile (since there is no space for it), but then made the whole heading a link so that you can still click it.

| Before | After |
|--------|--------|
| <img width="359" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/58645973-ff4d-48ff-94ba-255011112eea"> | <img width="360" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/2e0db106-0e31-4f52-b20f-13ce30bfb693"> |

## Changed hit/hover area

I also updated the hit/hover area to just the text, not the full width of the heading. To me it feels weird when I'm hovering over the heading on the right-hand side of the page, and the anchor link is appearing on the left.

<img width="751" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/b52f647e-bd92-45ee-90a2-6a8f469fb96a">

## Removed old props

Finally I removed the `number` and `badge` props from the `<Heading>` component — pretty sure these aren't used anywhere and are remnants of the previous version of the website.