### PR TITLE
Change variant used on `scroll-behavior` docs

### DIFF
--- a/src/pages/docs/overscroll-behavior.mdx
+++ b/src/pages/docs/overscroll-behavior.mdx
@@ -65,7 +65,7 @@ Use `overscroll-auto` to make it possible for the user to continue scrolling a p
 
 ### <Heading ignore>Hover, focus, and other states</Heading>
 
-<HoverFocusAndOtherStates defaultClass="overscroll-auto" featuredClass="overscroll-contain" />
+<HoverFocusAndOtherStates defaultClass="overscroll-auto" featuredClass="overscroll-contain" variant="focus" />
 
 ### <Heading ignore>Breakpoints and media queries</Heading>
 

--- a/src/pages/docs/scroll-behavior.mdx
+++ b/src/pages/docs/scroll-behavior.mdx
@@ -29,7 +29,7 @@ Use the `scroll-smooth` utilities to enable smooth scrolling within an element.
 
 ### <Heading ignore>Hover, focus, and other states</Heading>
 
-<HoverFocusAndOtherStates defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" />
+<HoverFocusAndOtherStates defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" variant="focus" />
 
 ### <Heading ignore>Breakpoints and media queries</Heading>
 

--- a/src/pages/docs/scroll-behavior.mdx
+++ b/src/pages/docs/scroll-behavior.mdx
@@ -27,6 +27,10 @@ Use the `scroll-smooth` utilities to enable smooth scrolling within an element.
 
 ## <Heading ignore>Applying conditionally</Heading>
 
+### <Heading ignore>Hover, focus, and other states</Heading>
+
+<HoverFocusAndOtherStates defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" />
+
 ### <Heading ignore>Breakpoints and media queries</Heading>
 
 <BreakpointsAndMediaQueries defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" />

--- a/src/pages/docs/scroll-behavior.mdx
+++ b/src/pages/docs/scroll-behavior.mdx
@@ -27,10 +27,6 @@ Use the `scroll-smooth` utilities to enable smooth scrolling within an element.
 
 ## <Heading ignore>Applying conditionally</Heading>
 
-### <Heading ignore>Hover, focus, and other states</Heading>
-
-<HoverFocusAndOtherStates defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" />
-
 ### <Heading ignore>Breakpoints and media queries</Heading>
 
 <BreakpointsAndMediaQueries defaultClass="scroll-smooth" featuredClass="scroll-auto" element="html" />


### PR DESCRIPTION
I think this help text is misleading for this component. at least the hover state makes no sense in my opinion and lead to confusions. maybe remove that for this component?

the html container will have always a hover state if someone clicks anywhere in the content of the page. so the first style will never apply? maybe I am incorrect. No hard feeling if the MR get's closed :)
At least I was quite confused and I think this is only added, because lots of the help-pages have the states. 
Thx!