### PR TITLE
Fix custom opacity notation in opacity.mdx

### DIFF
--- a/src/pages/docs/opacity.mdx
+++ b/src/pages/docs/opacity.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Changing an element's opacity
 
-Control the opacity of an element using the `opacity-{amount}` utilities.
+Control the opacity of an element using the `opacity-[amount]` utilities.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-16 text-white text-sm font-bold leading-6">


### PR DESCRIPTION
<img width="239" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/1936984/befdda5a-22c8-4263-9afa-d8897b04f0a9">
<img width="510" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/1936984/6b1f63d5-4331-4d10-b11b-b59dacf5023c">

######################################

<img width="505" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/1936984/9dc06247-7fb7-4f63-a560-765cc0819fbf">
<img width="265" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/1936984/a4afbeca-b85b-4606-ae67-7c982d51f3a6">
