### PR TITLE
Document Forced Colors 

### DIFF
--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -226,7 +226,7 @@ export const documentationNav = {
     pages['will-change'],
   ],
   SVG: [pages['fill'], pages['stroke'], pages['stroke-width']],
-  Accessibility: [pages['screen-readers']],
+  Accessibility: [pages['screen-readers'], pages['forced-color-adjust']],
   'Official Plugins': [
     pages['typography-plugin'],
     {

--- a/src/pages/docs/forced-color-adjust.mdx
+++ b/src/pages/docs/forced-color-adjust.mdx
@@ -1,0 +1,120 @@
+---
+title: "Forced Color Adjust"
+description: "Utilities for adjusting the appearance of forced color modes"
+---
+
+import utilities from 'utilities?plugin=forced-color-adjust'
+import { ArbitraryValues } from '@/components/ArbitraryValues'
+import { BreakpointsAndMediaQueries } from '@/components/BreakpointsAndMediaQueries'
+import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
+
+export const classes = { utilities }
+
+## Basic usage
+
+### Opting out of forced color modes
+
+Use `forced-color-adjust-none` to opt an element out of the user defined color palette enforced by [forced colors mode](/docs/examples/hover-focus-and-other-states#forced-colors-mode).
+
+```html {{ example: { hint: 'Try emulating &#96;forced-colors: active&#96; in your developer tools to see the changes' }}}
+<div class="mx-auto max-w-sm overflow-clip rounded-lg bg-white shadow">
+  <div class="aspect-h-3 aspect-w-3 overflow-hidden">
+    <img src="https://tailwindui.com/img/ecommerce-images/shopping-cart-page-01-product-02.jpg" alt="Two each of gray, white, and black shirts laying flat." class="h-full w-full object-cover object-center" />
+  </div>
+  <div class="grid grid-cols-[1fr_auto] items-center gap-4 p-4">
+    <div>
+      <h3 class="font-medium text-gray-900">Basic Tee</h3>
+      <h3 class="text-sm font-medium text-gray-900">$35</h3>
+    </div>
+    <fieldset>
+      <legend class="sr-only">Choose a color</legend>
+      <div class="forced-color-adjust-none grid grid-flow-col items-center gap-3">
+        <label class="has-[:checked]:ring-gray-400 has-[:checked]:ring-1 has-[:checked]:ring-offset-1 relative -m-0.5 flex cursor-pointer items-center justify-center rounded-full p-0.5 ring-0 focus:outline-none">
+          <input type="radio" name="color-choice" value="White" class="sr-only" aria-labelledby="color-choice-0-label" />
+          <span id="color-choice-0-label" class="sr-only">White</span>
+          <span aria-hidden="true" class="size-6 rounded-full border border-black border-opacity-10 bg-white"></span>
+        </label>
+        <label class="has-[:checked]:ring-gray-400 has-[:checked]:ring-1 has-[:checked]:ring-offset-1 relative -m-0.5 flex cursor-pointer items-center justify-center rounded-full p-0.5 ring-0 focus:outline-none">
+          <input type="radio" checked name="color-choice" value="Gray" class="sr-only" />
+          <span id="color-choice-1-label" class="sr-only">Gray</span>
+          <span aria-hidden="true" class="size-6 rounded-full border border-black border-opacity-10 bg-gray-200"></span>
+        </label>
+        <label class="has-[:checked]:ring-gray-900 has-[:checked]:ring-1 has-[:checked]:ring-offset-1 relative -m-0.5 flex cursor-pointer items-center justify-center rounded-full p-0.5 ring-0 focus:outline-none">
+          <input type="radio" name="color-choice" value="Black" class="sr-only" aria-labelledby="color-choice-2-label" />
+          <span id="color-choice-2-label" class="sr-only">Black</span>
+          <span aria-hidden="true" class="size-6 rounded-full border border-black border-opacity-10 bg-gray-900"></span>
+        </label>
+      </div>
+    </fieldset>
+  </div>
+</div>
+```
+
+```html
+<form>
+  <img src="..." />
+  <div>
+    <h3>Basic Tee</h3>
+    <h3>$35</h3>
+    <fieldset>
+      <legend class="sr-only">Choose a color</legend>
+      <div class="**forced-color-adjust-none** ...">
+        <label >
+          <input class="sr-only" type="radio" name="color-choice" value="White" />
+          <span class="sr-only">White</span>
+          <span class="size-6 rounded-full border border-black border-opacity-10 bg-white"></span>
+        </label>
+        <!-- ... -->
+      </div>
+    </fieldset>
+</form>
+```
+
+This utility is useful in situations where enforcing a limited color palette will seriously degrade usability.
+
+
+### Reverting to user preferences
+
+Use `forced-color-adjust-auto` to undo `forced-color-adjust-none`, making an element adhere to the user defined color palette enforced by forced colors mode. 
+
+This can be useful if you use a different control on a larger screen size for example: 
+
+```html
+<form>
+  <fieldset class="forced-color-adjust-none lg:**forced-color-adjust-auto** ...">
+    <legend>Choose a color:</legend>
+    <select class="hidden lg:block">
+      <option value="White">White</option>
+      <option value="Gray">Gray</option>
+      <option value="Black">Black</option>
+    </select>
+    <div class="lg:hidden">
+      <label>
+        <input class="sr-only" type="radio" name="color-choice" value="White" />
+        <!-- ... -->
+      </label>
+      <!-- ... -->
+    </div>
+  </fieldset>
+</form>
+```
+
+---
+
+## <Heading ignore>Applying conditionally</Heading>
+
+### <Heading ignore>Hover, focus, and other states</Heading>
+
+<HoverFocusAndOtherStates featuredClass="forced-color-adjust-none" variant="focus">
+
+```html
+<a href="#content" class="forced-color-adjust-none **focus:forced-color-adjust-auto**">
+  Skip to content
+</a>
+```
+
+</HoverFocusAndOtherStates>
+
+### <Heading ignore>Breakpoints and media queries</Heading>
+
+<BreakpointsAndMediaQueries defaultClass="forced-color-adjust-none" featuredClass="forced-color-adjust-auto" />

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1072,9 +1072,6 @@ Use the `forced-colors` modifier to conditionally add styles when the user has e
         </div>
       </label>
     </div>
-    <!-- <div class="mt-4 hidden h-16 w-full items-center justify-center rounded-lg border border-slate-200 forced-colors:flex">
-      <p>Never mind.</p>
-    </div> -->
   </form>
 </div>
 ```

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1022,19 +1022,46 @@ Tailwind also includes a `contrast-less` modifier you can use to conditionally a
 
 ### Forced colors mode
 
-The `forced-colors` media query tells you if the user is using a forced colors mode. In forced color modes your site's colors will be overridden by a user defined palette for text, backgrounds, links and buttons.
+The `forced-colors` media query indicates if the user is using a forced colors mode. These modes override your site's colors with a user defined palette for text, backgrounds, links and buttons.
 
 Use the `forced-colors` modifier to conditionally add styles when the user has enabled a forced color mode:
 
-```html {{ example: { p: 'none', hint: 'Try emulating &#96;prefers-contrast: more&#96; in your developer tools to see the changes' } }}
+```html {{ example: { p: 'none', hint: 'Try emulating &#96;forced-colors: active&#96; in your developer tools to see the changes' } }}
 <div class="max-w-sm mx-auto bg-white shadow pt-6 pb-4 px-6">
   <form>
-    <div>
-      <label for="contrast-example" class="block text-sm font-medium text-slate-700">Social Security Number</label>
-      <div class="mt-1">
-        <input type="text" name="contrast-example" id="contrast-example" class="px-3 py-2 bg-white border shadow-sm border-slate-200 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1 contrast-more:border-slate-400 contrast-more:placeholder-slate-500"  placeholder="000-00-0000" />
-        <p class="mt-2 text-sm text-slate-600 opacity-10 forced-colors:opacity-100 forced-color-adjust-none">We need this to steal your identity.</p>
-      </div>
+    <legend> Choose a theme: </legend>
+    <div class="grid grid-flow-col mt-4 forced-colors:hidden">
+      <label for="theme-1" class="text-sm font-medium text-slate-700">
+        <input type="radio" name="themes" id="theme-1" class="peer sr-only" checked />
+        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-cyan-500 peer-checked:bg-cyan-50 peer-checked:text-cyan-50">
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-cyan-200"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-cyan-500 ring-2 ring-current"></div>
+        </div>
+      </label>
+      <label for="theme-2" class="text-sm font-medium text-slate-700">
+        <input type="radio" name="themes" id="theme-2" class="peer sr-only" />
+        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-blue-500 peer-checked:bg-blue-50 peer-checked:text-blue-50">
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-blue-200"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-blue-500 ring-2 ring-current"></div>
+        </div>
+      </label>
+      <label for="theme-3" class="text-sm font-medium text-slate-700">
+        <input type="radio" name="themes" id="theme-3" class="peer sr-only" />
+        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-indigo-500 peer-checked:bg-indigo-50 peer-checked:text-indigo-50">
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-indigo-200"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-indigo-500 ring-2 ring-current"></div>
+        </div>
+      </label>
+      <label for="theme-4" class="text-sm font-medium text-slate-700">
+        <input type="radio" name="themes" id="theme-4" class="peer sr-only" />
+        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-purple-500 peer-checked:bg-purple-50 peer-checked:text-purple-50">
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-purple-200"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-purple-500 ring-2 ring-current"></div>
+        </div>
+      </label>
+    </div>
+    <div class="mt-4 hidden h-16 w-full items-center justify-center rounded-lg border border-slate-200 forced-colors:flex">
+      <p>Never mind.</p>
     </div>
   </form>
 </div>
@@ -1042,13 +1069,13 @@ Use the `forced-colors` modifier to conditionally add styles when the user has e
 
 ```html
 <form>
-  <label class="block">
-    <span class="block text-sm font-medium text-slate-700">Social Security Number</span>
-    <input class="border-slate-200 placeholder-slate-400 **contrast-more:border-slate-400** **contrast-more:placeholder-slate-500**"/>
-    <p class="mt-2 opacity-10 **contrast-more:opacity-100** text-slate-600 text-sm">
-      We need this to steal your identity.
-    </p>
-  </label>
+  <legend> Choose a theme: </legend>
+  <div class="... grid **forced-colors:hidden**">
+    <!-- ... -->
+  </div>
+  <div class="... hidden **forced-colors:flex**">
+    <p>Never mind.</p>
+  </div>
 </form>
 ```
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -999,7 +999,7 @@ Use the `contrast-more` modifier to conditionally add styles when the user has r
       <label for="contrast-example" class="block text-sm font-medium text-slate-700">Social Security Number</label>
       <div class="mt-1">
         <input type="text" name="contrast-example" id="contrast-example" class="px-3 py-2 bg-white border shadow-sm border-slate-200 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1 contrast-more:border-slate-400 contrast-more:placeholder-slate-500"  placeholder="000-00-0000" />
-        <p class="mt-2 text-sm text-slate-600 opacity-10 contrast-more:opacity-100">We need this to steal your identity.</p>
+        <p class="mt-2 text-sm text-slate-600 opacity-10 contrast-more:opacity-100 ">We need this to steal your identity.</p>
       </div>
     </div>
   </form>
@@ -1019,6 +1019,40 @@ Use the `contrast-more` modifier to conditionally add styles when the user has r
 ```
 
 Tailwind also includes a `contrast-less` modifier you can use to conditionally add styles when the user has requested less contrast.
+
+### Forced colors mode
+
+The `forced-colors` media query tells you if the user is using a forced colors mode. In forced color modes your site's colors will be overridden by a user defined palette for text, backgrounds, links and buttons.
+
+Use the `forced-colors` modifier to conditionally add styles when the user has enabled a forced color mode:
+
+```html {{ example: { p: 'none', hint: 'Try emulating &#96;prefers-contrast: more&#96; in your developer tools to see the changes' } }}
+<div class="max-w-sm mx-auto bg-white shadow pt-6 pb-4 px-6">
+  <form>
+    <div>
+      <label for="contrast-example" class="block text-sm font-medium text-slate-700">Social Security Number</label>
+      <div class="mt-1">
+        <input type="text" name="contrast-example" id="contrast-example" class="px-3 py-2 bg-white border shadow-sm border-slate-200 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1 contrast-more:border-slate-400 contrast-more:placeholder-slate-500"  placeholder="000-00-0000" />
+        <p class="mt-2 text-sm text-slate-600 opacity-10 forced-colors:opacity-100 forced-color-adjust-none">We need this to steal your identity.</p>
+      </div>
+    </div>
+  </form>
+</div>
+```
+
+```html
+<form>
+  <label class="block">
+    <span class="block text-sm font-medium text-slate-700">Social Security Number</span>
+    <input class="border-slate-200 placeholder-slate-400 **contrast-more:border-slate-400** **contrast-more:placeholder-slate-500**"/>
+    <p class="mt-2 opacity-10 **contrast-more:opacity-100** text-slate-600 text-sm">
+      We need this to steal your identity.
+    </p>
+  </label>
+</form>
+```
+
+Tailwind also includes a `forced-color-adjust-none` modifier you can use to opt certain elements out of forced color modes, as well as `forced-color-adjust-auto` to set elements back to the user preference.
 
 ### Viewport orientation
 

--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1030,39 +1030,51 @@ Use the `forced-colors` modifier to conditionally add styles when the user has e
 <div class="max-w-sm mx-auto bg-white shadow pt-6 pb-4 px-6">
   <form>
     <legend> Choose a theme: </legend>
-    <div class="grid grid-flow-col mt-4 forced-colors:hidden">
+    <div class="grid grid-flow-col mt-4 ">
       <label for="theme-1" class="text-sm font-medium text-slate-700">
-        <input type="radio" name="themes" id="theme-1" class="peer sr-only" checked />
-        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-cyan-500 peer-checked:bg-cyan-50 peer-checked:text-cyan-50">
-          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-cyan-200"></div>
-          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-cyan-500 ring-2 ring-current"></div>
+        <div class="relative h-16 w-16 rounded-xl forced-colors:border-0 bg-transparent border border-transparent text-white hover:bg-slate-50 has-[:checked]:border-cyan-500 has-[:checked]:bg-cyan-50 has-[:checked]:text-cyan-50 grid items-center justify-center">
+          <input type="radio" name="themes" id="theme-1" class="forced-colors:appearance-auto appearance-none" checked />
+          <p class="forced-colors:block hidden">
+            Cyan
+          </p>
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-cyan-200 forced-colors:hidden"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-cyan-500 ring-2 ring-current forced-colors:hidden"></div>
         </div>
       </label>
       <label for="theme-2" class="text-sm font-medium text-slate-700">
-        <input type="radio" name="themes" id="theme-2" class="peer sr-only" />
-        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-blue-500 peer-checked:bg-blue-50 peer-checked:text-blue-50">
-          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-blue-200"></div>
-          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-blue-500 ring-2 ring-current"></div>
+        <div class="relative h-16 w-16 rounded-xl forced-colors:border-0 bg-transparent border border-transparent text-white hover:bg-slate-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-50 grid items-center justify-center">
+          <input type="radio" name="themes" id="theme-2" class="forced-colors:appearance-auto appearance-none" />
+          <p class="forced-colors:block hidden">
+            Blue
+          </p>
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-blue-200 forced-colors:hidden"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-blue-500 ring-2 ring-current forced-colors:hidden"></div>
         </div>
       </label>
       <label for="theme-3" class="text-sm font-medium text-slate-700">
-        <input type="radio" name="themes" id="theme-3" class="peer sr-only" />
-        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-indigo-500 peer-checked:bg-indigo-50 peer-checked:text-indigo-50">
-          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-indigo-200"></div>
-          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-indigo-500 ring-2 ring-current"></div>
+        <div class="relative h-16 w-16 rounded-xl forced-colors:border-0 border bg-transparent border-transparent text-white hover:bg-slate-50 has-[:checked]:border-indigo-500 has-[:checked]:bg-indigo-50 has-[:checked]:text-indigo-50 grid items-center justify-center">
+          <input type="radio" name="themes" id="theme-3" class="forced-colors:appearance-auto appearance-none" />
+          <p class="forced-colors:block hidden">
+            Indigo
+          </p>
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-indigo-200  forced-colors:hidden"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-indigo-500 ring-2 ring-current forced-colors:hidden"></div>
         </div>
       </label>
       <label for="theme-4" class="text-sm font-medium text-slate-700">
-        <input type="radio" name="themes" id="theme-4" class="peer sr-only" />
-        <div class="relative h-16 w-16 rounded-xl border border-transparent text-white hover:bg-slate-50 peer-checked:border-purple-500 peer-checked:bg-purple-50 peer-checked:text-purple-50">
-          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-purple-200"></div>
-          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-purple-500 ring-2 ring-current"></div>
+        <div class="relative h-16 w-16 rounded-xl forced-colors:border-0 border bg-transparent border-transparent text-white hover:bg-slate-50 has-[:checked]:border-purple-500 has-[:checked]:bg-purple-50 has-[:checked]:text-purple-50 grid items-center justify-center">
+          <input type="radio" name="themes" id="theme-4" class="forced-colors:appearance-auto appearance-none" />
+          <p class="forced-colors:block hidden">
+            Purple
+          </p>
+          <div class="absolute left-3 top-3 h-6 w-6 rounded-full bg-purple-200 forced-colors:hidden"></div>
+          <div class="absolute bottom-3 right-3 h-6 w-6 rounded-full bg-purple-500 ring-2 ring-current forced-colors:hidden"></div>
         </div>
       </label>
     </div>
-    <div class="mt-4 hidden h-16 w-full items-center justify-center rounded-lg border border-slate-200 forced-colors:flex">
+    <!-- <div class="mt-4 hidden h-16 w-full items-center justify-center rounded-lg border border-slate-200 forced-colors:flex">
       <p>Never mind.</p>
-    </div>
+    </div> -->
   </form>
 </div>
 ```
@@ -1070,12 +1082,15 @@ Use the `forced-colors` modifier to conditionally add styles when the user has e
 ```html
 <form>
   <legend> Choose a theme: </legend>
-  <div class="... grid **forced-colors:hidden**">
-    <!-- ... -->
-  </div>
-  <div class="... hidden **forced-colors:flex**">
-    <p>Never mind.</p>
-  </div>
+  <label>
+    <input type="radio" class="**forced-colors:appearance-auto** appearance-none" />
+    <p class="**forced-colors:block** hidden">
+      Cyan
+    </p>
+    <div class="**forced-colors:hidden** h-6 w-6 rounded-full bg-cyan-200 ..."></div>
+    <div class="**forced-colors:hidden** h-6 w-6 rounded-full bg-cyan-500 ..."></div>
+  </label>
+  <!-- ... -->
 </form>
 ```
 


### PR DESCRIPTION
Adds documentation for  the `forced-colors` modifier as well as `forced-color-adjust-none` and `forced-color-adjust-auto`

https://tailwindcss-com-git-document-forced-colors-tailwindlabs.vercel.app/docs/hover-focus-and-other-states#forced-colors-mode
<img width="804" alt="Screenshot 2023-12-11 at 19 38 55" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/de03f0a1-cc9e-48d3-9018-26f968e9ed92">
<img width="837" alt="Screenshot 2023-12-11 at 19 39 13" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/8c6751fe-661d-4af3-abe1-1135149f6f41">
