### PR TITLE
Documents min/max height/width scales

### DIFF
--- a/src/pages/docs/max-height.mdx
+++ b/src/pages/docs/max-height.mdx
@@ -18,19 +18,7 @@ export const classes = {
 
 ### Setting the maximum height
 
-Set the maximum height of an element using the `max-h-full` or `max-h-screen` utilities.
-
-```html
-<div class="h-24 ...">
-  <div class="h-48 **max-h-full** ...">
-    <!-- ... -->
-  </div>
-</div>
-```
-
-### Fixed maximum heights
-
-Use `max-h-{number}` to set an element to a fixed maximum height based on the default spacing scale.
+Set the minimum height of an element using `max-h-{height}` or `max-h-{number}` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white">
@@ -41,45 +29,52 @@ Use `max-h-{number}` to set an element to a fixed maximum height based on the de
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-80 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-80</div>
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-64 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-64</div>
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-48 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-48</div>
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-40 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-40</div>
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-32 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-32</div>
       </div>
     </div>
   </div>
-    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
     <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-24 relative">
       <div class="absolute w-8 text-nowrap bottom-6">
         <div class="-rotate-90">max-h-24</div>
+      </div>
+    </div>
+  </div>
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-full relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-full</div>
       </div>
     </div>
   </div>
@@ -88,13 +83,14 @@ Use `max-h-{number}` to set an element to a fixed maximum height based on the de
 
 ```html
 <div class="flex items-end ...">
-  <div class="h-full **max-h-96** ...">min-h-96</div>
-  <div class="h-full **max-h-80** ...">min-h-80</div>
-  <div class="h-full **max-h-64** ...">min-h-64</div>
-  <div class="h-full **max-h-48** ...">min-h-48</div>
-  <div class="h-full **max-h-40** ...">min-h-40</div>
-  <div class="h-full **max-h-32** ...">min-h-32</div>
-  <div class="h-full **max-h-24** ...">min-h-24</div>
+  <div class="h-full **max-h-96** ...">max-h-96</div>
+  <div class="h-full **max-h-80** ...">max-h-80</div>
+  <div class="h-full **max-h-64** ...">max-h-64</div>
+  <div class="h-full **max-h-48** ...">max-h-48</div>
+  <div class="h-full **max-h-40** ...">max-h-40</div>
+  <div class="h-full **max-h-32** ...">max-h-32</div>
+  <div class="h-full **max-h-24** ...">max-h-24</div>
+  <div class="h-full **max-h-full** ...">max-h-full</div>
 </div>
 ```
 

--- a/src/pages/docs/max-height.mdx
+++ b/src/pages/docs/max-height.mdx
@@ -28,6 +28,76 @@ Set the maximum height of an element using the `max-h-full` or `max-h-screen` ut
 </div>
 ```
 
+### Fixed maximum heights
+
+Use `max-h-{number}` to set an element to a fixed maximum height based on the default spacing scale.
+
+```html {{ example: true }}
+<div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white">
+  <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-96 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-96</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-80 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-80</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-64 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-64</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-48 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-48</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-40 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-40</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-32 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-32</div>
+      </div>
+    </div>
+  </div>
+    <div class="w-8 grid items-end bg-stripes-blue rounded-lg h-96 ">
+    <div class="w-full bg-blue-500 rounded-lg shadow-lg h-full max-h-24 relative">
+      <div class="absolute w-8 text-nowrap bottom-6">
+        <div class="-rotate-90">max-h-24</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+```html
+<div class="flex items-end ...">
+  <div class="h-full **max-h-96** ...">min-h-96</div>
+  <div class="h-full **max-h-80** ...">min-h-80</div>
+  <div class="h-full **max-h-64** ...">min-h-64</div>
+  <div class="h-full **max-h-48** ...">min-h-48</div>
+  <div class="h-full **max-h-40** ...">min-h-40</div>
+  <div class="h-full **max-h-32** ...">min-h-32</div>
+  <div class="h-full **max-h-24** ...">min-h-24</div>
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>
@@ -46,7 +116,7 @@ Set the maximum height of an element using the `max-h-full` or `max-h-screen` ut
 
 ### Customizing your theme
 
-By default, Tailwind's max-height scale uses a combination of the [default spacing scale](/docs/customizing-spacing) as well as some additional height related values.
+By default, Tailwind's minimum height scale is a combination of the [default spacing scale](/docs/customizing-spacing#default-spacing-scale) as well as some additional values specific to heights.
 
 You can customize your spacing scale by editing `theme.spacing` or `theme.extend.spacing` in your `tailwind.config.js` file.
 
@@ -62,7 +132,7 @@ You can customize your spacing scale by editing `theme.spacing` or `theme.extend
   }
 ```
 
-Alternatively, you can customize just the max-height scale by editing `theme.maxHeight` or `theme.extend.maxHeight` in your `tailwind.config.js` file.
+To customize `max-height` separately, use the `theme.minHeight` section of your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
@@ -80,4 +150,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="max-height" featuredClass="max-h-[32rem]" />
+<ArbitraryValues property="max-height" featuredClass="max-h-[220px]" />

--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -25,7 +25,7 @@ Set the maximum width of an element using the `max-w-{size}` utilities.
   <img class="absolute -left-6 w-28 h-28 rounded-full shadow-lg" src="https://images.unsplash.com/photo-1501196354995-cbb51c65aaea?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=4&w=256&h=256&q=80" />
   <div class="min-w-0 py-5 pl-28 pr-5">
     <div class="text-slate-900 font-medium text-sm sm:text-base truncate dark:text-slate-200">Andrew Alfred</div>
-    <div class="text-slate-500 font-medium text-sm sm:text-base leading-tight truncate dark:text-slate-400">Assistant to the Traveling Secretary</div>
+    <div class="text-slate-500 text-sm sm:text-base leading-tight truncate dark:text-slate-400">Assistant to the Traveling Secretary</div>
   </div>
 </div>
 ```

