### PR TITLE
Update browser-support.mdx

### DIFF
--- a/src/pages/docs/browser-support.mdx
+++ b/src/pages/docs/browser-support.mdx
@@ -19,8 +19,8 @@ Many CSS properties require vendor prefixes to be understood by browsers, for ex
 
 ```css
 .bg-clip-text {
-  background-clip: text;
   -webkit-background-clip: text;
+  background-clip: text;
 }
 ```
 


### PR DESCRIPTION
Correct the order of CSS properties output by autoprefixer (it puts the prefixed properties first).