### PR TITLE
Documents size utilities

### DIFF
--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -103,6 +103,7 @@ export const documentationNav = {
     pages['height'],
     pages['min-height'],
     pages['max-height'],
+    pages['size'],
   ],
   Typography: [
     pages['font-family'],

--- a/src/pages/docs/size.mdx
+++ b/src/pages/docs/size.mdx
@@ -1,0 +1,140 @@
+---
+title: "Size"
+description: "Utilities for setting the width and height of an element simultaneously."
+---
+
+import utilities from 'utilities?plugin=size'
+import { numbersFirst } from '@/utils/sortClasses'
+import { ArbitraryValues } from '@/components/ArbitraryValues'
+import { BreakpointsAndMediaQueries } from '@/components/BreakpointsAndMediaQueries'
+import { HoverFocusAndOtherStates } from '@/components/HoverFocusAndOtherStates'
+
+export const classes = {
+  utilities,
+  sort: numbersFirst,
+}
+
+## Basic usage
+
+### Fixed sizes
+
+Use `size-{number}` or `size-px` to set an element to a fixed width and height simultaneously.
+
+```html {{ example: true }}
+<div class="grid grid-flow-col justify-center gap-4 font-mono font-bold text-xs text-center text-white">  
+    <div class="grid items-center justify-center bg-blue-500 rounded-lg shadow-lg size-16">size-16</div>
+    <div class="grid items-center justify-center bg-blue-500 rounded-lg shadow-lg size-20">size-20</div>
+    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-24 grid">size-24</div>
+    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-32 grid ">size-32</div>
+    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-40 hidden sm:grid">size-40</div>
+</div>
+```
+
+```html
+<div class="**size-16** ...">size-16</div>
+<div class="**size-20** ...">size-20</div>
+<div class="**size-24** ...">size-24</div>
+<div class="**size-32** ...">size-32</div>
+<div class="**size-40** ...">size-40</div>
+```
+
+### Percentage sizes
+
+Use `size-{fraction}` or `size-full` to set an element an element's width and height to the same percentage value. This might force the element's width and height to be unequal depending on the space available in each axis.
+
+```html {{ example: true }}
+<div class="space-y-4 font-mono font-bold text-xs  text-white">
+  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
+    <div class="grid items-center justify-center size-1/3 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-1/3</div>
+  </div>
+  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
+    <div class="grid items-center justify-center size-1/2 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-1/2</div>
+  </div>
+  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
+    <div class="grid items-center justify-self-stretch self-stretch size-4/5 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-4/5</div>
+  </div>
+   <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
+    <div class="grid items-center justify-center size-full px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-full</div>
+  </div>
+</div>
+```
+
+```html
+<div class="flex h-[140px] ... ">
+  <div class="**size-1/4** ... ">size-1/4</div>
+</div>
+<div class="flex h-[140px] ... ">
+  <div class="**size-1/2** .. ">size-1/2</div>
+</div>
+<div class="flex h-[140px] ... ">
+  <div class="**size-4/5** ... ">size-4/5</div>
+</div>
+<div class="flex h-[140px] ... ">
+  <div class="**size-full** ... ">size-full</div>
+</div>
+
+```
+
+### Resetting the size
+
+The `size-auto` utility can be useful if you need to remove an element's assigned width and height under a specific condition, like at a particular breakpoint:
+
+```html
+<div class="size-full md:size-auto">
+  <!-- ... -->
+</div>
+```
+
+---
+
+## <Heading ignore>Applying conditionally</Heading>
+
+### <Heading ignore>Hover, focus, and other states</Heading>
+
+<HoverFocusAndOtherStates defaultClass="size-1/2" featuredClass="size-full" />
+
+### <Heading ignore>Breakpoints and media queries</Heading>
+
+<BreakpointsAndMediaQueries defaultClass="size-1/2" featuredClass="size-full" />
+
+---
+
+## Using custom values
+
+### Customizing your theme
+
+By default, Tailwind's size scale is a combination of the [default spacing scale](/docs/customizing-spacing#default-spacing-scale) as well as some additional values specific to sizing.
+
+You can customize your spacing scale by editing `theme.spacing` or `theme.extend.spacing` in your `tailwind.config.js` file.
+
+```diff-js {{ filename: 'tailwind.config.js' }}
+  module.exports = {
+    theme: {
+      extend: {
++       spacing: {
++         '128': '32rem',
++       }
+      }
+    }
+  }
+```
+
+To customize size separately, use the `theme.size` section of your `tailwind.config.js` file.
+
+```diff-js {{ filename: 'tailwind.config.js' }}
+  module.exports = {
+    theme: {
+      extend: {
++       size: {
++         '128': '32rem',
++       }
+      }
+    }
+  }
+```
+
+Learn more about customizing the default theme in the [theme customization](/docs/theme#customizing-the-default-theme) documentation.
+
+### Arbitrary values
+
+<ArbitraryValues property="size" featuredClass="size-[32rem]" />

--- a/src/pages/docs/size.mdx
+++ b/src/pages/docs/size.mdx
@@ -25,8 +25,8 @@ Use `size-{number}` or `size-px` to set an element to a fixed width and height s
     <div class="grid items-center justify-center bg-blue-500 rounded-lg shadow-lg size-16">size-16</div>
     <div class="grid items-center justify-center bg-blue-500 rounded-lg shadow-lg size-20">size-20</div>
     <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-24 grid">size-24</div>
-    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-32 grid ">size-32</div>
-    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-40 hidden sm:grid">size-40</div>
+    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-32 hidden sm:grid">size-32</div>
+    <div class="items-center justify-center bg-blue-500 rounded-lg shadow-lg size-40 hidden md:grid">size-40</div>
 </div>
 ```
 
@@ -40,36 +40,18 @@ Use `size-{number}` or `size-px` to set an element to a fixed width and height s
 
 ### Percentage sizes
 
-Use `size-{fraction}` or `size-full` to set an element an element's width and height to the same percentage value. This might force the element's width and height to be unequal depending on the space available in each axis.
+Use `size-full` to set an element's width and height to be 100% of the parent container's width and height.
 
 ```html {{ example: true }}
 <div class="space-y-4 font-mono font-bold text-xs  text-white">
-  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
-    <div class="grid items-center justify-center size-1/3 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-1/3</div>
-  </div>
-  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
-    <div class="grid items-center justify-center size-1/2 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-1/2</div>
-  </div>
-  <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
-    <div class="grid items-center justify-self-stretch self-stretch size-4/5 px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-4/5</div>
-  </div>
-   <div class="flex space-x-4 h-[140px] bg-stripes-purple p-1">
+  <div class="flex space-x-4 h-56 bg-stripes-purple p-2">
     <div class="grid items-center justify-center size-full px-4 py-2 bg-violet-500 rounded-lg shadow-lg text-center">size-full</div>
   </div>
 </div>
 ```
 
 ```html
-<div class="flex h-[140px] ... ">
-  <div class="**size-1/4** ... ">size-1/4</div>
-</div>
-<div class="flex h-[140px] ... ">
-  <div class="**size-1/2** .. ">size-1/2</div>
-</div>
-<div class="flex h-[140px] ... ">
-  <div class="**size-4/5** ... ">size-4/5</div>
-</div>
-<div class="flex h-[140px] ... ">
+<div class="flex h-56 p-2 ... ">
   <div class="**size-full** ... ">size-full</div>
 </div>
 
@@ -91,11 +73,11 @@ The `size-auto` utility can be useful if you need to remove an element's assigne
 
 ### <Heading ignore>Hover, focus, and other states</Heading>
 
-<HoverFocusAndOtherStates defaultClass="size-1/2" featuredClass="size-full" />
+<HoverFocusAndOtherStates defaultClass="size-48" featuredClass="size-full" />
 
 ### <Heading ignore>Breakpoints and media queries</Heading>
 
-<BreakpointsAndMediaQueries defaultClass="size-1/2" featuredClass="size-full" />
+<BreakpointsAndMediaQueries defaultClass="size-48" featuredClass="size-full" />
 
 ---
 


### PR DESCRIPTION
Adds documentation for the new `size-` utilities.

https://tailwindcss-com-git-document-size-utilities-tailwindlabs.vercel.app/docs/size
<img width="797" alt="Screenshot 2023-12-11 at 19 33 11" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/a79e70cc-5ed6-4dd3-93c3-dc30e01969f0">
