### PR TITLE
Fix heading ID in the v3.4 news summary

### DIFF
--- a/src/pages/blog/tailwindcss-v3-4/index.mdx
+++ b/src/pages/blog/tailwindcss-v3-4/index.mdx
@@ -29,7 +29,7 @@ As always the improvements range from things you've been angry about for years, 
 - [**New `size-*` utilities**:](#new-size-utilities) Set width and height at the same time, finally.
 - [**Balanced headlines with `text-wrap` utilities**:](#balanced-headlines-with-text-wrap-utilities) No more max-width tweaking or responsive line breaks.
 - [**Subgrid support**:](#subgrid-support) That grid feature you struggle to understand, finally in Tailwind CSS.
-- [**Extended min-width, max-width, and min-height scales**:](#xtended-min-width-max-width-and-min-height-scales) Now `min-w-12` is a real class.
+- [**Extended min-width, max-width, and min-height scales**:](#extended-min-width-max-width-and-min-height-scales) Now `min-w-12` is a real class.
 - [**Extended opacity scale**:](#extended-opacity-scale) For those moments when neither 60% or 70% were quite right.
 - [**Extended `grid-rows-*` scale**:](#extended-grid-rows-scale) Might as well make it match the column scale.
 - [**New `forced-colors` variant**:](#new-forced-colors-variant) Easily fine-tune your site for forced colors mode.


### PR DESCRIPTION
I opened that section in a new tab and noticed the page wasn't scrolled to it, turns out it's just a tiny typo in the link.