### PR TITLE
Document aria-busy variant

### DIFF
--- a/src/pages/docs/hover-focus-and-other-states.mdx
+++ b/src/pages/docs/hover-focus-and-other-states.mdx
@@ -1400,6 +1400,7 @@ By default we've included modifiers for the most common boolean ARIA attributes:
 
 | Modifier | CSS |
 | --- | --- |
+| <code className="before:content-none after:content-none">aria-busy</code> | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-slate-400">&</span>[aria-busy="true"]</code> |
 | <code className="before:content-none after:content-none">aria-checked</code> | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-slate-400">&</span>[aria-checked="true"]</code> |
 | <code className="before:content-none after:content-none">aria-disabled</code> | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-slate-400">&</span>[aria-disabled="true"]</code> |
 | <code className="before:content-none after:content-none">aria-expanded</code> | <code className="whitespace-nowrap before:content-none after:content-none"><span className="text-slate-400">&</span>[aria-expanded="true"]</code> |


### PR DESCRIPTION
This was added back in Tailwind 3.3.3 (https://github.com/tailwindlabs/tailwindcss/pull/10966) but not documented.