### PR TITLE
Fix: typo on window variable

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -108,7 +108,7 @@ How you add the `dark` class to the `html` element is up to you, but a common ap
 
 ### Supporting system preference and manual selection
 
-The `class` strategy can be used to support both the user's system preference _or_ a manually selected mode by using the [`Window.matchMedia()` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
+The `class` strategy can be used to support both the user's system preference _or_ a manually selected mode by using the [`window.matchMedia()` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
 
 Here's a simple example of how you can support light mode, dark mode, as well as respecting the operating system preference:
 


### PR DESCRIPTION
Renamed `Window.matchMedia()` to `window.matchMedia()` to give clarity that method of global variable `window` is being referred instead of `Window` interface instance method, and also analogous with the given example following the passage.