### PR TITLE
Document new `selector` and `variant` dark mode strategies

### DIFF
--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -81,7 +81,7 @@ module.exports = {
 }
 ```
 
-Now instead of `dark:{class}` classes being applied based on `prefers-color-scheme`, they will be applied whenever `dark` class is present earlier in the HTML tree.
+Now instead of `dark:{class}` classes being applied based on `prefers-color-scheme`, they will be applied whenever the `dark` class is present earlier in the HTML tree.
 
 ```html
 <!-- Dark mode not enabled -->

--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -4,6 +4,7 @@ description: Using Tailwind CSS to style your site in dark mode.
 ---
 
 import { Heading } from '@/components/Heading'
+import { TipInfo } from '@/components/Tip'
 
 ## <Heading hidden>Basic usage</Heading>
 
@@ -62,18 +63,20 @@ To make this as easy as possible, Tailwind includes a `dark` variant that lets y
 </div>
 ```
 
-By default this uses the `prefers-color-scheme` CSS media feature, but you can also build sites that support toggling dark mode manually using the ['class' strategy](#toggling-dark-mode-manually).
+By default this uses the `prefers-color-scheme` CSS media feature, but you can also build sites that support toggling dark mode manually using the ['selector' strategy](#toggling-dark-mode-manually).
 
 ---
 
 ## Toggling dark mode manually
 
-If you want to support toggling dark mode manually instead of relying on the operating system preference, use the `class` strategy instead of the `media` strategy:
+If you want to support toggling dark mode manually instead of relying on the operating system preference, use the `selector` strategy instead of the `media` strategy:
+
+<TipInfo>The `selector` dark mode strategy replaced the previous `class` strategy in Tailwind CSS v3.4.1.</TipInfo>
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'class',
+  darkMode: 'selector',
   // ...
 }
 ```
@@ -104,11 +107,27 @@ Now instead of `dark:{class}` classes being applied based on `prefers-color-sche
 
 If you've set <a href="/docs/configuration#prefix">a prefix</a> in your Tailwind config, be sure to add that to the `dark` class. For example, if you have a prefix of `tw-`, you'll need to use the `tw-dark` class to enable dark mode.
 
-How you add the `dark` class to the `html` element is up to you, but a common approach is to use a bit of JS that reads a preference from somewhere (like `localStorage`) and updates the DOM accordingly.
+How you add the `dark` class to the `html` element is up to you, but a common approach is to use a bit of JavaScript that reads a preference from somewhere (like `localStorage`) and updates the DOM accordingly.
+
+### Customizing the selector
+
+Some frameworks (like NativeScript) have their own approach to enabling dark mode and add a different class name when dark mode is active.
+
+You can customize the dark mode selector by setting `darkMode` to an array with your custom selector as the second item:
+
+```js {{ filename: 'tailwind.config.js' }}
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['selector', '[data-mode="dark"]'],
+  // ...
+}
+```
+
+Tailwind will automatically wrap your custom dark mode selector with the `:where()` pseudo class to ensure consistency between the `media` and `selector` strategies.
 
 ### Supporting system preference and manual selection
 
-The `class` strategy can be used to support both the user's system preference _or_ a manually selected mode by using the [`window.matchMedia()` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
+The `selector` strategy can be used to support both the user's system preference _or_ a manually selected mode by using the [`window.matchMedia()` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
 
 Here's a simple example of how you can support light mode, dark mode, as well as respecting the operating system preference:
 
@@ -132,16 +151,31 @@ localStorage.removeItem('theme')
 
 Again you can manage this however you like, even storing the preference server-side in a database and rendering the class on the server — it's totally up to you.
 
-### Customizing the class name
+## Overriding the dark variant
 
-Some frameworks (like NativeScript) have their own approach to enabling dark mode and add a different class name when dark mode is active.
-
-You can customize the dark mode selector name by setting `darkMode` to an array with your custom selector as the second item:
+If you'd like to replace Tailwind's built-in dark variant with your own custom variant, you can do so using the `variant` dark mode strategy:
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ['class', '[data-mode="dark"]'],
+  darkMode: ['variant', '&:not(.light *)'],
+  // ...
+}
+```
+
+When using this strategy Tailwind will not modify the provided selector in any way, so be mindful of it's specificity and consider using the `:where()` pseudo class to ensure it has the same specificity as other utilities.
+
+### Using multiple selectors
+
+If you have multiple scenarios where dark mode should be enabled, you can specify all of them by providing an array:
+
+```js {{ filename: 'tailwind.config.js' }}
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['variant', [
+    '@media (prefers-color-scheme: dark) { &:not(.light *) }',
+    '&:is(.dark *)',
+  ]],
   // ...
 }
 ```

--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -71,7 +71,7 @@ By default this uses the `prefers-color-scheme` CSS media feature, but you can a
 
 If you want to support toggling dark mode manually instead of relying on the operating system preference, use the `selector` strategy instead of the `media` strategy:
 
-<TipInfo>The `selector` dark mode strategy replaced the previous `class` strategy in Tailwind CSS v3.4.1.</TipInfo>
+<TipInfo>The `selector` strategy replaced the `class` strategy in Tailwind CSS v3.4.1.</TipInfo>
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */

--- a/src/pages/docs/dark-mode.mdx
+++ b/src/pages/docs/dark-mode.mdx
@@ -123,7 +123,13 @@ module.exports = {
 }
 ```
 
-Tailwind will automatically wrap your custom dark mode selector with the `:where()` pseudo class to ensure consistency between the `media` and `selector` strategies.
+Tailwind will automatically wrap your custom dark mode selector with the `:where()` pseudo-class to make sure the specificity is the same as it would be when using the `media` strategy:
+
+```css
+.dark\:underline:where([data-mode="dark"], [data-mode="dark"] *){
+  text-decoration-line: underline
+}
+```
 
 ### Supporting system preference and manual selection
 
@@ -163,7 +169,7 @@ module.exports = {
 }
 ```
 
-When using this strategy Tailwind will not modify the provided selector in any way, so be mindful of it's specificity and consider using the `:where()` pseudo class to ensure it has the same specificity as other utilities.
+When using this strategy Tailwind will not modify the provided selector in any way, so be mindful of it's specificity and consider using the `:where()` pseudo-class to ensure it has the same specificity as other utilities.
 
 ### Using multiple selectors
 


### PR DESCRIPTION
Resolves #1766

This PR updates the dark mode page to include the new `selector` and `variant` strategies that came out in Tailwind CSS v3.4.1. It still (briefly) mentions the `class` strategy, just in case anyone is still on an earlier version of Tailwind, but ideally if you're enabling a class/selector based dark mode strategy its best to just upgrade to the latest version of Tailwind.