### PR TITLE
Add missing `g` flag in custom extraction example

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -519,7 +519,7 @@ module.exports = {
     files: ['./src/**/*.{html,wtf}'],
     extract: {
       wtf: (content) => {
-        return content.match(/[^<>"'`\s]*/)
+        return content.match(/[^<>"'`\s]*/g)
       }
     }
   },


### PR DESCRIPTION
The example extraction regex is missing the `g` flag, so it currently only finds the fix match. Add `g` so it find all matches in `content`.