### PR TITLE
Laravel Guide: Make including of vite resource more clear

### DIFF
--- a/src/pages/docs/guides/laravel.js
+++ b/src/pages/docs/guides/laravel.js
@@ -110,7 +110,7 @@ let tabs = [
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    @vite('resources/css/app.css')
+>    @vite('resources/css/app.css')
   </head>
   <body>
 >   <h1 class="text-3xl font-bold underline">


### PR DESCRIPTION
While the step description talks about both including the CSS in your head and styling using Tailwind, only the latter is highlighted. This PR solves this to provide more clarity to the reader by making the vite line also highlighted. 