### PR TITLE
Fix dark mode custom classname example

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -141,7 +141,7 @@ You can customize the dark mode selector name by setting `darkMode` to an array 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ['class', '[data-mode="dark"]'],
+  darkMode: ['class', '[class="dark"]'],
   // ...
 }
 ```

--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -141,7 +141,7 @@ You can customize the dark mode selector name by setting `darkMode` to an array 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ['class', '[class="dark"]'],
+  darkMode: ['class', '[class="night"]'],
   // ...
 }
 ```


### PR DESCRIPTION
[Docs](https://tailwindcss.com/docs/dark-mode#customizing-the-class-name) currently show to use "data-mode" which does not appear to work, however "class" does