### PR TITLE
Add explanation of `theme.extend` to theme documentation

### DIFF
--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -222,7 +222,7 @@ module.exports = {
 }
 ```
 
-After adding this to your theme you can use it just as with any other utility in your HTML:
+After adding this to your theme you can use it in your HTML just like any other utility:
 
 ```html
 <h1 class="**font-display**">

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -222,7 +222,7 @@ module.exports = {
 }
 ```
 
-After adding this to your theme you can use it in your HTML just like any other utility:
+After adding this to your theme you can use it just like any other `font-{family}` utility:
 
 ```html
 <h1 class="**font-display**">

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -226,12 +226,12 @@ module.exports = {
 After adding these to your theme you can use them just as with any other utility in your HTML:
 
 ```html
-<h1 class="**text-2xs**">
-  Hello world!
-</h1>
-<span class="**text-10xl**">
+<span class="**text-2xs**">
   Hi world
 </span>
+<h1 class="**text-10xl**">
+  Hello world!
+</h1>
 ```
 
 In some cases, properties map to [variants](https://tailwindcss.com/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -207,30 +207,26 @@ Out of the box, your project will automatically inherit the values from [the def
 
 Most properties under `theme` map to utility classes and any values you add will become available as suffixes for existing utilities. If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `theme.extend` key in your configuration file. Values under this key are merged with existing `theme` values and automatically become available as new classes that you can use.
 
-As an example, here we extend the `fontSize` property to add the classes `text-2xs` and `text-10xl` to change the font size:
+As an example, here we extend the `fontFamily` property to add the `font-display` class that can change the font used on an element:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   theme: {
     extend: {
-      fontSize: {
-        '2xs': '0.625rem', // Adds a new `text-2xs` class
-        '10xl': '10rem', // Adds a new `text-10xl` class
+      fontFamily: {
+        display: 'Oswald, ui-serif', // Adds a new `font-display` class
       }
     }
   }
 }
 ```
 
-After adding these to your theme you can use them just as with any other utility in your HTML:
+After adding this to your theme you can use it just as with any other utility in your HTML:
 
 ```html
-<span class="**text-2xs**">
-  Hi world
-</span>
-<h1 class="**text-10xl**">
-  Hello world!
+<h1 class="**font-display**">
+  This uses the Oswald font
 </h1>
 ```
 

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -223,6 +223,21 @@ module.exports = {
 }
 ```
 
+To use any of the extended values you can call them like you would with a normal one.
+
+Using the example above with the new screens `3xl` property we get:
+
+```html
+<div class="h-full w-full bg-white">
+  <div class="grid h-full w-full grid-cols-1 3xl:grid-cols-3">
+    <div class="h-full w-full bg-blue-200 opacity-75"></div>
+    <div class="hidden h-full w-full bg-red-200 opacity-75 3xl:block"></div>
+    <div class="hidden h-full w-full bg-green-200 opacity-75 3xl:block"></div>
+  </div>
+</div>
+
+```
+
 ### Overriding the default theme
 
 To override an option in the default theme, add your overrides directly under the `theme` section of your `tailwind.config.js`:

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -230,7 +230,7 @@ After adding this to your theme you can use it in your HTML just like any other 
 </h1>
 ```
 
-In some cases, properties map to [variants](/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
+In some cases, properties map to [variants](/docs/hover-focus-and-other-states) that can be placed in front of a utility to conditionally apply its styles. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -234,7 +234,7 @@ After adding these to your theme you can use them just as with any other utility
 </span>
 ```
 
-In some case, properties map to [variants](https://tailwindcss.com/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
+In some cases, properties map to [variants](https://tailwindcss.com/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -223,19 +223,12 @@ module.exports = {
 }
 ```
 
-To use any of the extended values you can call them like you would with a normal one.
-
-Using the example above with the new screens `3xl` property we get:
+Values under the `theme.extend` key are merged with existing `theme` values and automatically become available as new classes that you can use. For example, in the snippet above that adds a new `3xl` screen size, classes can now be prefixed with `3xl:` just like the other responsive variants:
 
 ```html
-<div class="h-full w-full bg-white">
-  <div class="grid h-full w-full grid-cols-1 3xl:grid-cols-3">
-    <div class="h-full w-full bg-blue-200 opacity-75"></div>
-    <div class="hidden h-full w-full bg-red-200 opacity-75 3xl:block"></div>
-    <div class="hidden h-full w-full bg-green-200 opacity-75 3xl:block"></div>
-  </div>
-</div>
-
+<blockquote class="text-base md:text-md **3xl:text-lg**">
+  Oh I gotta get on that internet, I'm late on everything!
+</blockquote>
 ```
 
 ### Overriding the default theme

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -207,7 +207,7 @@ Out of the box, your project will automatically inherit the values from [the def
 
 Most properties under `theme` map to utility classes and any values you add will become available as suffixes for existing utilities. If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `theme.extend` key in your configuration file. Values under this key are merged with existing `theme` values and automatically become available as new classes that you can use.
 
-As an example, here we extend the `fontSize` property to add the classes `font-smol` and `font-reallybig` to change the font size:
+As an example, here we extend the `fontSize` property to add the classes `text-2xs` and `text-10xl` to change the font size:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
@@ -215,8 +215,8 @@ module.exports = {
   theme: {
     extend: {
       fontSize: {
-        smol: '10px', // adds the class `font-smol`
-        reallybig: '96px', // adds the class `font-reallybig`
+        '2xs': '0.625rem', // adds a new `text-2xs` class
+        '10xl': '10rem', // adds a new `text-10xl` class
       }
     }
   }
@@ -226,10 +226,10 @@ module.exports = {
 After adding these to your theme you can use them just as with any other utility in your HTML:
 
 ```html
-<h1 class="**font-reallybig**">
+<h1 class="**text-2xs**">
   Hello world!
 </h1>
-<span class="**font-smol**">
+<span class="**text-10xl**">
   Hi world
 </span>
 ```
@@ -242,14 +242,14 @@ module.exports = {
   theme: {
     extend: {
       screens: {
-        '3xl': '1600px', // adds new utilities prefxied with `3xl:`
+        '3xl': '1600px', // adds a new `3xl:` screen variant
       }
     }
   }
 }
 ```
 
-With this addition to the theme, a new `3xl` screen size is made available alongside the existing screen sizes like `sm`, `md`, `lg`, etc… You can use this new screen size by placing it before the utility name just like any of the existing screen sizes:
+With this addition to the theme, a new `3xl` screen size is made available alongside the existing screen sizes like `sm`, `md`, `lg`, etc. You can use this new screen size by placing it before the utility name just like any of the existing screen sizes:
 
 ```html
 <blockquote class="text-base md:text-md **3xl:text-lg**">

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -245,7 +245,7 @@ module.exports = {
 }
 ```
 
-With this addition to the theme, a new `3xl` screen size is made available alongside the existing screen sizes like `sm`, `md`, `lg`, etc. You can use this new screen size by placing it before the utility name just like any of the existing screen sizes:
+With this addition, a new `3xl` screen size is made available alongside the existing responsive variants like `sm`, `md`, `lg`, etc. You can use this new variant by placing it before a utility class:
 
 ```html
 <blockquote class="text-base md:text-md **3xl:text-lg**">

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -205,25 +205,51 @@ Out of the box, your project will automatically inherit the values from [the def
 
 ### Extending the default theme
 
-If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `extend` key in the `theme` section of your configuration file.
+Most properties under `theme` map to utility classes and any values you add will become available as suffixes for existing utilities. If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `theme.extend` key in your configuration file. Values under this key are merged with existing `theme` values and automatically become available as new classes that you can use.
 
-For example, if you wanted to add an extra breakpoint but preserve the existing ones, you could extend the `screens` property:
+As an example, here we extend the `fontSize` property to add the classes `font-smol` and `font-reallybig` to change the font size:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   theme: {
     extend: {
-      // Adds a new breakpoint in addition to the default breakpoints
-      screens: {
-        '3xl': '1600px',
+      fontSize: {
+        smol: '10px', // adds the class `font-smol`
+        reallybig: '96px', // adds the class `font-reallybig`
       }
     }
   }
 }
 ```
 
-Values under the `theme.extend` key are merged with existing `theme` values and automatically become available as new classes that you can use. For example, in the snippet above that adds a new `3xl` screen size, classes can now be prefixed with `3xl:` just like the other responsive variants:
+After adding these to your theme you can use them just as with any other utility in your HTML:
+
+```html
+<h1 class="**font-reallybig**">
+  Hello world!
+</h1>
+<span class="**font-smol**">
+  Hi world
+</span>
+```
+
+In some case, properties map to [variants](https://tailwindcss.com/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
+
+```js {{ filename: 'tailwind.config.js' }}
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {
+      screens: {
+        '3xl': '1600px', // adds new utilities prefxied with `3xl:`
+      }
+    }
+  }
+}
+```
+
+With this addition to the theme, a new `3xl` screen size is made available alongside the existing screen sizes like `sm`, `md`, `lg`, etc… You can use this new screen size by placing it before the utility name just like any of the existing screen sizes:
 
 ```html
 <blockquote class="text-base md:text-md **3xl:text-lg**">

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -205,7 +205,7 @@ Out of the box, your project will automatically inherit the values from [the def
 
 ### Extending the default theme
 
-Most properties under `theme` map to utility classes and any values you add will become available as suffixes for existing utilities. If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `theme.extend` key in your configuration file. Values under this key are merged with existing `theme` values and automatically become available as new classes that you can use.
+If you'd like to preserve the default values for a theme option but also add new values, add your extensions under the `theme.extend` key in your configuration file. Values under this key are merged with existing `theme` values and automatically become available as new classes that you can use.
 
 As an example, here we extend the `fontFamily` property to add the `font-display` class that can change the font used on an element:
 

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -215,8 +215,8 @@ module.exports = {
   theme: {
     extend: {
       fontSize: {
-        '2xs': '0.625rem', // adds a new `text-2xs` class
-        '10xl': '10rem', // adds a new `text-10xl` class
+        '2xs': '0.625rem', // Adds a new `text-2xs` class
+        '10xl': '10rem', // Adds a new `text-10xl` class
       }
     }
   }
@@ -242,7 +242,7 @@ module.exports = {
   theme: {
     extend: {
       screens: {
-        '3xl': '1600px', // adds a new `3xl:` screen variant
+        '3xl': '1600px', // Adds a new `3xl:` screen variant
       }
     }
   }

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -230,7 +230,7 @@ After adding this to your theme you can use it just as with any other utility in
 </h1>
 ```
 
-In some cases, properties map to [variants](https://tailwindcss.com/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
+In some cases, properties map to [variants](/docs/hover-focus-and-other-states) that can be placed in front of a utility to alter their behavior. For example, to add a `3xl` screen size that works just like the existing responsive screens, add a property under the `screens` key:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */


### PR DESCRIPTION
We talk about how to extend the theme but never discuss how you use the values within it. This PR adds a short snippet to the bottom of the docs discussing this.

Fixes #1571
Supersedes #1663
