### PR TITLE
Fix typo in grid-template-rows subgrid

### DIFF
--- a/src/pages/docs/grid-template-rows.mdx
+++ b/src/pages/docs/grid-template-rows.mdx
@@ -49,7 +49,7 @@ Use the `grid-rows-subgrid` utility to adopt the row tracks defined by the item'
   <div class="rounded-lg dark:bg-indigo-900 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">03</div>
   <div class="rounded-lg dark:bg-indigo-900 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">04</div>
   <div class="rounded-lg dark:bg-indigo-900 bg-indigo-300 grid items-center justify-center h-14 shadow-lg">05</div>
-  <div class="row-span-3 grid grid-row-subgrid gap-4">
+  <div class="row-span-3 grid grid-rows-subgrid gap-4">
     <div class="rounded-lg bg-stripes-fuchsia h-14"></div>
     <div class="rounded-lg bg-fuchsia-500 grid items-center justify-center h-14 shadow-lg">06</div>
     <div class="rounded-lg bg-stripes-fuchsia h-14"></div>
@@ -66,7 +66,7 @@ Use the `grid-rows-subgrid` utility to adopt the row tracks defined by the item'
   <div>01</div>
   <!-- ... -->
   <div>05</div>
-  <div class="grid **grid-row-subgrid** gap-4 row-span-3">
+  <div class="grid **grid-rows-subgrid** gap-4 row-span-3">
       <div class="row-start-2">06</div>
   </div>
   <div>07</div>


### PR DESCRIPTION
`grid-row-subgrid` -> `grid-rows-subgrid`

before|after
-|-
<img width="679" alt="スクリーンショット 2023-12-26 22 30 47" src="https://github.com/tailwindlabs/tailwindcss.com/assets/45055030/484c46bd-11ce-43bd-ac66-b34ac78d1376">|<img width="680" alt="スクリーンショット 2023-12-26 22 29 02" src="https://github.com/tailwindlabs/tailwindcss.com/assets/45055030/8027709f-6485-43ea-9683-817a81a91625">
