### PR TITLE
Fix unexpected installations tabs scroll (continuation of #1653)

### DIFF
--- a/src/components/Guides/TabBar.jsx
+++ b/src/components/Guides/TabBar.jsx
@@ -11,7 +11,7 @@ export function TabBar({ tabs, selectedTabIndex }) {
   return (
     <div className="flex overflow-auto mb-6 -mx-4 sm:-mx-6">
       <div className="flex-none min-w-full px-4 sm:px-6">
-        <ul className="border-b border-slate-200 space-x-6 flex whitespace-nowrap dark:border-slate-200/5">
+        <ul className="border-b border-slate-200 space-x-6 flex whitespace-nowrap dark:border-slate-200/5 mb-px">
           {tabs.map((tab, tabIndex) => (
             <li key={tab.key || tab.name}>
               <h2>

--- a/src/layouts/InstallationLayout.js
+++ b/src/layouts/InstallationLayout.js
@@ -130,7 +130,7 @@ export function InstallationLayout({ children }) {
           </h2>
           <div className="flex overflow-auto mb-6 -mx-4 sm:-mx-6">
             <div className="flex-none min-w-full px-4 sm:px-6">
-              <ul className="border-b border-slate-200 space-x-6 flex whitespace-nowrap dark:border-slate-200/5">
+              <ul className="border-b border-slate-200 space-x-6 flex whitespace-nowrap dark:border-slate-200/5 mb-px">
                 {Object.entries(tabs).map(([name, href]) => (
                   <li key={name}>
                     <h2>

--- a/src/layouts/InstallationLayout.js
+++ b/src/layouts/InstallationLayout.js
@@ -138,7 +138,7 @@ export function InstallationLayout({ children }) {
                         href={href}
                         scroll={false}
                         className={clsx(
-                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b',
+                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b-2 -mb-px',
                           href === router.pathname
                             ? 'text-sky-500 border-current'
                             : 'text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700'

--- a/src/layouts/InstallationLayout.js
+++ b/src/layouts/InstallationLayout.js
@@ -138,7 +138,7 @@ export function InstallationLayout({ children }) {
                         href={href}
                         scroll={false}
                         className={clsx(
-                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b-2 -mb-px',
+                          'flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b',
                           href === router.pathname
                             ? 'text-sky-500 border-current'
                             : 'text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700'


### PR DESCRIPTION
This PR is a continuation of #1653. I don't have push permissions on the original PR so had to create a new PR with the additional changes.

In short, on windows a scrollbar is shown on the installation pages in the tabbar because of the overflowing tab indicators that are floating on top of the gray border.

Closes: #1653

