### PR TITLE
Fix unexpected installations tabs scroll

### DIFF
--- a/src/layouts/InstallationLayout.js
+++ b/src/layouts/InstallationLayout.js
@@ -138,7 +138,7 @@ export function InstallationLayout({ children }) {
                         href={href}
                         scroll={false}
                         className={clsx(
-                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b-2 -mb-px',
+                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b',
                           href === router.pathname
                             ? 'text-sky-500 border-current'
                             : 'text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700'


### PR DESCRIPTION
Fix unexpected installations tabs scroll which is caused by the negative margin on the anchor menu items.

Current:
![image](https://github.com/tailwindlabs/tailwindcss.com/assets/5566282/189d0110-d575-4336-b85a-110d3b2d5c36)

After:
![image](https://github.com/tailwindlabs/tailwindcss.com/assets/5566282/cd9da331-d16a-48b6-b465-f05d015fff40)
