### PR TITLE
Fix mobile scroll positioning when navigating between pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@badrap/bar-of-progress": "^0.1.1",
         "@docsearch/react": "^3.3.3",
-        "@headlessui/react": "^1.7.2",
+        "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.1.1",
         "@mdx-js/loader": "^2.3.0",
         "@mdx-js/react": "^2.3.0",
@@ -1762,8 +1762,13 @@
       "optional": true
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.2",
-      "license": "MIT",
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -2391,6 +2396,31 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.2.0.tgz",
+      "integrity": "sha512-OEdMByf2hEfDa6XDbGlZN8qO6bTjlNKqjM3im9JG+u3mCL8jALy0T/67oDI001raUUPh1Bdmfn4ZvPOV5knpcg==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.2.0.tgz",
+      "integrity": "sha512-P5XgYoAw/vfW65byBbJQCw+cagdXDT/qH6wmABiLt4v4YBT2q2vqCOhihe+D1Nt325F/S/0Tkv6C5z0Lv+VBQQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/acorn": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@badrap/bar-of-progress": "^0.1.1",
     "@docsearch/react": "^3.3.3",
-    "@headlessui/react": "^1.7.2",
+    "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "@mdx-js/loader": "^2.3.0",
     "@mdx-js/react": "^2.3.0",

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -35,9 +35,9 @@ export default function App({ Component, pageProps, router }) {
     function handleRouteChange() {
       setNavIsOpen(false)
     }
-    Router.events.on('routeChangeComplete', handleRouteChange)
+    Router.events.on('routeChangeStart', handleRouteChange)
     return () => {
-      Router.events.off('routeChangeComplete', handleRouteChange)
+      Router.events.off('routeChangeStart', handleRouteChange)
     }
   }, [navIsOpen])
 


### PR DESCRIPTION
Resolves #1785

This PR fixes an issue on mobile when navigating between pages from the main navigation where the scroll position wasn't being reset back to the top of the page.

I've fixed this by using an updated version of Headless UI which has a fix for this, as well as using the `routeChangeStart` router event instead of `routeChangeComplete`.

You can read more details about how this fix works here:

https://github.com/tailwindlabs/tailwindui-issues/issues/1387#issuecomment-1431543346