### PR TITLE
fix(adonisjs): we should have only one vite tag

### DIFF
--- a/src/pages/docs/guides/adonisjs.js
+++ b/src/pages/docs/guides/adonisjs.js
@@ -98,8 +98,7 @@ let steps = [
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
->   @vite(['resources/css/app.css'])
-    @vite(['resources/js/app.js'])
+>   @vite(['resources/css/app.css', 'resources/js/app.js'])
   </head>
   <body>
 >   <h1 class="text-3xl font-bold underline">


### PR DESCRIPTION
Hey there! 👋🏻 

We should not have two `@vite()` tags inside the template.