### PR TITLE
Update scroll-margin.mdx

### DIFF
--- a/src/pages/docs/scroll-margin.mdx
+++ b/src/pages/docs/scroll-margin.mdx
@@ -105,23 +105,23 @@ Use the `scroll-ms-*` and `scroll-me-*` utilities to set the `scroll-margin-inli
 </div>
 <p class="mb-4 mt-4 pl-6 text-sm font-medium">Right-to-left</p>
 <div class="w-full flex gap-12 snap-x overflow-x-auto pb-10" dir="rtl">
-  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pr-[calc(100%-21.5rem)]">
+  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pl-[calc(100%-21.5rem)]">
     <div class="bg-stripes-pink w-6 absolute top-0 start-0 bottom-0"></div>
     <img class="relative shrink-0 w-80 h-40 rounded-lg shadow-xl bg-white" src="https://images.unsplash.com/photo-1604999565976-8913ad2ddb7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80" />
   </div>
-  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pr-[calc(100%-21.5rem)]">
+  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pl-[calc(100%-21.5rem)]">
     <div class="bg-stripes-pink w-6 absolute top-0 -start-6 bottom-0"></div>
     <img class="relative shrink-0 w-80 h-40 rounded-lg shadow-xl bg-white" src="https://images.unsplash.com/photo-1540206351-d6465b3ac5c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80" />
   </div>
-  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pr-[calc(100%-21.5rem)]">
+  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pl-[calc(100%-21.5rem)]">
     <div class="bg-stripes-pink w-6 absolute top-0 -start-6 bottom-0"></div>
     <img class="relative shrink-0 w-80 h-40 rounded-lg shadow-xl bg-white" src="https://images.unsplash.com/photo-1622890806166-111d7f6c7c97?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80" />
   </div>
-  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pr-[calc(100%-21.5rem)]">
+  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pl-[calc(100%-21.5rem)]">
     <div class="bg-stripes-pink w-6 absolute top-0 -start-6 bottom-0"></div>
     <img class="relative shrink-0 w-80 h-40 rounded-lg shadow-xl bg-white" src="https://images.unsplash.com/photo-1590523277543-a94d2e4eb00b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80" />
   </div>
-  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pr-[calc(100%-21.5rem)]">
+  <div class="snap-start scroll-ms-6 shrink-0 relative first:ps-6 last:pl-[calc(100%-21.5rem)]">
     <div class="bg-stripes-pink w-6 absolute top-0 -start-6 bottom-0"></div>
     <img class="relative shrink-0 w-80 h-40 rounded-lg shadow-xl bg-white" src="https://images.unsplash.com/photo-1575424909138-46b05e5919ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80" />
   </div>


### PR DESCRIPTION
`last:pr-[calc(100%-21.5rem)]` should be `last:pl-[calc(100%-21.5rem)]` (for left margin) on the right-to-left example. However, this will not work if the class isn't created during build time, hence why the fix doesn't show when using developer tools in the DOM. 