### PR TITLE
Link `ClassTable` properties to MDN docs

### DIFF
--- a/src/components/ClassTable.js
+++ b/src/components/ClassTable.js
@@ -26,8 +26,15 @@ function renderProperties(
           return (
             <Fragment key={i}>
               {'  '.repeat(indent)}
-              {property}: {transformedValue};
-              {px && <span className="text-indigo-400"> {`/* ${px} */`}</span>}
+              <a
+                className="border-b border-dotted"
+                href={'https://developer.mozilla.org/en-US/docs/Web/CSS/' + property}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {property}
+              </a>
+              : {transformedValue};{px && <span className="text-indigo-400"> {`/* ${px} */`}</span>}
               {'\n'}
             </Fragment>
           )


### PR DESCRIPTION
When I notice some new property I haven't used before but a coworker did I often find myself on tailwind docs and then googling mdn. I thought it would be useful to just be linked there.

This is just a link on the property with a dotted underline. I haven't really tested it and I don't know if it is something you would care for (personally I'd like `mdn`, `caniuse` links to the right of the CSS. Maybe even `caniuse` icons if they have an API, but I kept this simple just to show what I mean).