--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -36,6 +36,48 @@ Set the maximum width of an element using the `max-w-{size}` utilities.
 </div>
 ```
 
+### Fixed maximum widths
+
+Use `max-w-{number}` to set an element to a fixed maximum width based on the default spacing scale.
+
+```html {{ example: { resizable: true }, }}
+<div class="grid gap-4 font-mono font-bold text-xs text-center text-white align-start  ">
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+        <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-96 hidden sm:block">max-w-96</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-80 hidden sm:block">max-w-80</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-64 hidden sm:block">max-w-64</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-48">max-w-48</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-40">max-w-40</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-32">max-w-32</div>
+    </div>
+    <div class="grid bg-stripes-blue w-full rounded-lg">
+      <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg max-w-24">max-w-24</div>
+    </div>
+</div>
+```
+
+```html
+<div>
+  <div class="w-full **max-w-96** ...">max-w-96</div>
+  <div class="w-full **max-w-80** ...">max-w-80</div>
+  <div class="w-full **max-w-64** ...">max-w-64</div>
+  <div class="w-full **max-w-48** ...">max-w-48</div>
+  <div class="w-full **max-w-40** ...">max-w-40</div>
+  <div class="w-full **max-w-32** ...">max-w-32</div>
+  <div class="w-full **max-w-24** ...">max-w-24</div>
+</div>
+```
+
 ### Reading width
 
 The `max-w-prose` utility gives an element a max-width optimized for readability and adapts based on the font size.
@@ -104,23 +146,36 @@ The `max-w-screen-{breakpoint}` classes can be used to give an element a max-wid
 ## Using custom values
 
 ### Customizing your theme
+By default, Tailwind's maximum width scale is a combination of the [default spacing scale](/docs/customizing-spacing#default-spacing-scale) as well as some additional values specific to widths.
 
-You can customize your `max-width` scale by editing `theme.maxWidth` or `theme.extend.maxWidth` in your `tailwind.config.js` file.
+You can customize your spacing scale by editing `theme.spacing` or `theme.extend.spacing` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
     theme: {
       extend: {
-+       maxWidth: {
-+         '1/2': '50%',
++       spacing: {
++         '128': '32rem',
 +       }
       }
     }
   }
 ```
 
