### PR TITLE
Update sveltekit install guide.

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -47,7 +47,7 @@ let steps = [
       name: 'svelte.config.js',
       lang: 'js',
       code: `  import adapter from '@sveltejs/adapter-auto';
-> import { vitePreprocess } from '@sveltejs/kit/vite';
+> import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
   /** @type {import('@sveltejs/kit').Config} */
   const config = {
     kit: {


### PR DESCRIPTION
In SvelteKit 2, `vitePreprocess` is no longer exported from `@sveltejs/kit/vite`

It should be imported from `@sveltejs/vite-plugin-svelte`

Source: https://kit.svelte.dev/docs/migrating-to-sveltekit-2#vitepreprocess-is-no-longer-exported-from-sveltejs-kit-vite