### PR TITLE
Move example below tailwind utilities

### DIFF
--- a/src/pages/docs/adding-custom-styles.mdx
+++ b/src/pages/docs/adding-custom-styles.mdx
@@ -435,13 +435,12 @@ If you want to add some custom CSS that should always be included, add it to you
 ```css {{ filename: 'main.css' }}
 @tailwind base;
 @tailwind components;
+@tailwind utilities;
 
 /* This will always be included in your compiled CSS */
 .card {
   /* ... */
 }
-
-@tailwind utilities;
 ```
 
 Make sure to put your custom styles where they need to go to get the precedence behavior you want. In the example above, we've added the `.card` class before `@tailwind utilities` to make sure utilities can still override it.


### PR DESCRIPTION
If I remember correctly, you had to place custom CSS above utilities. This has changed, and in every other example on this page, the custom css is placed below. Should be the same for this example, to prevent confusion