### PR TITLE
Update content-configuration.mdx

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -8,7 +8,7 @@ import { TipGood, TipBad } from '@/components/Tip'
 import { SnippetGroup } from '@/components/SnippetGroup'
 import { ThemeReference } from '@/components/ThemeReference'
 
-The `content` section of your `tailwind.config.js` file is where you configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names.
+The `content` section of your `tailwind.config.js` file is where you configure the paths to all of your HTML templates, JavaScript components, and any other source files that use Tailwind class names.
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */


### PR DESCRIPTION
Improving the field description.
Replacing `contain` as it gives an impression that these are the places where we define tailwind classes.