### PR TITLE
Update flex-direction.mdx

### DIFF
--- a/src/pages/docs/flex-direction.mdx
+++ b/src/pages/docs/flex-direction.mdx
@@ -16,7 +16,7 @@ export const classes = { utilities }
 Use `flex-row` to position flex items horizontally in the same direction as text:
 
 ```html {{ example: true }}
-<div class="flex flex-row space-x-4 font-mono text-white text-sm font-bold leading-6">
+<div class="flex flex-row gap-x-4 font-mono text-white text-sm font-bold leading-6">
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">01</div>
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">02</div>
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-fuchsia-500 shadow-lg">03</div>
@@ -36,7 +36,7 @@ Use `flex-row` to position flex items horizontally in the same direction as text
 Use `flex-row-reverse` to position flex items horizontally in the opposite direction:
 
 ```html {{ example: true }}
-<div class="flex flex-row-reverse space-x-reverse space-x-4 font-mono text-white text-sm font-bold leading-6">
+<div class="flex flex-row-reverse space-x-reverse gap-x-4 font-mono text-white text-sm font-bold leading-6">
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">01</div>
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">02</div>
   <div class="w-14 h-14 rounded-lg flex items-center justify-center bg-blue-500 shadow-lg">03</div>


### PR DESCRIPTION
Replaced space by gap as suggested in https://tailwindcss.com/docs/space to ensure a correct gap if the page's direction is set to rtl.