### PR TITLE
Fix blog heading hyperlink hover on dark mode

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -41,7 +41,12 @@ export function Heading({
       >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 group-focus:opacity-100 lg:flex">
           &#8203;
-          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:hover:text-slate-100 dark:shadow-none dark:ring-0">
+          <div
+            className={clsx(
+              'flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10',
+              'dark:bg-slate-800 dark:text-slate-400 dark:shadow-none dark:ring-0 dark:hover:bg-slate-700 dark:hover:text-slate-200'
+            )}
+          >
             <svg width="12" height="12" fill="none" aria-hidden="true">
               <path
                 d="M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10"

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -41,7 +41,7 @@ export function Heading({
       >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 group-focus:opacity-100 lg:flex">
           &#8203;
-          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5  hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:hover:text-slate-100 dark:shadow-none dark:ring-0">
+          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:hover:text-slate-100 dark:shadow-none dark:ring-0">
             <svg width="12" height="12" fill="none" aria-hidden="true">
               <path
                 d="M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10"

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -41,7 +41,7 @@ export function Heading({
       >
         <div className="absolute -ml-8 hidden items-center border-0 opacity-0 group-hover:opacity-100 group-focus:opacity-100 lg:flex">
           &#8203;
-          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5 hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
+          <div className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 shadow-sm ring-1 ring-slate-900/5  hover:text-slate-700 hover:shadow hover:ring-slate-900/10 dark:bg-slate-700 dark:text-slate-300 dark:hover:text-slate-100 dark:shadow-none dark:ring-0">
             <svg width="12" height="12" fill="none" aria-hidden="true">
               <path
                 d="M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10"


### PR DESCRIPTION
Currently, on a blog post when using dark mode, the [hyperlink button](https://tailwindcss.com/blog/tailwindcss-v3-4#dynamic-viewport-units) on hover text colour is the same as the background colour leading to the icon disappearing on hover.

This change just adds `dark:hover:text-slate-100` to the icon.

See below:
Current hover | neutral state | fixed hover
![tailwind_hover_issue](https://github.com/tailwindlabs/tailwindcss.com/assets/14802302/ba82b885-f25d-46f2-8155-07a52d086089)
