### PR TITLE
docs: Add error page path for nuxtjs guide

### DIFF
--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -83,6 +83,7 @@ let tabs = [
 >     "./pages/**/*.vue",
 >     "./plugins/**/*.{js,ts}",
 >     "./app.vue",
+>     "./error.vue",
 >   ],
     theme: {
       extend: {},


### PR DESCRIPTION
The file path `error.vue` does't exist in the tailwind configuration file for [nuxtjs](https://nuxt.com)
So I add it

`error.vue` file:
https://nuxt.com/docs/getting-started/error-handling#rendering-an-error-page

Example:
https://nuxt.com/docs/getting-started/error-handling#example