### PR TITLE
Replace typo "clip-page" with "clip-path"

### DIFF
--- a/src/pages/docs/box-decoration-break.mdx
+++ b/src/pages/docs/box-decoration-break.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the box decoration break
 
-Use the `box-decoration-slice` and `box-decoration-clone` utilities to control whether properties like background, border, border-image, box-shadow, clip-page, margin, and padding should be rendered as if the element were one continuous fragment, or distinct blocks.
+Use the `box-decoration-slice` and `box-decoration-clone` utilities to control whether properties like background, border, border-image, box-shadow, clip-path, margin, and padding should be rendered as if the element were one continuous fragment, or distinct blocks.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-10 px-10 font-mono font-bold">


### PR DESCRIPTION
There is no `clip-page` property, this was probably a typo.

List of affected properties can be found at https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break