-Learn more about customizing the default theme in the [theme customization](/docs/theme#customizing-the-default-theme) documentation.
+To customize `max-width` separately, use the `theme.maxWidth` section of your `tailwind.config.js` file.
+
+```diff-js {{ filename: 'tailwind.config.js' }}
+  module.exports = {
+    theme: {
+      extend: {
++       maxWidth: {
++         '128': '32rem',
++       }
+      }
+    }
+  }
+```
 
 ### Arbitrary values
 
-<ArbitraryValues property="max-width" featuredClass="max-w-[50%]" />
+<ArbitraryValues property="max-width" featuredClass="max-w-[220px]" />

--- a/src/pages/docs/min-height.mdx
+++ b/src/pages/docs/min-height.mdx
@@ -24,6 +24,60 @@ Set the minimum height of an element using the `min-h-0`, `min-h-full`, or `min-
 </div>
 ```
 
+### Fixed minimum heights
+
+Use `min-h-{number}` to set an element to a fixed minimum height based on the default spacing scale.
+
+```html {{ example: true }}
+<div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white">
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-96 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-96</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-80 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-80</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-64 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-64</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-48 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-48</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-40 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-40</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-32 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-32</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-24 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">h-24</div>
+    </div>
+  </div>
+</div>
+```
+
+```html
+<div class="**min-h-96** ...">min-h-96</div>
+<div class="**min-h-80** ...">min-h-80</div>
+<div class="**min-h-64** ...">min-h-64</div>
+<div class="**min-h-48** ...">min-h-48</div>
+<div class="**min-h-40** ...">min-h-40</div>
+<div class="**min-h-32** ...">min-h-32</div>
+<div class="**min-h-24** ...">min-h-24</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>
@@ -42,20 +96,37 @@ Set the minimum height of an element using the `min-h-0`, `min-h-full`, or `min-
 
 ### Customizing your theme
 
-You can customize your `min-height` scale by editing `theme.minHeight` or `theme.extend.minHeight` in your `tailwind.config.js` file.
+By default, Tailwind's minimum height scale is a combination of the [default spacing scale](/docs/customizing-spacing#default-spacing-scale) as well as some additional values specific to heights.
+
+You can customize your spacing scale by editing `theme.spacing` or `theme.extend.spacing` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
     theme: {
-+     minHeight: {
-+       '1/2': '50%',
-+     }
+      extend: {
++       spacing: {
++         '128': '32rem',
++       }
+      }
     }
   }
 ```
 
+To customize `min-height` separately, use the `theme.minHeight` section of your `tailwind.config.js` file.
+
+```diff-js {{ filename: 'tailwind.config.js' }}
+  module.exports = {
+    theme: {
+      extend: {
++       minHeight: {
++         '128': '32rem',
++       }
+      }
+    }
+  }
+```
 Learn more about customizing the default theme in the [theme customization](/docs/theme#customizing-the-default-theme) documentation.
 
 ### Arbitrary values
 
-<ArbitraryValues property="min-height" featuredClass="min-h-[50%]" />
+<ArbitraryValues property="min-height" featuredClass="min-h-[220px]" />

--- a/src/pages/docs/min-height.mdx
+++ b/src/pages/docs/min-height.mdx
@@ -14,55 +14,48 @@ export const classes = { utilities }
 
 ### Setting the minimum height
 
-Set the minimum height of an element using the `min-h-0`, `min-h-full`, or `min-h-screen` utilities.
-
-```html
-<div class="h-48">
-  <div class="h-24 **min-h-full**">
-    <!-- ... -->
-  </div>
-</div>
-```
-
-### Fixed minimum heights
-
-Use `min-h-{number}` to set an element to a fixed minimum height based on the default spacing scale.
+Set the minimum height of an element using `min-h-{height}` or `min-h-{number}` utilities.
 
 ```html {{ example: true }}
-<div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white">
+<div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white whitespace-nowrap">
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-96 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-96</div>
+      <div class="-rotate-90">min-h-96</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-80 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-80</div>
+      <div class="-rotate-90">min-h-80</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-64 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-64</div>
+      <div class="-rotate-90">min-h-64</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-48 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-48</div>
+      <div class="-rotate-90">min-h-48</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-40 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-40</div>
+      <div class="-rotate-90">min-h-40</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-32 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-32</div>
+      <div class="-rotate-90">min-h-32</div>
     </div>
   </div>
   <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-24 relative">
     <div class="absolute w-8 bottom-6">
-      <div class="-rotate-90">h-24</div>
+      <div class="-rotate-90">min-h-24</div>
+    </div>
+  </div>
+  <div class="w-8 bg-blue-500 rounded-lg shadow-lg min-h-full h-96 relative">
+    <div class="absolute w-8 bottom-6">
+      <div class="-rotate-90">min-h-full</div>
     </div>
   </div>
 </div>
@@ -76,6 +69,7 @@ Use `min-h-{number}` to set an element to a fixed minimum height based on the de
 <div class="**min-h-40** ...">min-h-40</div>
 <div class="**min-h-32** ...">min-h-32</div>
 <div class="**min-h-24** ...">min-h-24</div>
