### PR TITLE
💬 Update Remix Guide. Different config with Vite

### DIFF
--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -77,7 +77,8 @@ let steps = [
     code: {
       name: 'root.tsx',
       lang: 'tsx',
-      code: `import stylesheet from "~/tailwind.css?url";
+      code: `import type { LinksFunction } from "@remix-run/node";
+import stylesheet from "~/tailwind.css?url";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
@@ -101,7 +102,7 @@ export const links: LinksFunction = () => [
     title: 'Start using Tailwind in your project',
     body: () => <p>Start using Tailwind’s utility classes to style your content.</p>,
     code: {
-      name: 'index.tsx',
+      name: '_index.tsx',
       lang: 'tsx',
       code: `  export default function Index() {
     return (

--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -22,13 +22,13 @@ let steps = [
     body: () => (
       <p>
         Install <code>tailwindcss</code> via npm, and then run the init command to generate a{' '}
-        <code>tailwind.config.ts</code> file.
+        <code>tailwind.config.ts</code> and <code>postcss.config.js</code> file.
       </p>
     ),
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss\nnpx tailwindcss init --ts',
+      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init --ts -p',
     },
   },
   {
@@ -77,7 +77,7 @@ let steps = [
     code: {
       name: 'root.tsx',
       lang: 'tsx',
-      code: `import stylesheet from "~/tailwind.css";
+      code: `import stylesheet from "~/tailwind.css?url";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },


### PR DESCRIPTION
## Description

Recently, Remix migrated to Vite. With the update, the instructions within the Remix/Tailwind install guide no longer worked. 

Anytime I tried building the project, I'd get the following error:

![CleanShot 2024-03-20 at 17 31 10](https://github.com/tailwindlabs/tailwindcss.com/assets/212300/1c90cd49-890b-4234-be05-2b904b671bbc)

## Solution

I updated the docs to match the solution filed in this issue on Remix's side: https://github.com/remix-run/remix/issues/8832#issuecomment-1977696930

Key differences:
- Needs a postcss.config.js file
- Vite requires `?url` to respect the `.css` extension: `import stylesheet from "~/tailwind.css?url`
