### PR TITLE
Update customizing-spacing.mdx to reflect 3.4.0 changes

### DIFF
--- a/src/pages/docs/customizing-spacing.mdx
+++ b/src/pages/docs/customizing-spacing.mdx
@@ -24,7 +24,7 @@ module.exports = {
 }
 ```
 
-By default the spacing scale is inherited by the `padding`, `margin`, `width`, `height`, `maxHeight`, `gap`, `inset`, `space`, `translate`, `scrollMargin`, and `scrollPadding` core plugins.
+By default the spacing scale is inherited by the `padding`, `margin`, `width`, `minWidth`, `maxWidth`, `height`, `minHeight`, `maxHeight`, `gap`, `inset`, `space`, `translate`, `scrollMargin`, and `scrollPadding` core plugins.
 
 ---
 


### PR DESCRIPTION
In 3.4.0, the `min-width`, `max-width`, and `min-height` scales were extended to include the full spacing scale: https://tailwindcss.com/blog/tailwindcss-v3-4#extended-min-width-max-width-and-min-height-scales