+<div class="**min-h-full** ...">min-h-full</div>
 ```
 
 ---

--- a/src/pages/docs/min-width.mdx
+++ b/src/pages/docs/min-width.mdx
@@ -14,20 +14,10 @@ export const classes = { utilities }
 
 ### Setting the minimum width
 
-Set the minimum width of an element using the `min-w-{width}` utilities.
+Set the minimum width of an element using `min-w-{width}` or `min-w-{number}` utilities.
 
-```html
-<span class="**min-w-full** ...">
-  <!-- ... -->
-</span>
-```
-
-### Fixed minimum widths
-
-Use `min-w-{number}` to set an element to a fixed minimum width based on the default spacing scale.
-
-```html {{ example: { resizable: true }, }}
-<div class="grid gap-4 font-mono font-bold text-xs text-center text-white justify-center justify-items-start align-start">
+```html {{ example: true }}
+<div class="grid max-w-72 mx-auto gap-4 font-mono font-bold text-xs text-center text-white p-2 justify-center justify-items-start align-start">
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-96 hidden sm:block">min-w-96</div>
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-80 hidden sm:block">min-w-80</div>
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-64 hidden sm:block">min-w-64</div>
@@ -35,6 +25,7 @@ Use `min-w-{number}` to set an element to a fixed minimum width based on the def
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-40">min-w-40</div>
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-32">min-w-32</div>
     <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-24">min-w-24</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-full hidden sm:block">min-w-full</div>
 </div>
 ```
 
@@ -47,6 +38,7 @@ Use `min-w-{number}` to set an element to a fixed minimum width based on the def
   <div class="**min-w-40** ...">min-w-40</div>
   <div class="**min-w-32** ...">min-w-32</div>
   <div class="**min-w-24** ...">min-w-24</div>
+  <div class="**min-w-full** ...">min-w-full</div>
 </div>
 ```
 

--- a/src/pages/docs/min-width.mdx
+++ b/src/pages/docs/min-width.mdx
@@ -22,6 +22,34 @@ Set the minimum width of an element using the `min-w-{width}` utilities.
 </span>
 ```
 
+### Fixed minimum widths
+
+Use `min-w-{number}` to set an element to a fixed minimum width based on the default spacing scale.
+
+```html {{ example: { resizable: true }, }}
+<div class="grid gap-4 font-mono font-bold text-xs text-center text-white justify-center justify-items-start align-start">
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-96 hidden sm:block">min-w-96</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-80 hidden sm:block">min-w-80</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-64 hidden sm:block">min-w-64</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-48">min-w-48</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-40">min-w-40</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-32">min-w-32</div>
+    <div class="px-4 py-2 bg-blue-500 rounded-lg shadow-lg min-w-24">min-w-24</div>
+</div>
+```
+
+```html
+<div class="grid justify-items-start ...">
+  <div class="**min-w-96** ...">min-w-96</div>
+  <div class="**min-w-80** ...">min-w-80</div>
+  <div class="**min-w-64** ...">min-w-64</div>
+  <div class="**min-w-48** ...">min-w-48</div>
+  <div class="**min-w-40** ...">min-w-40</div>
+  <div class="**min-w-32** ...">min-w-32</div>
+  <div class="**min-w-24** ...">min-w-24</div>
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>
@@ -39,15 +67,32 @@ Set the minimum width of an element using the `min-w-{width}` utilities.
 ## Using custom values
 
 ### Customizing your theme
+By default, Tailwind's minimum width scale is a combination of the [default spacing scale](/docs/customizing-spacing#default-spacing-scale) as well as some additional values specific to widths.
 
-You can customize your `min-width` scale by editing `theme.minWidth` or `theme.extend.minWidth` in your `tailwind.config.js` file.
+You can customize your spacing scale by editing `theme.spacing` or `theme.extend.spacing` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
     theme: {
-+     minWidth: {
-+       '1/2': '50%',
-+     }
+      extend: {
++       spacing: {
++         '128': '32rem',
++       }
+      }
+    }
+  }
+```
+
+To customize `min-width` separately, use the `theme.minWidth` section of your `tailwind.config.js` file.
+
+```diff-js {{ filename: 'tailwind.config.js' }}
+  module.exports = {
+    theme: {
+      extend: {
++       minWidth: {
++         '128': '32rem',
++       }
+      }
     }
   }
 ```
@@ -56,4 +101,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="min-width" featuredClass="min-w-[50%]" />
+<ArbitraryValues property="min-width" featuredClass="min-w-[220px]" />


### PR DESCRIPTION
Adds documentation for the new fixed scales added to `min-h`, `max-h`, `min-w` and `max-w`

https://tailwindcss-com-git-document-min-max-scales-tailwindlabs.vercel.app/docs/min-width
https://tailwindcss-com-git-document-min-max-scales-tailwindlabs.vercel.app/docs/max-width
https://tailwindcss-com-git-document-min-max-scales-tailwindlabs.vercel.app/docs/min-height
https://tailwindcss-com-git-document-min-max-scales-tailwindlabs.vercel.app/docs/max-height

<img width="813" alt="Screenshot 2023-12-11 at 19 34 37" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/f94b8d26-c82d-43a6-9077-8ec2b262b194">

