### PR TITLE
Document how to load the Prettier plugin

### DIFF
--- a/src/pages/blog/automatic-class-sorting-with-prettier/index.mdx
+++ b/src/pages/blog/automatic-class-sorting-with-prettier/index.mdx
@@ -25,13 +25,21 @@ This plugin scans your templates for class attributes containing Tailwind CSS cl
 
 It works seamlessly with custom Tailwind configurations, and because it's just a [Prettier](https://prettier.io/) plugin, it works anywhere Prettier works — including every popular editor and IDE, and of course on the command line.
 
-To get started, just install `prettier-plugin-tailwindcss` as a dev-dependency:
+To get started, install `prettier-plugin-tailwindcss` as a dev-dependency:
 
 ```sh {{ filename: 'Terminal' }}
 npm install -D prettier prettier-plugin-tailwindcss
 ```
 
-This plugin follows Prettier's [autoloading convention](https://prettier.io/docs/en/plugins.html), so as long as you've got Prettier set up in your project, it'll start working automatically as soon as it's installed.
+Then add the plugin to your [Prettier configuration file](https://prettier.io/docs/en/configuration):
+
+```json {{ filename: '.prettierrc' }}
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}
+```
+
+You can also [load the plugin by using the `--plugin` flag with the Prettier CLI, or by using the `plugins` option with the Prettier API](https://prettier.io/docs/en/plugins.html#using-plugins).
 
 ---
 


### PR DESCRIPTION
As of v3, Prettier [no longer autoloads plugins](https://prettier.io/blog/2023/07/05/3.0.0.html#plugin-search-feature-has-been-removed-14759httpsgithubcomprettierprettierpull14759-by-fiskerhttpsgithubcomfisker).