### PR TITLE
docs: use 'create' command alias for creation of sveltekit project

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -18,7 +18,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm init svelte@latest my-project\ncd my-project',
+      code: 'npm create svelte@latest my-project\ncd my-project',
     },
   },
   {


### PR DESCRIPTION
[SvelteKit's documentation](https://kit.svelte.dev/docs/creating-a-project) uses `npm create svelte@latest my-app` instead of `npm init svelte@latest my-app`

`npm create` is an [alias](https://docs.npmjs.com/cli/v9/commands/npm-init?v=true) of `npm init`, so this change might not be necessary, but it might be beneficial to be coherent with SvelteKit's documentation.

Regards.