### PR TITLE
Document subgrid

### DIFF
--- a/src/pages/docs/grid-template-columns.mdx
+++ b/src/pages/docs/grid-template-columns.mdx
@@ -38,6 +38,36 @@ Use the `grid-cols-{n}` utilities to create grids with _n_ equally sized columns
 </div>
 ```
 
+### Subgrid
+
+Use the `grid-cols-subgrid` utility to adopt the column tracks defined by the item's parent.
+
+```html {{ example: true }}
+  <div class=" grid grid-cols-4 gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-indigo-400">
+    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">01</div>
+    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">02</div>
+    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">03</div>
+    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">04</div>
+    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">05</div>
+    <div class="col-span-3 grid grid-cols-subgrid gap-4 text-white">
+      <div class="rounded-lg bg-stripes-pink p-4 shadow-lg"></div>
+      <div class="rounded-lg bg-pink-500 p-4 shadow-lg ">06</div>
+      <div class="rounded-lg bg-stripes-pink p-4 shadow-lg"></div>
+    </div>
+    <!-- <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">07</div> -->
+  </div>
+```
+
+```html
+<div class="grid grid-cols-4 gap-4">
+  <!-- ... -->
+  <div class="grid **grid-cols-subgrid** gap-4 col-span-3">
+      <div class="col-start-2">06</div>
+  </div>
+  <!-- ... -->
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>

--- a/src/pages/docs/grid-template-columns.mdx
+++ b/src/pages/docs/grid-template-columns.mdx
@@ -43,18 +43,17 @@ Use the `grid-cols-{n}` utilities to create grids with _n_ equally sized columns
 Use the `grid-cols-subgrid` utility to adopt the column tracks defined by the item's parent.
 
 ```html {{ example: true }}
-  <div class=" grid grid-cols-4 gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-indigo-400">
-    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">01</div>
-    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">02</div>
-    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">03</div>
-    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">04</div>
-    <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">05</div>
-    <div class="col-span-3 grid grid-cols-subgrid gap-4 text-white">
-      <div class="rounded-lg bg-stripes-pink p-4 shadow-lg"></div>
-      <div class="rounded-lg bg-pink-500 p-4 shadow-lg ">06</div>
-      <div class="rounded-lg bg-stripes-pink p-4 shadow-lg"></div>
+  <div class=" grid grid-cols-4 gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-white">
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 p-4 shadow-lg">01</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 p-4 shadow-lg">02</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 p-4 shadow-lg">03</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 p-4 shadow-lg">04</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 p-4 shadow-lg">05</div>
+    <div class="col-span-3 grid grid-cols-subgrid gap-4">
+      <div class="rounded-lg bg-stripes-pink p-4"></div>
+      <div class="rounded-lg bg-pink-500 p-4 shadow-lg">06</div>
+      <div class="rounded-lg bg-stripes-pink p-4"></div>
     </div>
-    <!-- <div class="rounded-lg bg-indigo-800 p-4 shadow-lg">07</div> -->
   </div>
 ```
 

--- a/src/pages/docs/grid-template-rows.mdx
+++ b/src/pages/docs/grid-template-rows.mdx
@@ -38,6 +38,39 @@ Use the `grid-rows-{n}` utilities to create grids with _n_ equally sized rows.
 </div>
 ```
 
+### Subgrid
+
+Use the `grid-rows-subgrid` utility to adopt the row tracks defined by the item's parent.
+
+```html {{ example: true }}
+  <div class=" grid grid-rows-4 grid-flow-col gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-indigo-400">
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">01</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">02</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">03</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">04</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">05</div>
+    <div class="row-span-3 grid grid-row-subgrid gap-4 text-white">
+      <div class="rounded-lg bg-stripes-pink h-14 shadow-lg"></div>
+      <div class="rounded-lg bg-pink-500 grid items-center justify-center h-14 shadow-lg">06</div>
+      <div class="rounded-lg bg-stripes-pink h-14 shadow-lg"></div>
+    </div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">07</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">08</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">09</div>
+    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">10</div>
+  </div>
+```
+
+```html
+<div class="grid grid-rows-4 grid-flow-col gap-4">
+  <!-- ... -->
+  <div class="grid **grid-row-subgrid** gap-4 row-span-3">
+      <div class="row-start-2">06</div>
+  </div>
+  <!-- ... -->
+</div>
+```
+
 ---
 
 ## <Heading ignore>Applying conditionally</Heading>

--- a/src/pages/docs/grid-template-rows.mdx
+++ b/src/pages/docs/grid-template-rows.mdx
@@ -43,21 +43,21 @@ Use the `grid-rows-{n}` utilities to create grids with _n_ equally sized rows.
 Use the `grid-rows-subgrid` utility to adopt the row tracks defined by the item's parent.
 
 ```html {{ example: true }}
-  <div class=" grid grid-rows-4 grid-flow-col gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-indigo-400">
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">01</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">02</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">03</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">04</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">05</div>
-    <div class="row-span-3 grid grid-row-subgrid gap-4 text-white">
-      <div class="rounded-lg bg-stripes-pink h-14 shadow-lg"></div>
-      <div class="rounded-lg bg-pink-500 grid items-center justify-center h-14 shadow-lg">06</div>
-      <div class="rounded-lg bg-stripes-pink h-14 shadow-lg"></div>
+  <div class=" grid grid-rows-4 grid-flow-col gap-4 rounded-lg text-center font-mono text-sm font-bold leading-6 text-white">
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">01</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">02</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">03</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">04</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">05</div>
+    <div class="row-span-3 grid grid-row-subgrid gap-4">
+      <div class="rounded-lg bg-stripes-fuchsia h-14"></div>
+      <div class="rounded-lg bg-fuchsia-500 grid items-center justify-center h-14 shadow-lg">06</div>
+      <div class="rounded-lg bg-stripes-fuchsia h-14"></div>
     </div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">07</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">08</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">09</div>
-    <div class="rounded-lg bg-indigo-800 grid items-center justify-center h-14 shadow-lg">10</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">07</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">08</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">09</div>
+    <div class="rounded-lg dark:bg-indigo-800 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">10</div>
   </div>
 ```
 

--- a/src/pages/docs/grid-template-rows.mdx
+++ b/src/pages/docs/grid-template-rows.mdx
@@ -67,7 +67,6 @@ Use the `grid-rows-subgrid` utility to adopt the row tracks defined by the item'
   <div class="grid **grid-row-subgrid** gap-4 row-span-3">
       <div class="row-start-2">06</div>
   </div>
-  <!-- ... -->
 </div>
 ```
 


### PR DESCRIPTION
Adds documentation for `grid-cols-subgrid` and `grid-rows-subgrid`

https://tailwindcss-com-git-document-subgrid-tailwindlabs.vercel.app/docs/grid-template-columns
https://tailwindcss-com-git-document-subgrid-tailwindlabs.vercel.app/docs/grid-template-rows

<img width="797" alt="Screenshot 2023-12-11 at 19 29 01" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/836ae23d-ccf3-468e-9cdf-e843a36f04ad">
<img width="784" alt="Screenshot 2023-12-11 at 19 29 12" src="https://github.com/tailwindlabs/tailwindcss.com/assets/13898607/e5b34563-dd3e-4aff-bf18-83574b9e956d">
