### PR TITLE
Update font-family.mdx

### DIFF
--- a/src/pages/docs/font-family.mdx
+++ b/src/pages/docs/font-family.mdx
@@ -143,7 +143,7 @@ For convenience, [Preflight](/docs/preflight) sets the font family on the `html`
     theme: {
       extend: {
         fontFamily: {
-+         'sans': ['Proxima Nova', ...defaultTheme.fontFamily.sans],
++         'sans': ['"Proxima Nova"', ...defaultTheme.fontFamily.sans],
         },
       }
     }


### PR DESCRIPTION
In the example above this one, spaces are not allowed. Therefore to keep the documentation consistent add them to "Proxima Nova" :
```
fontFamily: {
+         'sans': ['"Proxima Nova"', ...defaultTheme.fontFamily.sans],
},
```

```
// Won't work:
  'sans': ['Exo 2', ...],
```