### PR TITLE
fix : word order

### DIFF
--- a/src/pages/docs/gap.mdx
+++ b/src/pages/docs/gap.mdx
@@ -40,7 +40,7 @@ Use `gap-{size}` to change the gap between both rows and columns in grid and fle
 
 ### Changing row and column gaps independently
 
-Use `gap-x-{size}` and `gap-y-{size}` to change the gap between rows and columns independently.
+Use `gap-x-{size}` and `gap-y-{size}` to change the gap between columns and rows independently.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-x-8 gap-y-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-sky rounded-lg">


### PR DESCRIPTION
“gap-x” should correspond to “between column”，the same as "gap-y"