### PR TITLE
fix: added example to theme extend paragraph

### DIFF
--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -223,6 +223,21 @@ module.exports = {
 }
 ```
 
+To use any of the extended values you can call them like you would with a normal one.
+
+Using the example above with the new screens `3xl` property we get:
+
+```html
+<div class="h-full w-full bg-white">
+  <div class="grid h-full w-full grid-cols-1 3xl:grid-cols-3">
+    <div class="h-full w-full bg-blue-200 opacity-75"></div>
+    <div class="hidden h-full w-full bg-red-200 opacity-75 3xl:block"></div>
+    <div class="hidden h-full w-full bg-green-200 opacity-75 3xl:block"></div>
+  </div>
+</div>
+
+```
+
 ### Overriding the default theme
 
 To override an option in the default theme, add your overrides directly under the `theme` section of your `tailwind.config.js`:


### PR DESCRIPTION
Closes: #1571 

Result in the docs:

![Screenshot 2023-08-22 alle 16 32 01](https://github.com/tailwindlabs/tailwindcss.com/assets/102860588/09ddd393-69eb-4dea-b0bf-71ae935398cc)


Result of the code in the example:

<img width="1192" alt="Screenshot 2023-08-22 alle 16 30 26" src="https://github.com/tailwindlabs/tailwindcss.com/assets/102860588/d40c4674-72bb-4820-9483-d70bf781d0c0">
