### PR TITLE
add correct type to css file link in parcel example

### DIFF
--- a/src/pages/docs/guides/parcel.js
+++ b/src/pages/docs/guides/parcel.js
@@ -115,7 +115,7 @@ let steps = [
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
->   <link href="./index.css" rel="stylesheet">
+>   <link href="./index.css" type="text/css" rel="stylesheet">
   </head>
   <body>
 >   <h1 class="text-3xl font-bold underline">


### PR DESCRIPTION
Hi yall, this is a small fix to the documentation to make it easier to get started with tailwind and parcel. When I added parcel to my application built with parcel, I was following the guide and unfortunately it didn't work out of the box. After a bit of searching I came across the following issue on parcels gihub (https://github.com/parcel-bundler/parcel/discussions/7453).

This change essentially only adds the `type="text/css"` to the tutorial docs for parcel so that the framework parcel actually picks up the index.css file correctly and applies tailwind styles.