### PR TITLE
Corrected class order in documentation of !important utility

### DIFF
--- a/src/pages/docs/configuration.mdx
+++ b/src/pages/docs/configuration.mdx
@@ -443,7 +443,7 @@ When using the selector strategy, be sure that the template file that includes y
 Alternatively, you can make any utility important by adding a `!` character to the beginning:
 
 ```html
-<p class="font-bold !font-medium">
+<p class="!font-medium font-bold">
   This will be medium even though bold comes later in the CSS.
 </p>
 ```


### PR DESCRIPTION
The text states that bold comes later than medium in the css, but the order in the code was the reverse. Tailwind gives preference to the later declaration, so font-bold should be after !font-medium. Now the example matches the text.