### PR TITLE
fix: initiate postcss config file

### DIFF
--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {


### PR DESCRIPTION
Some setup instructions include the `-p` flag, but it is missing from the [standard using POSTCSS instructions](https://tailwindcss.com/docs/installation/using-postcss), so this PR adds the flag to initialize that file