### PR TITLE
chore: fix broken link to NextJS Image API reference

### DIFF
--- a/src/pages/blog/2022-08-17-tailwind-framer-motion-template-and-tailwind-jobs/index.mdx
+++ b/src/pages/blog/2022-08-17-tailwind-framer-motion-template-and-tailwind-jobs/index.mdx
@@ -18,7 +18,7 @@ All about the brand new Tailwind UI template we just shipped, the official Tailw
 
 Got another update for you today on some cool things we've shipped, and some other things that are in the works but shipping soon!
 
-Since the [Tailwind UI site templates and all-access](/blog/2022-06-23-tailwind-templates-and-all-access) release back in June we've been doing a lot of maintenance-focused stuff, like processing [over 350 GitHub issues and pull requests](https://github.com/search?q=is%3Aclosed+org%3Atailwindlabs+archived%3Afalse+sort%3Acreated-desc+is%3Apublic+closed%3A%3E%3D2022-06-23+-author%3Aapp%2Fdependabot+-author%3Aapp%2Fgithub-actions+-author%3Aapp%2Fdepfu&type=Issues) and updating all of the new templates we released to use [Next.js 12.2](https://nextjs.org/blog/next-12-2) and the new [`next/future/image`](https://nextjs.org/docs/api-reference/next/future/image) component.
+Since the [Tailwind UI site templates and all-access](/blog/2022-06-23-tailwind-templates-and-all-access) release back in June we've been doing a lot of maintenance-focused stuff, like processing [over 350 GitHub issues and pull requests](https://github.com/search?q=is%3Aclosed+org%3Atailwindlabs+archived%3Afalse+sort%3Acreated-desc+is%3Apublic+closed%3A%3E%3D2022-06-23+-author%3Aapp%2Fdependabot+-author%3Aapp%2Fgithub-actions+-author%3Aapp%2Fdepfu&type=Issues) and updating all of the new templates we released to use [Next.js 12.2](https://nextjs.org/blog/next-12-2) and the new [`next/future/image`](https://nextjs.org/docs/app/api-reference/next-config-js/images) component.
 
 We did find time to ship a few new things in there too though!
 


### PR DESCRIPTION
Fix broken link to image reference.


I do understand this blogpost is outdated, but still, it's nice to reference to the working images API of NextJS