### PR TITLE
Fixed missing "to" in editor-setup.mdx

### DIFF
--- a/src/pages/docs/editor-setup.mdx
+++ b/src/pages/docs/editor-setup.mdx
@@ -42,7 +42,7 @@ It works seamlessly with custom Tailwind configurations, and because it’s just
 <button class="bg-sky-700 px-4 py-2 text-white hover:bg-sky-800 sm:px-8 sm:py-3">...</button>
 ```
 
-Check out the plugin [on GitHub](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) learn more and get started.
+Check out the plugin [on GitHub](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) to learn more and get started.
 
 ## JetBrains IDEs
 


### PR DESCRIPTION
"editor-setup.mdx" was stating "Check out the plugin on GitHub learn more and get started." where the word "to" was missing before "learn more", so I forked and edited.

Hopefully PRing to the `master` branch is fine. I looked at the [CONTRIBUTING.md](https://github.com/tailwindlabs/tailwindcss/blob/master/.github/CONTRIBUTING.md) file and a preferred branch name wasn't specified it seems.
If I should have PRed in the `3.3` branch or another, please let me know and I'll do it. :)

Hope it helps!
Thank you so much for creating Tailwind ♥