### PR TITLE
Update width.mdx

### DIFF
--- a/src/pages/docs/width.mdx
+++ b/src/pages/docs/width.mdx
@@ -35,13 +35,13 @@ Use `w-{number}` or `w-px` to set an element to a fixed width.
 ```
 
 ```html
-<div class="**w-96** ..."></div>
-<div class="**w-80** ..."></div>
-<div class="**w-64** ..."></div>
-<div class="**w-48** ..."></div>
-<div class="**w-40** ..."></div>
-<div class="**w-32** ..."></div>
-<div class="**w-24** ..."></div>
+<div class="**w-96** ...">w-96</div>
+<div class="**w-80** ...">w-80</div>
+<div class="**w-64** ...">w-64</div>
+<div class="**w-48** ...">w-48</div>
+<div class="**w-40** ...">w-40</div>
+<div class="**w-32** ...">w-32</div>
+<div class="**w-24** ...">w-24</div>
 ```
 
 ### Percentage widths


### PR DESCRIPTION
Fixed little missing words in Documentations of Width section

![Screenshot (114)](https://github.com/tailwindlabs/tailwindcss.com/assets/89210111/0811c4f2-472f-4147-a87c-66f9284e703a)

## Before
```html
<div class="**w-96** ..."></div>
<div class="**w-80** ..."></div>
<div class="**w-64** ..."></div>
<div class="**w-48** ..."></div>
<div class="**w-40** ..."></div>
<div class="**w-32** ..."></div>
<div class="**w-24** ..."></div>
```
## After
```html
<div class="**w-96** ...">w-96</div>
<div class="**w-80** ...">w-80</div>
<div class="**w-64** ...">w-64</div>
<div class="**w-48** ...">w-48</div>
<div class="**w-40** ...">w-40</div>
<div class="**w-32** ...">w-32</div>
<div class="**w-24** ...">w-24</div>
```

### Code in below screenshot did not have values "w-80' and so on.