### PR TITLE
update module export in Laravel guide

### DIFF
--- a/src/pages/docs/guides/laravel.js
+++ b/src/pages/docs/guides/laravel.js
@@ -54,7 +54,7 @@ let tabs = [
           name: 'tailwind.config.js',
           lang: 'js',
           code: `  /** @type {import('tailwindcss').Config} */
-  export default = {
+  export default {
 >   content: [
 >     "./resources/**/*.blade.php",
 >     "./resources/**/*.js",
@@ -169,7 +169,7 @@ let tabs = [
           name: 'tailwind.config.js',
           lang: 'js',
           code: `  /** @type {import('tailwindcss').Config} */
-  export default = {
+  export default {
 >   content: [
 >     "./resources/**/*.blade.php",
 >     "./resources/**/*.js",

--- a/src/pages/docs/guides/laravel.js
+++ b/src/pages/docs/guides/laravel.js
@@ -54,7 +54,7 @@ let tabs = [
           name: 'tailwind.config.js',
           lang: 'js',
           code: `  /** @type {import('tailwindcss').Config} */
-  module.exports = {
+  export default = {
 >   content: [
 >     "./resources/**/*.blade.php",
 >     "./resources/**/*.js",
@@ -169,7 +169,7 @@ let tabs = [
           name: 'tailwind.config.js',
           lang: 'js',
           code: `  /** @type {import('tailwindcss').Config} */
-  module.exports = {
+  export default = {
 >   content: [
 >     "./resources/**/*.blade.php",
 >     "./resources/**/*.js",


### PR DESCRIPTION
Working with version 3.4.1 of Tailwind CSS, there is no `module.exports` in the `tailwind.config.js` file, but `export default` instead.