### PR TITLE
Fix invalid path of the output.css file

### DIFF
--- a/src/pages/docs/installation/index.js
+++ b/src/pages/docs/installation/index.js
@@ -77,7 +77,7 @@ let steps = [
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
->   <link href="/output.css" rel="stylesheet">
+>   <link href="./output.css" rel="stylesheet">
   </head>
   <body>
 >   <h1 class="text-3xl font-bold underline">


### PR DESCRIPTION
The changes done in PR #1754 has an issue where the output.css file is not detected by the HTML file.

This is because the href points to `/output.css`.

A better approach would be to add a relative path since all the three files (index.html, input.css and output.css) are within a single folder `src`.

I have added a (.) so that the relative path is taken into consideration.

Please review.