### PR TITLE
Utility name cleanup and other consistency improvements

### DIFF
--- a/src/components/ArbitraryValues/index.jsx
+++ b/src/components/ArbitraryValues/index.jsx
@@ -13,17 +13,15 @@ export function ArbitraryValues({
     <>
       {hasTheme ? (
         <p>
-          If you need to use a one-off{' '}
-          {typeof property === 'string' ? <code>{property}</code> : property} value that doesn’t
-          make sense to include in your theme, use square brackets to generate a property on the fly
+          If you need to use a one-off {name ?? <code>{property}</code>} value that doesn’t make
+          sense to include in your theme, use square brackets to generate a property on the fly
           using any arbitrary value.
         </p>
       ) : (
         <p>
-          If you need to use a one-off{' '}
-          {typeof property === 'string' ? <code>{property}</code> : property} value that isn't
-          included in Tailwind by default, use square brackets to generate a property on the fly
-          using any arbitrary value.
+          If you need to use a one-off {name ?? <code>{property}</code>} value that isn't included
+          in Tailwind by default, use square brackets to generate a property on the fly using any
+          arbitrary value.
         </p>
       )}
       {children || (

--- a/src/components/ArbitraryValues/index.jsx
+++ b/src/components/ArbitraryValues/index.jsx
@@ -9,25 +9,21 @@ export function ArbitraryValues({
   element = 'div',
   children,
 }) {
-  const nameOrProperty = name ? (
-    name
-  ) : (
-    <>
-      <code>{property}</code> value
-    </>
-  )
-
   return (
     <>
       {hasTheme ? (
         <p>
-          If you need to use a one-off {nameOrProperty} that doesn’t make sense to include in your
-          theme, use square brackets to generate a property on the fly using any arbitrary value.
+          If you need to use a one-off{' '}
+          {typeof property === 'string' ? <code>{property}</code> : property} value that doesn’t
+          make sense to include in your theme, use square brackets to generate a property on the fly
+          using any arbitrary value.
         </p>
       ) : (
         <p>
-          If you need to use a one-off {nameOrProperty} that isn't included in Tailwind by default,
-          use square brackets to generate a property on the fly using any arbitrary value.
+          If you need to use a one-off{' '}
+          {typeof property === 'string' ? <code>{property}</code> : property} value that isn't
+          included in Tailwind by default, use square brackets to generate a property on the fly
+          using any arbitrary value.
         </p>
       )}
       {children || (

--- a/src/pages/docs/accent-color.mdx
+++ b/src/pages/docs/accent-color.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the accent color
 
-Use the `accent-{color}` utilities to change the accent color of an element. This is helpful for styling elements like checkboxes and radio groups by overriding the browser's default color.
+Use the `accent-*` utilities to change the accent color of an element. This is helpful for styling elements like checkboxes and radio groups by overriding the browser's default color.
 
 ```html {{ example: true }}
 <div class="flex flex-wrap justify-center gap-6">

--- a/src/pages/docs/aspect-ratio.mdx
+++ b/src/pages/docs/aspect-ratio.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the aspect ratio
 
-Use the `aspect-{ratio}` utilities to set the desired aspect ratio of an element.
+Use the `aspect-*` utilities to set the desired aspect ratio of an element.
 
 ```html {{ example: { resizable: true } }}
 <iframe class="w-full aspect-video rounded-lg shadow-lg" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -28,7 +28,7 @@ Tailwind doesn't include a large set of aspect ratio values out of the box since
 
 ### Browser support
 
-The `aspect-{ratio}` utilities use the native `aspect-ratio` CSS property, which was not supported in Safari until version 15. Until Safari 15 is popularized, Tailwind's [aspect-ratio](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) plugin is a good alternative.
+The `aspect-*` utilities use the native `aspect-ratio` CSS property, which was not supported in Safari until version 15. Until Safari 15 is popularized, Tailwind's [aspect-ratio](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) plugin is a good alternative.
 
 ---
 

--- a/src/pages/docs/backdrop-blur.mdx
+++ b/src/pages/docs/backdrop-blur.mdx
@@ -23,7 +23,7 @@ export const classes = {
 
 ### Blurring behind an element
 
-Use the `backdrop-blur-{amount?}` utilities to control an element’s backdrop blur.
+Use the `backdrop-blur-*` utilities to control an element’s backdrop blur.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/backdrop-brightness.mdx
+++ b/src/pages/docs/backdrop-brightness.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Controlling backdrop brightness
 
-Use the `backdrop-brightness-{amount?}` utilities to control an element's backdrop brightness.
+Use the `backdrop-brightness-*` utilities to control an element's backdrop brightness.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/backdrop-contrast.mdx
+++ b/src/pages/docs/backdrop-contrast.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Controlling backdrop contrast
 
-Use the `backdrop-contrast-{amount?}` utilities to control an element's backdrop contrast.
+Use the `backdrop-contrast-*` utilities to control an element's backdrop contrast.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/backdrop-hue-rotate.mdx
+++ b/src/pages/docs/backdrop-hue-rotate.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Rotating the backdrop's hue
 
-Use the `backdrop-hue-rotate-{amount}` utilities to rotate the hue of an element's backdrop.
+Use the `backdrop-hue-rotate-*` utilities to rotate the hue of an element's backdrop.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/backdrop-opacity.mdx
+++ b/src/pages/docs/backdrop-opacity.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Controlling opacity of backdrop filters
 
-Use the `backdrop-opacity-{amount}` utilities to control the opacity of other backdrop filters applied to an element.
+Use the `backdrop-opacity-*` utilities to control the opacity of other backdrop filters applied to an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/backdrop-saturate.mdx
+++ b/src/pages/docs/backdrop-saturate.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Changing backdrop saturation
 
-Use the `backdrop-saturate-{amount}` utilities to control an element's backdrop saturation.
+Use the `backdrop-saturate-*` utilities to control an element's backdrop saturation.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/background-blend-mode.mdx
+++ b/src/pages/docs/background-blend-mode.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the background blend mode
 
-Use the `bg-blend-{mode}` utilities to control how an element's background image(s) should blend with its background color.
+Use the `bg-blend-*` utilities to control how an element's background image(s) should blend with its background color.
 
 ```html
 <div class="bg-blend-multiply ...">

--- a/src/pages/docs/background-clip.mdx
+++ b/src/pages/docs/background-clip.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the background clip
 
-Use the `bg-clip-{keyword}` utilities to control the bounding box of an element's background.
+Use the `bg-clip-*` utilities to control the bounding box of an element's background.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-center space-y-10 sm:space-y-0 sm:space-x-10">

--- a/src/pages/docs/background-color.mdx
+++ b/src/pages/docs/background-color.mdx
@@ -36,7 +36,7 @@ export const classes = {
 
 ### Setting the background color
 
-Control the background color of an element using the `bg-{color}` utilities.
+Use the `bg-*` utilities to control the background color of an element.
 
 ```html {{ example: true }}
 <div class="text-center">

--- a/src/pages/docs/background-color.mdx
+++ b/src/pages/docs/background-color.mdx
@@ -54,7 +54,7 @@ Use the `bg-*` utilities to control the background color of an element.
 
 ### Changing the opacity
 
-Control the opacity of an element's background color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's background color.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-3 text-sm text-white">

--- a/src/pages/docs/background-image.mdx
+++ b/src/pages/docs/background-image.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Linear gradients
 
-To give an element a linear gradient background, use one of the `bg-gradient-{direction}` utilities, in combination with the [gradient color stop](/docs/gradient-color-stops) utilities.
+Use the `bg-gradient-*` utilities in combination with the [gradient color stop](/docs/gradient-color-stops) utilities to give an element a linear gradient background.
 
 ```html {{ example: true }}
 <div class="space-y-4">

--- a/src/pages/docs/background-position.mdx
+++ b/src/pages/docs/background-position.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the background position
 
-Use the `bg-{side}` utilities to control the position of an element's background image.
+Use the `bg-*` utilities to control the position of an element's background image.
 
 ```html {{ example: { p: 'none' } }}
 <div class="w-full">

--- a/src/pages/docs/blur.mdx
+++ b/src/pages/docs/blur.mdx
@@ -23,7 +23,7 @@ export const classes = {
 
 ### Blurring elements
 
-Use the `blur-{amount?}` utilities to blur an element.
+Use the `blur-*` utilities to blur an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/border-color.mdx
+++ b/src/pages/docs/border-color.mdx
@@ -61,7 +61,7 @@ Use the `border-*` utilities to control the border color of an element.
 
 ### Changing the opacity
 
-Control the opacity of an element's border color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's border color.
 
 ```html {{ example: true }}
 <div class="grid lg:grid-cols-3 gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/border-color.mdx
+++ b/src/pages/docs/border-color.mdx
@@ -43,7 +43,7 @@ export const classes = {
 
 ### Setting the border color
 
-Control the border color of an element using the `border-{color}` utilities.
+Use the `border-*` utilities to control the border color of an element.
 
 ```html {{ example: true }}
 <div class="max-w-xs mx-auto space-y-1">
@@ -94,7 +94,7 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Individual sides
 
-Use the `border-{side}-{color}` utilities to set the border color for one side of an element.
+Use the `border-t-*`, `border-r-*`, `border-b-*`, and `border-l-*` utilities to set the border color for one side of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">
@@ -126,7 +126,7 @@ Use the `border-{side}-{color}` utilities to set the border color for one side o
 
 ### Horizontal and vertical sides
 
-Use the `border-{x|y}-{color}` utilities to set the border color on two sides of an element at the same time.
+Use the `border-x-*` and `border-y-*` utilities to set the border color on two sides of an element at the same time.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/border-radius.mdx
+++ b/src/pages/docs/border-radius.mdx
@@ -82,7 +82,7 @@ This is most commonly used to remove a border radius that was applied at a small
 
 ### Rounding sides separately
 
-Use `rounded-{t|r|b|l}{-size?}` to only round one side of an element.
+Use the `rounded-t-*`, `rounded-r-*`, `rounded-b-*`, and `rounded-l-*` utilities to only round one side of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">
@@ -114,7 +114,7 @@ Use `rounded-{t|r|b|l}{-size?}` to only round one side of an element.
 
 ### Rounding corners separately
 
-Use `rounded-{tl|tr|br|bl}{-size?}` to only round one corner an element.
+Use `rounded-tl-*`, `rounded-tr-*`, `rounded-br-*`, and `rounded-bl-*` utilities to only round one corner an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">
@@ -146,7 +146,7 @@ Use `rounded-{tl|tr|br|bl}{-size?}` to only round one corner an element.
 
 ### <Heading ignore>Using logical properties</Heading>
 
-Use the `rounded-{s|e|ss|se|es|ee}{-size?}` utilities to set the border radius using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts), which map to the appropriate corners based on the text direction.
+Use the `rounded-s-*`, `rounded-e-*`, `rounded-ss-*`, `rounded-se-*`, `rounded-es-*`, and `rounded-ee-*` utilities to set the border radius using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts), which map to the appropriate corners based on the text direction.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-2 gap-x-4 place-items-center">

--- a/src/pages/docs/border-radius.mdx
+++ b/src/pages/docs/border-radius.mdx
@@ -114,7 +114,7 @@ Use the `rounded-t-*`, `rounded-r-*`, `rounded-b-*`, and `rounded-l-*` utilities
 
 ### Rounding corners separately
 
-Use `rounded-tl-*`, `rounded-tr-*`, `rounded-br-*`, and `rounded-bl-*` utilities to only round one corner an element.
+Use `rounded-tl-*`, `rounded-tr-*`, `rounded-br-*`, and `rounded-bl-*` utilities to only round one corner of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/border-style.mdx
+++ b/src/pages/docs/border-style.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the border style
 
-Use `border-{style}` to control an element's border style.
+Use `border-*` to control an element's border style.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/border-width.mdx
+++ b/src/pages/docs/border-width.mdx
@@ -46,7 +46,7 @@ Use the `border`, `border-0`, `border-2`, `border-4`, or `border-8` utilities to
 
 ### Individual sides
 
-Use the `border-{side}`, `border-{side}-0`, `border-{side}-2`, `border-{side}-4`, or `border-{side}-8` utilities to set the border width for one side of an element.
+Use the `border-*`, `border-*-0`, `border-*-2`, `border-*-4`, or `border-*-8` utilities to set the border width for one side of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">
@@ -78,7 +78,7 @@ Use the `border-{side}`, `border-{side}-0`, `border-{side}-2`, `border-{side}-4`
 
 ### Horizontal and vertical sides
 
-Use the `border-{x|y}-{width}` utilities to set the border width on two sides of an element at the same time.
+Use the `border-x-*` and `border-y-*` utilities to set the border width on two sides of an element at the same time.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-around gap-4 text-white text-sm text-center font-bold leading-6">
@@ -100,7 +100,7 @@ Use the `border-{x|y}-{width}` utilities to set the border width on two sides of
 
 ### Between elements
 
-You can also add borders between child elements using the `divide-{x/y}-{width}` and `divide-{color}` utilities.
+You can also add borders between child elements using the `divide-x-*` and `divide-y-*` width utilities along with the `divide-*` color utilities.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex flex-col divide-y divide-slate-200 dark:divide-slate-700 font-mono text-white text-sm text-center font-bold leading-6 shadow-lg overflow-hidden max-w-sm mx-auto">
@@ -204,4 +204,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="border-{side}-{width}" featuredClass="border-t-[3px]" />
+<ArbitraryValues property="border-width" featuredClass="border-t-[3px]" />

--- a/src/pages/docs/box-shadow-color.mdx
+++ b/src/pages/docs/box-shadow-color.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the box shadow color
 
-Use the `shadow-{color}` utilities to change the color of an existing box shadow. By default colored shadows have an opacity of 100%, but you can adjust this using the opacity modifier.
+Use the `shadow-*` utilities to change the color of an existing box shadow. By default colored shadows have an opacity of 100%, but you can adjust this using the opacity modifier.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row justify-center gap-8 sm:gap-16">

--- a/src/pages/docs/box-sizing.mdx
+++ b/src/pages/docs/box-sizing.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Including borders and padding
 
-Use `box-border` to set an element's `box-sizing` to `border-box`, telling the browser to include the element's borders and padding when you give it a height or width.
+Use the `box-border` utility to set an element's `box-sizing` to `border-box`, telling the browser to include the element's borders and padding when you give it a height or width.
 
 This means a 100px &times; 100px element with a 2px border and 4px of padding on all sides will be rendered as 100px &times; 100px, with an internal content area of 88px &times; 88px.
 
@@ -77,7 +77,7 @@ Tailwind makes this the default for all elements in our [preflight base styles](
 
 ### Excluding borders and padding
 
-Use `box-content` to set an element's `box-sizing` to `content-box`, telling the browser to add borders and padding on top of the element's specified width or height.
+Use the `box-content` utility to set an element's `box-sizing` to `content-box`, telling the browser to add borders and padding on top of the element's specified width or height.
 
 This means a 100px &times; 100px element with a 2px border and 4px of padding on all sides will actually be rendered as 112px &times; 112px, with an internal content area of 100px &times; 100px.
 

--- a/src/pages/docs/break-after.mdx
+++ b/src/pages/docs/break-after.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the break-after behavior
 
-Use the `break-after-{value}` utilities to control how a column or page break should behave after an element. For example, use the `break-after-column` utility to force a column break after an element.
+Use the `break-after-*` utilities to control how a column or page break should behave after an element. For example, use the `break-after-column` utility to force a column break after an element.
 
 ```html
 <div class="columns-2">

--- a/src/pages/docs/break-before.mdx
+++ b/src/pages/docs/break-before.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the break-before behavior
 
-Use the `break-before-{value}` utilities to control how a column or page break should behave before an element. For example, use the `break-before-column` utility to force a column break before an element.
+Use the `break-before-*` utilities to control how a column or page break should behave before an element. For example, use the `break-before-column` utility to force a column break before an element.
 
 ```html
 <div class="columns-2">

--- a/src/pages/docs/break-inside.mdx
+++ b/src/pages/docs/break-inside.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the break-inside behavior
 
-Use the `break-inside-{value}` utilities to control how a column or page break should behave within an element. For example, use the `break-inside-avoid-column` utility to avoid a column break within an element.
+Use the `break-inside-*` utilities to control how a column or page break should behave within an element. For example, use the `break-inside-avoid-column` utility to avoid a column break within an element.
 
 ```html
 <div class="columns-2">

--- a/src/pages/docs/brightness.mdx
+++ b/src/pages/docs/brightness.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Changing element brightness
 
-Use the `brightness-{amount?}` utilities to control an element's brightness.
+Use the `brightness-*` utilities to control an element's brightness.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/caret-color.mdx
+++ b/src/pages/docs/caret-color.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the caret color
 
-Use the `caret-{color}` utilities to change the color of the text input cursor.
+Use the `caret-*` utilities to change the color of the text input cursor.
 
 ```html {{ example: { hint: 'Focus the textarea to see the new caret color' } }}
 <div class="w-full flex items-center justify-center">

--- a/src/pages/docs/clear.mdx
+++ b/src/pages/docs/clear.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Clearing left-floated elements
 
-Use `clear-left` to position an element below any preceding left-floated elements.
+Use the `clear-left` utility to position an element below any preceding left-floated elements.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 text-sm sm:text-base leading-6 sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -43,7 +43,7 @@ Use `clear-left` to position an element below any preceding left-floated element
 
 ### Clearing right-floated elements
 
-Use `clear-right` to position an element below any preceding right-floated elements.
+Use the `clear-right` utility to position an element below any preceding right-floated elements.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 text-sm sm:text-base leading-6 sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -73,7 +73,7 @@ Use `clear-right` to position an element below any preceding right-floated eleme
 
 ### Clearing all floated elements
 
-Use `clear-both` to position an element below all preceding floated elements.
+Use the `clear-both` utility to position an element below all preceding floated elements.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 text-sm sm:text-base leading-6 sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -103,7 +103,7 @@ Use `clear-both` to position an element below all preceding floated elements.
 
 ### Disabling applied clears
 
-Use `clear-none` to reset any clears that are applied to an element. This is the default value for the clear property.
+Use the `clear-none` utility to reset any clears that are applied to an element. This is the default value for the clear property.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 dark:bg-slate-800 dark:text-slate-400">

--- a/src/pages/docs/columns.mdx
+++ b/src/pages/docs/columns.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Adding based on column count
 
-Use the `columns-{count}` utilities to set the number of columns that should be created for the content within an element. The column width will be automatically adjusted to accommodate that number.
+Use utilities like `columns-2` and `columns-3` to set the number of columns that should be created for the content within an element. The column width will be automatically adjusted to accommodate that number.
 
 ```html {{ example: true }}
 <div class="relative">
@@ -74,7 +74,7 @@ Use the `columns-{count}` utilities to set the number of columns that should be 
 
 ### Adding based on column width
 
-Use the `columns-{width}` utilities to set the ideal column width for the content within an element, with the number of columns (the count) automatically adjusting to accommodate that value.
+Use utilities like `columns-xs` and `columns-sm` to set the ideal column width for the content within an element, with the number of columns (the count) automatically adjusting to accommodate that value.
 
 This "t-shirt" scale is the same as the [max-width](/docs/max-width) scale, with the addition of `2xs` and `3xs`, since smaller columns may be desirable.
 

--- a/src/pages/docs/container.mdx
+++ b/src/pages/docs/container.mdx
@@ -70,7 +70,7 @@ To center a container, use the `mx-auto` utility:
 </div>
 ```
 
-To add horizontal padding, use the `px-{size}` utilities:
+To add horizontal padding, use the `px-*` utilities:
 
 ```html
 <div class="container mx-auto **px-4**">

--- a/src/pages/docs/content.mdx
+++ b/src/pages/docs/content.mdx
@@ -17,7 +17,7 @@ export const classes = {
 
 ### Setting a pseudo-element's content
 
-Use the `content-{value}` utilities along with the `before` and `after` variant modifiers to set the contents of the `::before` and `::after` pseudo-elements.
+Use the `content-*` utilities along with the `before` and `after` variant modifiers to set the contents of the `::before` and `::after` pseudo-elements.
 
 Out of the box, `content-none` is the only available preconfigured content utility. And while you can add additional utilities by [customizing your theme](#customizing-your-theme), it generally makes more sense to just use an arbitrary value.
 

--- a/src/pages/docs/contrast.mdx
+++ b/src/pages/docs/contrast.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Changing element contrast
 
-Use the `contrast-{amount?}` utilities to control an element's contrast.
+Use the `contrast-*` utilities to control an element's contrast.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/cursor.mdx
+++ b/src/pages/docs/cursor.mdx
@@ -27,7 +27,7 @@ export const classes = {
 
 ### Setting the cursor style
 
-Use the `cursor-{style}` to control which cursor is displayed when hovering over an element.
+Use the `cursor-*` utilities to control which cursor is displayed when hovering over an element.
 
 ```html {{ example: { hint: 'Hover over each button to see the cursor change' } }}
 <div class="flex flex-col sm:flex-row gap-4 sm:gap-0 items-center justify-around">

--- a/src/pages/docs/display.mdx
+++ b/src/pages/docs/display.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Block & Inline
 
-Use `inline`, `inline-block`, and `block` to control the flow of text and elements.
+Use the `inline`, `inline-block`, and `block` utilities to control the flow of text and elements.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-auto max-w-xs bg-white shadow-xl p-4 text-slate-500 text-sm leading-6 sm:text-base sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -46,7 +46,7 @@ Use `inline`, `inline-block`, and `block` to control the flow of text and elemen
 
 ### Flow Root
 
-Use `flow-root` to create a block-level element with its own [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context).
+Use the `flow-root` utility to create a block-level element with its own [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context).
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-auto max-w-xs bg-white shadow-xl p-4 text-slate-500 text-sm leading-6 sm:text-base sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -72,7 +72,7 @@ Use `flow-root` to create a block-level element with its own [block formatting c
 
 ### Flex
 
-Use `flex` to create a block-level flex container.
+Use the `flex` utility to create a block-level flex container.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-auto max-w-xs bg-white shadow-xl p-4 text-slate-500 leading-6 flex justify-center dark:bg-slate-800 dark:text-slate-400">
@@ -98,7 +98,7 @@ Use `flex` to create a block-level flex container.
 
 ### Inline Flex
 
-Use `inline-flex` to create an inline flex container that flows with text.
+Use the `inline-flex` utility to create an inline flex container that flows with text.
 
 ```html {{ example: { p: 'none' } }}
 <p class="mx-auto max-w-lg bg-white shadow-xl p-4 text-slate-500 text-sm leading-6 sm:text-base sm:leading-7 dark:bg-slate-800 dark:text-slate-400">
@@ -119,7 +119,7 @@ Use `inline-flex` to create an inline flex container that flows with text.
 
 ### Grid
 
-Use `grid` to create a grid container.
+Use the `grid` utility to create a grid container.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 grid-rows-3 gap-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-fuchsia rounded-lg text-center">
@@ -143,7 +143,7 @@ Use `grid` to create a grid container.
 
 ### Inline Grid
 
-Use `inline-grid` to create an inline grid container.
+Use the `inline-grid` utility to create an inline grid container.
 
 ```html {{ example: { p: 'none' } }}
 <div class="space-x-3 overflow-x-scroll w-full p-8 whitespace-nowrap">
@@ -187,7 +187,7 @@ Use `inline-grid` to create an inline grid container.
 
 ### Contents
 
-Use `contents` to create a "phantom" container whose children act like direct children of the parent.
+Use the `contents` utility to create a "phantom" container whose children act like direct children of the parent.
 
 ```html {{ example: true }}
 <div class="flex gap-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-purple rounded-lg text-center">
@@ -277,7 +277,7 @@ Use the `table`, `table-row`, `table-cell`, `table-caption`, `table-column`, `ta
 
 ### Hidden
 
-Use `hidden` to set an element to `display: none` and remove it from the page layout (compare with `invisible` from the [visibility](/docs/visibility#invisible) documentation).
+Use the `hidden` utility to set an element to `display: none` and remove it from the page layout (compare with `invisible` from the [visibility](/docs/visibility#invisible) documentation).
 
 ```html {{ example: true }}
 <div class="flex gap-4 font-mono text-white text-sm font-bold leading-6 bg-stripes-purple rounded-lg text-center">

--- a/src/pages/docs/divide-color.mdx
+++ b/src/pages/docs/divide-color.mdx
@@ -44,7 +44,7 @@ export const classes = {
 
 ### Setting the divide color
 
-Control the border color between elements using the `divide-{color}` utilities.
+Use the `divide-*` utilities to control the border color between elements.
 
 ```html {{ example: { p: 'none' } }}
 <div class="grid grid-cols-1 divide-y divide-blue-200 font-mono text-white text-sm text-center font-bold leading-6 shadow-lg overflow-hidden max-w-sm mx-auto">
@@ -110,4 +110,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property="divide-{color}" featuredClass="divide-[#243c5a]" />
+<ArbitraryValues property={<>divide color</>} featuredClass="divide-[#243c5a]" />

--- a/src/pages/docs/divide-color.mdx
+++ b/src/pages/docs/divide-color.mdx
@@ -64,7 +64,7 @@ Use the `divide-*` utilities to control the border color between elements.
 
 ### Changing the opacity
 
-Control the opacity of the divide color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of the divide color.
 
 ```html {{ example: { p: 'none' } }}
 <div class="grid grid-cols-1 divide-y-4 divide-slate-400/25 font-mono text-white text-sm text-center font-bold leading-6 shadow-lg overflow-hidden max-w-sm mx-auto">

--- a/src/pages/docs/divide-color.mdx
+++ b/src/pages/docs/divide-color.mdx
@@ -110,4 +110,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property={<>divide color</>} featuredClass="divide-[#243c5a]" />
+<ArbitraryValues name="divide color" featuredClass="divide-[#243c5a]" />

--- a/src/pages/docs/divide-style.mdx
+++ b/src/pages/docs/divide-style.mdx
@@ -20,7 +20,7 @@ export const classes = {
 
 ### Set the divide style
 
-Control the border style between elements using the `divide-{style}` utilities.
+Use the `divide-*` utilities to control the border style between elements.
 
 ```html {{ example: { p: 'none' } }}
 <div class="grid grid-cols-1 divide-dashed divide-y font-mono text-sm text-center font-bold leading-6 shadow-lg overflow-hidden max-w-sm mx-auto dark:divide-slate-700">

--- a/src/pages/docs/divide-width.mdx
+++ b/src/pages/docs/divide-width.mdx
@@ -33,7 +33,7 @@ export const classes = {
 
 ### Add borders between horizontal children
 
-Add borders between horizontal elements using the `divide-x-{width}` utilities.
+Use the `divide-x-*` utilities to add borders between horizontal elements.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 divide-x font-mono text-sm text-center font-bold leading-6 rounded-lg shadow-lg overflow-hidden dark:divide-slate-700">
@@ -53,7 +53,7 @@ Add borders between horizontal elements using the `divide-x-{width}` utilities.
 
 ### Add borders between stacked children
 
-Add borders between stacked elements using the `divide-y-{width}` utilities.
+Use the `divide-y-*` utilities to add borders between stacked elements.
 
 ```html {{ example: { p: 'none' } }}
 <div class="grid grid-cols-1 divide-y font-mono text-sm text-center font-bold leading-6 shadow-lg overflow-hidden max-w-sm mx-auto dark:divide-slate-700">
@@ -149,4 +149,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="divide-{x|y}-{width}" featuredClass="divide-x-[3px]" />
+<ArbitraryValues property={<>divide width</>} featuredClass="divide-x-[3px]" />

--- a/src/pages/docs/divide-width.mdx
+++ b/src/pages/docs/divide-width.mdx
@@ -149,4 +149,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property={<>divide width</>} featuredClass="divide-x-[3px]" />
+<ArbitraryValues name="divide width" featuredClass="divide-x-[3px]" />

--- a/src/pages/docs/drop-shadow.mdx
+++ b/src/pages/docs/drop-shadow.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Adding a drop shadow
 
-Use the `drop-shadow-{amount}` utilities to add a drop shadow to an element.
+Use the `drop-shadow-*` utilities to add a drop shadow to an element.
 
 ```html {{ example: { p: 'none', lightOnly: true } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/fill.mdx
+++ b/src/pages/docs/fill.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the fill color
 
-Use the `fill-{color}` utilities to change the fill color of an SVG.
+Use the `fill-*` utilities to change the fill color of an SVG.
 
 ```html {{ example: true }}
 <div class="flex items-center justify-center">

--- a/src/pages/docs/flex-basis.mdx
+++ b/src/pages/docs/flex-basis.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the flex basis
 
-Use the `basis-{size}` utilities to set the initial size of flex items.
+Use the `basis-*` utilities to set the initial size of flex items.
 
 ```html {{ example: true }}
 <div class="flex flex-row space-x-4 font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/float.mdx
+++ b/src/pages/docs/float.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Floating elements to the right
 
-Use `float-right` to float an element to the right of its container.
+Use the `float-right` utility to float an element to the right of its container.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 dark:bg-slate-800 dark:text-slate-400">
@@ -34,7 +34,7 @@ Use `float-right` to float an element to the right of its container.
 
 ### Floating elements to the left
 
-Use `float-left` to float an element to the left of its container.
+Use the `float-left` utility to float an element to the left of its container.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 dark:bg-slate-800 dark:text-slate-400">
@@ -55,7 +55,7 @@ Use `float-left` to float an element to the left of its container.
 
 ### Disabling a float
 
-Use `float-none` to reset any floats that are applied to an element. This is the default value for the float property.
+Use the `float-none` utility to reset any floats that are applied to an element. This is the default value for the float property.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="mx-4 bg-white shadow-xl p-8 text-slate-700 dark:bg-slate-800 dark:text-slate-400">
@@ -77,7 +77,7 @@ Use `float-none` to reset any floats that are applied to an element. This is the
 
 ### Using logical properties
 
-Use the `float-start` or `float-end` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts), which map to either the left or right side based on the text direction.
+Use the `float-start` or `float-end` utilities, which use [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts) to map to either the left or right side based on the text direction.
 
 ```html {{ example: { resizable: true, p: 'none' } }}
 <div class="grid grid-flow-row gap-4 p-4">

--- a/src/pages/docs/font-size.mdx
+++ b/src/pages/docs/font-size.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the font size
 
-Control the font size of an element using the `text-{size}` utilities.
+Use the `text-*` utilities to control the font size of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8">
@@ -138,7 +138,7 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 #### Providing a default line-height
 
-Tailwind's default theme configures a sensible default `line-height` for each `text-{size}` utility. You can configure your own default line heights when using custom font sizes by defining each size using a tuple of the form `[fontSize, lineHeight]` in your `tailwind.config.js` file.
+Tailwind's default theme configures a sensible default `line-height` for each `font-size` utility. You can configure your own default line heights when using custom font sizes by defining each size using a tuple of the form `[fontSize, lineHeight]` in your `tailwind.config.js` file.
 
 ```js {{ filename: 'tailwind.config.js' }}
 /** @type {import('tailwindcss').Config} */

--- a/src/pages/docs/font-weight.mdx
+++ b/src/pages/docs/font-weight.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the font weight
 
-Control the font weight of an element using the `font-{weight}` utilities.
+Use the `font-*` utilities to control the font weight of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8">

--- a/src/pages/docs/gap.mdx
+++ b/src/pages/docs/gap.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the gap between elements
 
-Use `gap-{size}` to change the gap between both rows and columns in grid and flexbox layouts.
+Use the `gap-*` utilities to change the gap between both rows and columns in grid and flexbox layouts.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-2 gap-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-violet rounded-lg">
@@ -40,7 +40,7 @@ Use `gap-{size}` to change the gap between both rows and columns in grid and fle
 
 ### Changing row and column gaps independently
 
-Use `gap-x-{size}` and `gap-y-{size}` to change the gap between columns and rows independently.
+Use the `gap-x-*` and `gap-y-*` utilities to change the gap between columns and rows independently.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-x-8 gap-y-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-sky rounded-lg">

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -90,7 +90,7 @@ Use the `to-*` utilities to set the ending color of a gradient.
 <div class="bg-gradient-to-r from-cyan-500 **to-blue-500** ..."></div>
 ```
 
-Gradients to **do not** fade in from transparent by default. To fade in from transparent, reverse the gradient direction and use a `from-*` utility.
+Gradients **do not** fade in from transparent by default. To fade in from transparent, reverse the gradient direction and use a `from-*` utility.
 
 ### Middle color
 

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -42,7 +42,7 @@ export const classes = {
 
 ### Starting color
 
-Set the starting color of a gradient using the `from-{color}` utilities.
+Use the `from-*` utilities to set the starting color of a gradient.
 
 ```html {{ example: true }}
 <div class="mx-5">
@@ -64,7 +64,7 @@ Set the starting color of a gradient using the `from-{color}` utilities.
 
 ### Ending color
 
-Set the ending color of a gradient using the `to-{color}` utilities.
+Use the `to-*` utilities to set the ending color of a gradient.
 
 ```html {{ example: true }}
 <div class="mx-5">
@@ -90,11 +90,11 @@ Set the ending color of a gradient using the `to-{color}` utilities.
 <div class="bg-gradient-to-r from-cyan-500 **to-blue-500** ..."></div>
 ```
 
-Gradients to **do not** fade in from transparent by default. To fade in from transparent, reverse the gradient direction and use a `from-{color}` utility.
+Gradients to **do not** fade in from transparent by default. To fade in from transparent, reverse the gradient direction and use a `from-*` utility.
 
 ### Middle color
 
-Add a middle color to a gradient using the `via-{color}` utilities.
+Use the `via-*` utilities to add a middle color to a gradient.
 
 ```html {{ example: true }}
 <div class="mx-5">
@@ -126,11 +126,11 @@ Add a middle color to a gradient using the `via-{color}` utilities.
 <div class="bg-gradient-to-r from-indigo-500 **via-purple-500** to-pink-500 ..."></div>
 ```
 
-Gradients with a `from-{color}` and `via-{color}` will fade out to transparent by default if no `to-{color}` is present.
+Gradients with a `from-*` and `via-*` will fade out to transparent by default if no `to-*` is present.
 
 ### Specifying stop positions
 
-For more control over the gradient color stop positions, combine the `from-{position}`, `via-{position}` and `to-{position}` utilities with the gradient color utilities.
+For more control over the gradient color stop positions, combine the gradient color utilities with gradient position utilities like `from-10%`, `via-30%` and `to-90%`.
 
 ```html {{ example: true }}
 <div class="mx-5">

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -239,4 +239,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="from|via|to-{color|position}" featuredClass="from-[#243c5a]" />
+<ArbitraryValues name="gradient color stop" featuredClass="from-[#243c5a]" />

--- a/src/pages/docs/grid-auto-columns.mdx
+++ b/src/pages/docs/grid-auto-columns.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Sizing implicitly-created grid columns
 
-Use the `auto-cols-{size}` utilities to control the size of implicitly-created grid columns.
+Use the `auto-cols-*` utilities to control the size of implicitly-created grid columns.
 
 ```html
 <div class="grid grid-flow-col **auto-cols-max**">

--- a/src/pages/docs/grid-auto-flow.mdx
+++ b/src/pages/docs/grid-auto-flow.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Controlling grid element placement
 
-Use the `grid-flow-{keyword}` utilities to control how the auto-placement algorithm works for a grid layout.
+Use the `grid-flow-*` utilities to control how the auto-placement algorithm works for a grid layout.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 grid-rows-3 grid-flow-row-dense gap-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-purple rounded-lg">

--- a/src/pages/docs/grid-auto-rows.mdx
+++ b/src/pages/docs/grid-auto-rows.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Sizing implicitly-created grid rows
 
-Use the `auto-rows-{size}` utilities to control the size of implicitly-created grid rows.
+Use the `auto-rows-*` utilities to control the size of implicitly-created grid rows.
 
 ```html
 <div class="grid grid-flow-row **auto-rows-max**">

--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -92,7 +92,7 @@ Note that CSS grid lines start at 1, not 0, so a full-width element in a 6-colum
 
 By default, Tailwind includes grid-column utilities for working with grids with up to 12 columns. You change, add, or remove these by customizing the `gridColumn`, `gridColumnStart`, and `gridColumnEnd` sections of your Tailwind theme config.
 
-To add new `grid-column` utilities, customize the `gridColumn` section of your Tailwind theme config:
+To add new `col-*` utilities, customize the `gridColumn` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -148,4 +148,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="grid-column/grid-column-start/grid-column-end" featuredClass="col-[16_/_span_16]" />
+<ArbitraryValues name="grid column" featuredClass="col-[16_/_span_16]" />

--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Spanning columns
 
-Use the `col-span-{n}` utilities to make an element span _n_ columns.
+Use the `col-span-*` utilities to make an element span _n_ columns.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 font-mono text-white text-sm text-center font-bold leading-6">
@@ -46,7 +46,7 @@ Use the `col-span-{n}` utilities to make an element span _n_ columns.
 
 ### Starting and ending lines
 
-Use the `col-start-{n}` and `col-end-{n}` utilities to make an element start or end at the _nth_ grid line. These can also be combined with the `col-span-{n}` utilities to span a specific number of columns.
+Use the `col-start-*` and `col-end-*` utilities to make an element start or end at the _nth_ grid line. These can also be combined with the `col-span-*` utilities to span a specific number of columns.
 
 Note that CSS grid lines start at 1, not 0, so a full-width element in a 6-column grid would start at line 1 and end at line 7.
 
@@ -92,7 +92,7 @@ Note that CSS grid lines start at 1, not 0, so a full-width element in a 6-colum
 
 By default, Tailwind includes grid-column utilities for working with grids with up to 12 columns. You change, add, or remove these by customizing the `gridColumn`, `gridColumnStart`, and `gridColumnEnd` sections of your Tailwind theme config.
 
-For creating more `col-{value}` utilities that control the `grid-column` shorthand property directly, customize the `gridColumn` section of your Tailwind theme config:
+To add new `grid-column` utilities, customize the `gridColumn` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
@@ -106,9 +106,9 @@ For creating more `col-{value}` utilities that control the `grid-column` shortha
   }
 ```
 
-We use this internally for our `col-span-{n}` utilities. Note that since this configures the `grid-column` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
+We use this internally for our `col-span-*` utilities. Note that since this configures the `grid-column` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
 
-To add new `col-start-{n}` utilities, use the `gridColumnStart` section of your Tailwind theme config:
+To add new `grid-column-start` utilities, customize the `gridColumnStart` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
@@ -126,7 +126,7 @@ To add new `col-start-{n}` utilities, use the `gridColumnStart` section of your 
   }
 ```
 
-To add new `col-end-{n}` utilities, use the `gridColumnEnd` section of your Tailwind theme config:
+To add new `grid-column-end` utilities, customize the `gridColumnEnd` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -126,7 +126,7 @@ To add new `col-start-*` utilities, customize the `gridColumnStart` section of y
   }
 ```
 
-To add new `grid-column-end` utilities, customize the `gridColumnEnd` section of your Tailwind theme config:
+To add new `col-end-*` utilities, customize the `gridColumnEnd` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-column.mdx
+++ b/src/pages/docs/grid-column.mdx
@@ -108,7 +108,7 @@ To add new `col-*` utilities, customize the `gridColumn` section of your Tailwin
 
 We use this internally for our `col-span-*` utilities. Note that since this configures the `grid-column` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
 
-To add new `grid-column-start` utilities, customize the `gridColumnStart` section of your Tailwind theme config:
+To add new `col-start-*` utilities, customize the `gridColumnStart` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -113,7 +113,7 @@ To add new `row-start-*` utilities, customize the `gridRowStart` section of your
   }
 ```
 
-To add new `grid-row-end` utilities, customize the `gridRowEnd` section of your Tailwind theme config:
+To add new `row-end-*` utilities, customize the `gridRowEnd` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -78,7 +78,7 @@ Note that CSS grid lines start at 1, not 0, so a full-height element in a 3-row 
 
 By default, Tailwind includes grid-row utilities for working with grids with up to 6 explicit rows. You can customize these values by editing `theme.gridRow`, `theme.extend.gridRow`, `theme.gridRowStart`, `theme.extend.gridRowStart`, `theme.gridRowEnd`, and `theme.extend.gridRowEnd` in your `tailwind.config.js` file.
 
-To add new `grid-row` utilities, customize the `gridRow` section of your Tailwind theme config:
+To add new `row-*` utilities, customize the `gridRow` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Spanning rows
 
-Use the `row-span-{n}` utilities to make an element span _n_ rows.
+Use the `row-span-*` utilities to make an element span _n_ rows.
 
 ```html {{ example: true }}
 <div class="grid grid-rows-3 grid-flow-col gap-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-fuchsia rounded-lg">
@@ -38,7 +38,7 @@ Use the `row-span-{n}` utilities to make an element span _n_ rows.
 
 ### Starting and ending lines
 
-Use the `row-start-{n}` and `row-end-{n}` utilities to make an element start or end at the _nth_ grid line. These can also be combined with the `row-span-{n}` utilities to span a specific number of rows.
+Use the `row-start-*` and `row-end-*` utilities to make an element start or end at the _nth_ grid line. These can also be combined with the `row-span-*` utilities to span a specific number of rows.
 
 Note that CSS grid lines start at 1, not 0, so a full-height element in a 3-row grid would start at line 1 and end at line 4.
 
@@ -78,7 +78,7 @@ Note that CSS grid lines start at 1, not 0, so a full-height element in a 3-row 
 
 By default, Tailwind includes grid-row utilities for working with grids with up to 6 explicit rows. You can customize these values by editing `theme.gridRow`, `theme.extend.gridRow`, `theme.gridRowStart`, `theme.extend.gridRowStart`, `theme.gridRowEnd`, and `theme.extend.gridRowEnd` in your `tailwind.config.js` file.
 
-For creating more `row-{value}` utilities that control the `grid-row` shorthand property directly, customize the `gridRow` section of your Tailwind theme config:
+To add new `grid-row` utilities, customize the `gridRow` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
@@ -92,9 +92,9 @@ For creating more `row-{value}` utilities that control the `grid-row` shorthand 
   }
 ```
 
-We use this internally for our `row-span-{n}` utilities. Note that since this configures the `grid-row` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
+We use this internally for our `row-span-*` utilities. Note that since this configures the `grid-row` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
 
-To add new `row-start-{n}` utilities, use the `gridRowStart` section of your Tailwind theme config:
+To add new `grid-row-start` utilities, customize the `gridRowStart` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {
@@ -113,7 +113,7 @@ To add new `row-start-{n}` utilities, use the `gridRowStart` section of your Tai
   }
 ```
 
-To add new `row-end-{n}` utilities, use the `gridRowEnd` section of your Tailwind theme config:
+To add new `grid-row-end` utilities, customize the `gridRowEnd` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -94,7 +94,7 @@ To add new `row-*` utilities, customize the `gridRow` section of your Tailwind t
 
 We use this internally for our `row-span-*` utilities. Note that since this configures the `grid-row` shorthand property directly, we include the word `span` directly in the value name, it's _not_ baked into the class name automatically. That means you are free to add entries that do whatever you want here — they don't just have to be `span` utilities.
 
-To add new `grid-row-start` utilities, customize the `gridRowStart` section of your Tailwind theme config:
+To add new `row-start-*` utilities, customize the `gridRowStart` section of your Tailwind theme config:
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/grid-row.mdx
+++ b/src/pages/docs/grid-row.mdx
@@ -136,4 +136,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="grid-row/grid-row-start/grid-row-end" featuredClass="row-[span_16_/_span_16]" />
+<ArbitraryValues name="grid row" featuredClass="row-[span_16_/_span_16]" />

--- a/src/pages/docs/grid-template-columns.mdx
+++ b/src/pages/docs/grid-template-columns.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Specifying the columns in a grid
 
-Use the `grid-cols-{n}` utilities to create grids with _n_ equally sized columns.
+Use the `grid-cols-*` utilities to create grids with _n_ equally sized columns.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-4 gap-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-fuchsia rounded-lg">

--- a/src/pages/docs/grid-template-rows.mdx
+++ b/src/pages/docs/grid-template-rows.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Specifying the rows in a grid
 
-Use the `grid-rows-{n}` utilities to create grids with _n_ equally sized rows.
+Use the `grid-rows-*` utilities to create grids with _n_ equally sized rows.
 
 ```html {{ example: true }}
 <div class="grid grid-rows-4 grid-flow-col gap-4 font-mono text-white text-sm text-center font-bold leading-6 bg-stripes-pink rounded-lg">

--- a/src/pages/docs/height.mdx
+++ b/src/pages/docs/height.mdx
@@ -19,7 +19,7 @@ export const classes = {
 
 ### Fixed heights
 
-Use `h-{number}` or `h-px` to set an element to a fixed height.
+Use utilities like `h-px`, `h-1`, and `h-64` to set an element to a fixed height.
 
 ```html {{ example: true }}
 <div class="flex justify-center items-end space-x-4 font-mono font-bold text-xs text-center text-white">

--- a/src/pages/docs/hue-rotate.mdx
+++ b/src/pages/docs/hue-rotate.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Rotating an element's hue
 
-Use the `hue-rotate-{amount}` utilities to rotate the hue of an element.
+Use the `hue-rotate-*` utilities to rotate the hue of an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/letter-spacing.mdx
+++ b/src/pages/docs/letter-spacing.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the letter spacing
 
-Control the letter spacing of an element using the `tracking-{size}` utilities.
+Use the `tracking-*` utilities to control the letter spacing of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8">
@@ -92,7 +92,7 @@ module.exports = {
 
 ### Customizing your theme
 
-By default, Tailwind provides six tracking utilities. You can change, add, or remove these by editing the `theme.letterSpacing` section of your Tailwind config.
+By default, Tailwind provides six `letter-spacing` utilities. You can change, add, or remove these by editing the `theme.letterSpacing` section of your Tailwind config.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/line-height.mdx
+++ b/src/pages/docs/line-height.mdx
@@ -47,7 +47,7 @@ Use the `leading-none`, `leading-tight`, `leading-snug`, `leading-normal`, `lead
 
 ### Fixed line-heights
 
-Use the `leading-{size}` utilities to give an element a fixed line-height, irrespective of the current font-size. These are useful when you need very precise control over an element's final size.
+Use utilities like `leading-6` and `leading-7` to give an element a fixed line-height, irrespective of the current font-size. These are useful when you need very precise control over an element's final size.
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8">

--- a/src/pages/docs/list-style-image.mdx
+++ b/src/pages/docs/list-style-image.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the list style image
 
-Control the marker image for list items using the `list-image-{value}` utilities.
+Use the `list-image-*` utilities to control the marker image for list items.
 
 Out of the box, `list-image-none` is the only available preconfigured list style image utility. And while you can add additional utilities by [customizing your theme](#customizing-your-theme), you can also use the square bracket notation to generate an arbitrary value on the fly.
 
@@ -79,4 +79,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="list-image" featuredClass="list-image-[url(checkmark.png)]" element="ul" />
+<ArbitraryValues property="list-style-image" featuredClass="list-image-[url(checkmark.png)]" element="ul" />

--- a/src/pages/docs/list-style-position.mdx
+++ b/src/pages/docs/list-style-position.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting the list style position
 
-Control the position of the markers and text indentation in a list using the `list-inside` and `list-outside` utilities.
+Use the `list-inside` and `list-outside` utilities to control the position of the markers and text indentation in a list.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row gap-8">

--- a/src/pages/docs/margin.mdx
+++ b/src/pages/docs/margin.mdx
@@ -56,7 +56,7 @@ For example, `mt-6` would add `1.5rem` of margin to the top of an element, `mr-4
 
 ### Add horizontal margin
 
-Control the horizontal margin of an element using the `mx-*` utilities.
+Use the `mx-*` utilities to control the horizontal margin of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -72,7 +72,7 @@ Control the horizontal margin of an element using the `mx-*` utilities.
 
 ### Add vertical margin
 
-Control the vertical margin of an element using the `my-*` utilities.
+Use the `my-*` utilities to control the vertical margin of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -88,7 +88,7 @@ Control the vertical margin of an element using the `my-*` utilities.
 
 ### Add margin to all sides
 
-Control the margin on all sides of an element using the `m-*` utilities.
+Use the `m-*` utilities to control the margin on all sides of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/margin.mdx
+++ b/src/pages/docs/margin.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Add margin to a single side
 
-Control the margin on one side of an element using the `m{t|r|b|l}-{size}` utilities.
+Use the `mt-*`, `mr-*`, `mb-*`, and `ml-*` utilities to control the margin on one side of an element.
 
 For example, `mt-6` would add `1.5rem` of margin to the top of an element, `mr-4` would add `1rem` of margin to the right of an element, `mb-8` would add `2rem` of margin to the bottom of an element, and `ml-2` would add `0.5rem` of margin to the left of an element.
 
@@ -56,7 +56,7 @@ For example, `mt-6` would add `1.5rem` of margin to the top of an element, `mr-4
 
 ### Add horizontal margin
 
-Control the horizontal margin of an element using the `mx-{size}` utilities.
+Control the horizontal margin of an element using the `mx-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -72,7 +72,7 @@ Control the horizontal margin of an element using the `mx-{size}` utilities.
 
 ### Add vertical margin
 
-Control the vertical margin of an element using the `my-{size}` utilities.
+Control the vertical margin of an element using the `my-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -88,7 +88,7 @@ Control the vertical margin of an element using the `my-{size}` utilities.
 
 ### Add margin to all sides
 
-Control the margin on all sides of an element using the `m-{size}` utilities.
+Control the margin on all sides of an element using the `m-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/max-width.mdx
+++ b/src/pages/docs/max-width.mdx
@@ -121,7 +121,7 @@ The `max-w-prose` utility gives an element a max-width optimized for readability
 
 ### Constraining to your breakpoints
 
-The `max-w-screen-{breakpoint}` classes can be used to give an element a max-width matching a specific breakpoint. These values are automatically derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
+The `max-w-screen-*` classes can be used to give an element a max-width matching a specific breakpoint. These values are automatically derived from the [`theme.screens` section](/docs/theme#screens) of your `tailwind.config.js` file.
 
 ```html
 <div class="max-w-screen-2xl">

--- a/src/pages/docs/mix-blend-mode.mdx
+++ b/src/pages/docs/mix-blend-mode.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Setting an element's blend mode
 
-Use the `mix-blend-{mode}` utilities to control how an element's content should be blended with the background.
+Use the `mix-blend-*` utilities to control how an element's content should be blended with the background.
 
 ```html {{ example: true }}
 <div class="flex justify-center -space-x-14">

--- a/src/pages/docs/object-fit.mdx
+++ b/src/pages/docs/object-fit.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Resizing to cover a container
 
-Resize an element's content to cover its container using `object-cover`.
+Use the `object-cover` utility to resize an element's content to cover its container.
 
 ```html {{ example: true }}
 <div class="text-center rounded-lg overflow-hidden w-56 sm:w-96 mx-auto">
@@ -29,7 +29,7 @@ Resize an element's content to cover its container using `object-cover`.
 
 ### Containing an element
 
-Resize an element's content to stay contained within its container using `object-contain`.
+Use the `object-contain` utility to resize an element's content to stay contained within its container.
 
 ```html {{ example: true }}
 <div class="relative rounded-lg text-center overflow-hidden w-56 sm:w-96 mx-auto">
@@ -46,7 +46,7 @@ Resize an element's content to stay contained within its container using `object
 
 ### Stretching to fit a container
 
-Stretch an element's content to fit its container using `object-fill`.
+Use the `object-fill` utility to stretch an element's content to fit its container.
 
 ```html {{ example: true }}
 <div class="bg-stripes-sky-blue rounded-lg text-center overflow-hidden w-56 sm:w-96 mx-auto">
@@ -62,7 +62,7 @@ Stretch an element's content to fit its container using `object-fill`.
 
 ### Scaling down if too large
 
-Display an element's content at its original size but scale it down to fit its container if necessary using `object-scale-down`.
+Use the `object-scale-down` utility to display an element's content at its original size but scale it down to fit its container if necessary.
 
 ```html {{ example: true }}
 <div class="relative rounded-lg text-center overflow-hidden w-56 sm:w-96 mx-auto">
@@ -79,7 +79,7 @@ Display an element's content at its original size but scale it down to fit its c
 
 ### Using an element's original size
 
-Display an element's content at its original size ignoring the container size using `object-none`.
+Use the `object-none` utility to display an element's content at its original size ignoring the container size.
 
 ```html {{ example: true }}
 <div class="relative rounded-lg text-center overflow-hidden w-56 sm:w-96 mx-auto">

--- a/src/pages/docs/object-position.mdx
+++ b/src/pages/docs/object-position.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Positioning a replaced element
 
-Use the `object-{side}` utilities to specify how a replaced element's content should be positioned within its container.
+Use the `object-*` utilities to specify how a replaced element's content should be positioned within its container.
 
 ```html {{ example: { p: 'none' } }}
 <div class="w-full">

--- a/src/pages/docs/opacity.mdx
+++ b/src/pages/docs/opacity.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Changing an element's opacity
 
-Control the opacity of an element using the `opacity-{amount}` utilities.
+Use the `opacity-*` utilities to control the opacity of an element.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-16 text-white text-sm font-bold leading-6">

--- a/src/pages/docs/order.mdx
+++ b/src/pages/docs/order.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Ordering flex and grid items
 
-Use `order-{order}` to render flex and grid items in a different order than they appear in the DOM.
+Use the `order-*` utilities to render flex and grid items in a different order than they appear in the DOM.
 
 ```html {{ example: true }}
 <div class="flex justify-between font-mono text-white text-sm font-bold leading-6">
@@ -60,7 +60,7 @@ To use a negative order value, prefix the class name with a dash to convert it t
 
 ### Customizing your theme
 
-By default, Tailwind provides utilities for `order-first`, `order-last`, `order-none`, and an `order-{number}` utility for the numbers 1 through 12. You can customize these values by editing `theme.order` or `theme.extend.order` in your `tailwind.config.js` file.
+By default, Tailwind provides utilities for `order-first`, `order-last`, `order-none`, and numbered utilities from 1 through 12. You can customize these values by editing `theme.order` or `theme.extend.order` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/outline-color.mdx
+++ b/src/pages/docs/outline-color.mdx
@@ -42,7 +42,7 @@ Use the `outline-*` utilities to change the color of an element's outline.
 
 ### Changing the opacity
 
-Control the opacity of an element's outline color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's outline color.
 
 ```html {{ example: true }}
 <div class="text-center font-bold text-sm text-white">

--- a/src/pages/docs/outline-color.mdx
+++ b/src/pages/docs/outline-color.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the outline color
 
-Use the `outline-{color}` utilities to change the color of an element's outline.
+Use the `outline-*` utilities to change the color of an element's outline.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-16 font-bold text-sm text-white text-center">

--- a/src/pages/docs/outline-offset.mdx
+++ b/src/pages/docs/outline-offset.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the outline offset
 
-Use the `outline-{offset}` utilities to change the offset of an element's outline.
+Use the `outline-*` utilities to change the offset of an element's outline.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-1 gap-8 sm:grid-cols-3 sm:gap-4 font-bold text-white text-sm text-center">
@@ -57,7 +57,7 @@ Use the `outline-{offset}` utilities to change the offset of an element's outlin
 
 ### Customizing your theme
 
-You can customize the `outline-offset-{width}` utilities by editing `theme.outlineOffset` or `theme.extend.outlineOffset` in your `tailwind.config.js` file.
+You can customize the `outline-offset` utilities by editing `theme.outlineOffset` or `theme.extend.outlineOffset` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/outline-offset.mdx
+++ b/src/pages/docs/outline-offset.mdx
@@ -57,7 +57,7 @@ Use the `outline-*` utilities to change the offset of an element's outline.
 
 ### Customizing your theme
 
-You can customize the `outline-offset` utilities by editing `theme.outlineOffset` or `theme.extend.outlineOffset` in your `tailwind.config.js` file.
+You can customize the `outline-offset-*` utilities by editing `theme.outlineOffset` or `theme.extend.outlineOffset` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/outline-style.mdx
+++ b/src/pages/docs/outline-style.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the outline style
 
-Use the `outline-{style}` utilities to change the style of an element's outline.
+Use the `outline-*` utilities to change the style of an element's outline.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-6 text-white text-sm font-semibold text-center">

--- a/src/pages/docs/outline-width.mdx
+++ b/src/pages/docs/outline-width.mdx
@@ -59,7 +59,7 @@ The default outline width is `3px`.
 
 ### Customizing your theme
 
-You can customize the `outline-width` utilities by editing `theme.outlineWidth` or `theme.extend.outlineWidth` in your `tailwind.config.js` file.
+You can customize the `outline-*` utilities by editing `theme.outlineWidth` or `theme.extend.outlineWidth` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/outline-width.mdx
+++ b/src/pages/docs/outline-width.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the outline width
 
-Use the `outline-{width}` utilities to change the width of an element's outline.
+Use the `outline-*` utilities to change the width of an element's outline.
 
 ```html {{ example: true }}
 <div class="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-16 font-bold text-white text-sm text-center">
@@ -59,7 +59,7 @@ The default outline width is `3px`.
 
 ### Customizing your theme
 
-You can customize the `outline-{width}` utilities by editing `theme.outlineWidth` or `theme.extend.outlineWidth` in your `tailwind.config.js` file.
+You can customize the `outline-width` utilities by editing `theme.outlineWidth` or `theme.extend.outlineWidth` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/overflow.mdx
+++ b/src/pages/docs/overflow.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Showing content that overflows
 
-Use `overflow-visible` to prevent content within an element from being clipped. Note that any content that overflows the bounds of the element will then be visible.
+Use the `overflow-visible` utility to prevent content within an element from being clipped. Note that any content that overflows the bounds of the element will then be visible.
 
 ```html {{ example: true }}
 <div class="overflow-visible relative max-w-sm mx-auto bg-white shadow-lg ring-1 ring-black/5 rounded-xl flex items-center gap-6 dark:bg-slate-800 dark:highlight-white/5">
@@ -31,7 +31,7 @@ Use `overflow-visible` to prevent content within an element from being clipped. 
 
 ### Hiding content that overflows
 
-Use `overflow-hidden` to clip any content within an element that overflows the bounds of that element.
+Use the `overflow-hidden` utility to clip any content within an element that overflows the bounds of that element.
 
 ```html {{ example: true }}
 <div class="overflow-hidden relative max-w-sm mx-auto bg-white shadow-lg ring-1 ring-black/5 rounded-xl flex items-center gap-6 dark:bg-slate-800 dark:highlight-white/5">
@@ -49,7 +49,7 @@ Use `overflow-hidden` to clip any content within an element that overflows the b
 
 ### Scrolling if needed
 
-Use `overflow-auto` to add scrollbars to an element in the event that its content overflows the bounds of that element. Unlike `overflow-scroll`, which always shows scrollbars, this utility will only show them if scrolling is necessary.
+Use the `overflow-auto` utility to add scrollbars to an element in the event that its content overflows the bounds of that element. Unlike `overflow-scroll`, which always shows scrollbars, this utility will only show them if scrolling is necessary.
 
 ```html {{ example: true }}
 <div class="overflow-auto h-72 relative max-w-sm mx-auto bg-white dark:bg-slate-800 dark:highlight-white/5 shadow-lg ring-1 ring-black/5 rounded-xl flex flex-col divide-y dark:divide-slate-200/5">
@@ -90,7 +90,7 @@ Use `overflow-auto` to add scrollbars to an element in the event that its conten
 
 ### Scrolling horizontally if needed
 
-Use `overflow-x-auto` to allow horizontal scrolling if needed.
+Use the `overflow-x-auto` utility to allow horizontal scrolling if needed.
 
 ```html {{ example: { p: 'none' } }}
 <div class="max-w-md mx-auto bg-white shadow-xl min-w-0 dark:bg-slate-800 dark:highlight-white/5">
@@ -141,7 +141,7 @@ Use `overflow-x-auto` to allow horizontal scrolling if needed.
 
 ### Scrolling vertically if needed
 
-Use `overflow-y-auto` to allow vertical scrolling if needed.
+Use the `overflow-y-auto` utility to allow vertical scrolling if needed.
 
 ```html {{ example: true }}
 <div class="overflow-y-auto h-72 relative max-w-sm mx-auto bg-white dark:bg-slate-800 dark:highlight-white/5 shadow-lg ring-1 ring-black/5 rounded-xl flex flex-col divide-y dark:divide-slate-200/5">
@@ -182,7 +182,7 @@ Use `overflow-y-auto` to allow vertical scrolling if needed.
 
 ### Scrolling horizontally always
 
-Use `overflow-x-scroll` to allow horizontal scrolling and always show scrollbars unless always-visible scrollbars are disabled by the operating system.
+Use the `overflow-x-scroll` utility to allow horizontal scrolling and always show scrollbars unless always-visible scrollbars are disabled by the operating system.
 
 ```html {{ example: { p: 'none' } }}
 <div class="max-w-md mx-auto bg-white shadow-xl min-w-0 dark:bg-slate-800 dark:highlight-white/5">
@@ -233,7 +233,7 @@ Use `overflow-x-scroll` to allow horizontal scrolling and always show scrollbars
 
 ### Scrolling vertically always
 
-Use `overflow-y-scroll` to allow vertical scrolling and always show scrollbars unless always-visible scrollbars are disabled by the operating system.
+Use the `overflow-y-scroll` utility to allow vertical scrolling and always show scrollbars unless always-visible scrollbars are disabled by the operating system.
 
 ```html {{ example: true }}
 <div class="overflow-y-scroll h-72 relative max-w-sm mx-auto bg-white dark:bg-slate-800 shadow-lg ring-1 ring-black/5 rounded-xl flex flex-col divide-y dark:divide-slate-200/5">
@@ -274,7 +274,7 @@ Use `overflow-y-scroll` to allow vertical scrolling and always show scrollbars u
 
 ### Scrolling in all directions
 
-Use `overflow-scroll` to add scrollbars to an element. Unlike `overflow-auto`, which only shows scrollbars if they are necessary, this utility always shows them. Note that some operating systems (like macOS) hide unnecessary scrollbars regardless of this setting.
+Use the `overflow-scroll` utility to add scrollbars to an element. Unlike `overflow-auto`, which only shows scrollbars if they are necessary, this utility always shows them. Note that some operating systems (like macOS) hide unnecessary scrollbars regardless of this setting.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-4 bg-white dark:bg-slate-800 shadow-xl overflow-hidden">

--- a/src/pages/docs/overscroll-behavior.mdx
+++ b/src/pages/docs/overscroll-behavior.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Preventing parent overscrolling
 
-Use `overscroll-contain` to prevent scrolling in the target area from triggering scrolling in the parent element, but preserve "bounce" effects when scrolling past the end of the container in operating systems that support it.
+Use the `overscroll-contain` utility to prevent scrolling in the target area from triggering scrolling in the parent element, but preserve "bounce" effects when scrolling past the end of the container in operating systems that support it.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-4 overscroll-contain overflow-auto h-48 bg-white dark:bg-slate-800 shadow-xl p-8 space-y-4 text-slate-700 dark:text-slate-400 text-sm sm:text-base leading-6 sm:leading-7">
@@ -29,7 +29,7 @@ Use `overscroll-contain` to prevent scrolling in the target area from triggering
 
 ### Preventing overscroll bouncing
 
-Use `overscroll-none` to prevent scrolling in the target area from triggering scrolling in the parent element, and also prevent "bounce" effects when scrolling past the end of the container.
+Use the `overscroll-none` utility to prevent scrolling in the target area from triggering scrolling in the parent element, and also prevent "bounce" effects when scrolling past the end of the container.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-4 overscroll-none overflow-auto h-48 bg-white dark:bg-slate-800 shadow-xl p-8 space-y-4 text-slate-700 dark:text-slate-400 text-sm sm:text-base leading-6 sm:leading-7">
@@ -45,7 +45,7 @@ Use `overscroll-none` to prevent scrolling in the target area from triggering sc
 
 ### Using the default overscroll behavior
 
-Use `overscroll-auto` to make it possible for the user to continue scrolling a parent scroll area when they reach the boundary of the primary scroll area.
+Use the `overscroll-auto` utility to make it possible for the user to continue scrolling a parent scroll area when they reach the boundary of the primary scroll area.
 
 ```html {{ example: { p: 'none' } }}
 <div class="mx-4 overscroll-auto overflow-auto h-48 bg-white dark:bg-slate-800 shadow-xl p-8 space-y-4 text-slate-700 dark:text-slate-400 text-sm sm:text-base leading-6 sm:leading-7">

--- a/src/pages/docs/padding.mdx
+++ b/src/pages/docs/padding.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Add padding to a single side
 
-Control the padding on one side of an element using the `p{t|r|b|l}-{size}` utilities.
+Use the `pt-*`, `pr-*`, `pb-*`, and `pl-*` utilities to control the padding on one side of an element.
 
 For example, `pt-6` would add `1.5rem` of padding to the top of an element, `pr-4` would add `1rem` of padding to the right of an element, `pb-8` would add `2rem` of padding to the bottom of an element, and `pl-2` would add `0.5rem` of padding to the left of an element.
 
@@ -64,7 +64,7 @@ For example, `pt-6` would add `1.5rem` of padding to the top of an element, `pr-
 
 ### Add horizontal padding
 
-Control the horizontal padding of an element using the `px-{size}` utilities.
+Control the horizontal padding of an element using the `px-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -82,7 +82,7 @@ Control the horizontal padding of an element using the `px-{size}` utilities.
 
 ### Add vertical padding
 
-Control the vertical padding of an element using the `py-{size}` utilities.
+Control the vertical padding of an element using the `py-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -100,7 +100,7 @@ Control the vertical padding of an element using the `py-{size}` utilities.
 
 ### Add padding to all sides
 
-Control the padding on all sides of an element using the `p-{size}` utilities.
+Control the padding on all sides of an element using the `p-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/padding.mdx
+++ b/src/pages/docs/padding.mdx
@@ -64,7 +64,7 @@ For example, `pt-6` would add `1.5rem` of padding to the top of an element, `pr-
 
 ### Add horizontal padding
 
-Control the horizontal padding of an element using the `px-*` utilities.
+Use the `px-*` utilities to control the horizontal padding of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -82,7 +82,7 @@ Control the horizontal padding of an element using the `px-*` utilities.
 
 ### Add vertical padding
 
-Control the vertical padding of an element using the `py-*` utilities.
+Use the `py-*` utilities to control the vertical padding of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">
@@ -100,7 +100,7 @@ Control the vertical padding of an element using the `py-*` utilities.
 
 ### Add padding to all sides
 
-Control the padding on all sides of an element using the `p-*` utilities.
+Use the `p-*` utilities to control the padding on all sides of an element.
 
 ```html {{ example: true }}
 <div class="flex justify-center font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -99,7 +99,7 @@ The `@tailwindcss/forms` plugin adds an opinionated form reset layer that makes 
 
 ### Aspect ratio
 
-The `@tailwindcss/aspect-ratio` plugin is an alternative to native `aspect-ratio` support that works in older browsers, and adds `aspect-w-{n}` and `aspect-h-{n}` classes that can be combined to give an element a fixed aspect ratio.
+The `@tailwindcss/aspect-ratio` plugin is an alternative to native `aspect-ratio` support that works in older browsers, and adds `aspect-w-*` and `aspect-h-*` classes that can be combined to give an element a fixed aspect ratio.
 
 ```html
 <div class="aspect-w-16 aspect-h-9">

--- a/src/pages/docs/position.mdx
+++ b/src/pages/docs/position.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Statically positioning elements
 
-Use `static` to position an element according to the normal flow of the document.
+Use the `static` utility to position an element according to the normal flow of the document.
 
 Any [offsets](/docs/top-right-bottom-left) will be ignored and the element will not act as a position reference for absolutely positioned children.
 
@@ -41,7 +41,7 @@ Any [offsets](/docs/top-right-bottom-left) will be ignored and the element will 
 
 ### Relatively positioning elements
 
-Use `relative` to position an element according to the normal flow of the document.
+Use the `relative` utility to position an element according to the normal flow of the document.
 
 Any [offsets](/docs/top-right-bottom-left) are calculated relative to the element's normal position and the element *will* act as a position reference for absolutely positioned children.
 
@@ -69,7 +69,7 @@ Any [offsets](/docs/top-right-bottom-left) are calculated relative to the elemen
 
 ### Absolutely positioning elements
 
-Use `absolute` to position an element *outside* of the normal flow of the document, causing neighboring elements to act as if the element doesn't exist.
+Use the `absolute` utility to position an element *outside* of the normal flow of the document, causing neighboring elements to act as if the element doesn't exist.
 
 Any [offsets](/docs/top-right-bottom-left) are calculated relative to the nearest parent that has a position other than `static`, and the element *will* act as a position reference for other absolutely positioned children.
 
@@ -129,7 +129,7 @@ Any [offsets](/docs/top-right-bottom-left) are calculated relative to the neares
 
 ### Fixed positioning elements
 
-Use `fixed` to position an element relative to the browser window.
+Use the `fixed` utility to position an element relative to the browser window.
 
 Any [offsets](/docs/top-right-bottom-left) are calculated relative to the viewport and the element *will* act as a position reference for absolutely positioned children.
 
@@ -186,7 +186,7 @@ Any [offsets](/docs/top-right-bottom-left) are calculated relative to the viewpo
 
 ### Sticky positioning elements
 
-Use `sticky` to position an element as `relative` until it crosses a specified threshold, then treat it as `fixed` until its parent is off screen.
+Use the `sticky` utility to position an element as `relative` until it crosses a specified threshold, then treat it as `fixed` until its parent is off screen.
 
 Any [offsets](/docs/top-right-bottom-left) are calculated relative to the element's normal position and the element *will* act as a position reference for absolutely positioned children.
 

--- a/src/pages/docs/ring-color.mdx
+++ b/src/pages/docs/ring-color.mdx
@@ -80,4 +80,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property={<>ring color</>} featuredClass="ring-[#50d71e]" />
+<ArbitraryValues name="ring color" featuredClass="ring-[#50d71e]" />

--- a/src/pages/docs/ring-color.mdx
+++ b/src/pages/docs/ring-color.mdx
@@ -40,7 +40,7 @@ Use the `ring-*` utilities to set the color of an [outline ring](/docs/ring-widt
 
 ### Changing the opacity
 
-Control the opacity of an element's background color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's background color.
 
 ```html {{ example: true }}
 <div class="flex justify-center max-w-md mx-auto gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/ring-color.mdx
+++ b/src/pages/docs/ring-color.mdx
@@ -24,7 +24,7 @@ export const classes = {
 
 ### Setting the ring color
 
-Use the `ring-{color}` utilities to set the color of an [outline ring](/docs/ring-width).
+Use the `ring-*` utilities to set the color of an [outline ring](/docs/ring-width).
 
 ```html {{ example: true }}
 <div class="flex justify-center max-w-md mx-auto gap-4 text-white text-sm text-center font-bold leading-6">
@@ -80,4 +80,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property="ring-{color}" featuredClass="ring-[#50d71e]" />
+<ArbitraryValues property={<>ring color</>} featuredClass="ring-[#50d71e]" />

--- a/src/pages/docs/ring-offset-color.mdx
+++ b/src/pages/docs/ring-offset-color.mdx
@@ -43,7 +43,7 @@ Use the `ring-offset-*` utilities to change the color of a ring offset. Usually 
 
 ### Changing the opacity
 
-Control the opacity of an element's ring offset color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's ring offset color.
 
 ```html
 <button class="ring-2 ring-purple-500 ring-offset-4 ring-offset-purple-100**/50**"></button>

--- a/src/pages/docs/ring-offset-color.mdx
+++ b/src/pages/docs/ring-offset-color.mdx
@@ -77,4 +77,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property={<>ring offset color</>} featuredClass="ring-offset-[#50d71e]" />
+<ArbitraryValues name="ring offset color" featuredClass="ring-offset-[#50d71e]" />

--- a/src/pages/docs/ring-offset-color.mdx
+++ b/src/pages/docs/ring-offset-color.mdx
@@ -21,7 +21,7 @@ export const classes = {
 
 ### Setting the ring offset color
 
-Use the `ring-offset-{color}` utilities to change the color of a ring offset. Usually this is done to try and match the offset to the parent background color, since true box-shadow offsets aren't actually possible in CSS.
+Use the `ring-offset-*` utilities to change the color of a ring offset. Usually this is done to try and match the offset to the parent background color, since true box-shadow offsets aren't actually possible in CSS.
 
 ```html {{ example: true }}
 <div class="grid place-content-center text-white text-sm text-center font-bold leading-6">
@@ -77,4 +77,4 @@ You can use any value defined in your [opacity scale](/docs/opacity), or use arb
 
 ### Arbitrary values
 
-<ArbitraryValues property="ring-offset-{color}" featuredClass="ring-offset-[#50d71e]" />
+<ArbitraryValues property={<>ring offset color</>} featuredClass="ring-offset-[#50d71e]" />

--- a/src/pages/docs/ring-offset-width.mdx
+++ b/src/pages/docs/ring-offset-width.mdx
@@ -20,7 +20,7 @@ export const classes = {
 
 ### Setting the ring offset width
 
-Use the `ring-offset-{width}` utilities to simulate an offset by adding solid white box-shadow and increasing the thickness of the accompanying outline ring to accommodate the offset.
+Use utilities like `ring-offset-2` and `ring-offset-4` to simulate an offset by adding solid white box-shadow and increasing the thickness of the accompanying outline ring to accommodate the offset.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-white text-sm text-center font-bold leading-6">
@@ -47,7 +47,7 @@ Use the `ring-offset-{width}` utilities to simulate an offset by adding solid wh
 
 ### Changing the offset color
 
-You can't actually offset a box-shadow in CSS, so we have to fake it using a solid color shadow that matches the parent background color. We use white by default, but if you are adding a ring offset over a different background color, you should use the `ring-offset-{color}` utilities to match the parent background color:
+You can't actually offset a box-shadow in CSS, so we have to fake it using a solid color shadow that matches the parent background color. We use white by default, but if you are adding a ring offset over a different background color, use the ring offset color utilities, like `ring-offset-slate-50`, to match the parent background color:
 
 ```html {{ example: true }}
 <div class="grid place-content-center text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/ring-width.mdx
+++ b/src/pages/docs/ring-width.mdx
@@ -42,7 +42,7 @@ export const classes = {
 
 ### Adding a ring
 
-Use the `ring-{width}` utilities to apply solid box-shadow of a specific thickness to an element. Rings are a semi-transparent blue color by default, similar to the default focus ring style in many systems.
+Use the `ring-*` utilities to apply solid box-shadow of a specific thickness to an element. Rings are a semi-transparent blue color by default, similar to the default focus ring style in many systems.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-white text-center font-bold leading-6">
@@ -67,13 +67,13 @@ Use the `ring-{width}` utilities to apply solid box-shadow of a specific thickne
 <button class="... ring-offset-2 **ring-4**">Button C</button>
 ```
 
-Ring utilities compose gracefully with regular `shadow-{size}` utilities and can be combined on the same element.
+Ring utilities compose gracefully with regular `shadow-*` utilities and can be combined on the same element.
 
 You can also control the color, opacity, and offset of rings using the [ringColor](/docs/ring-color), [ringOpacity](/docs/ring-opacity), and [ringOffsetWidth](/docs/ring-offset-width) utilities.
 
 ### Focus rings
 
-The ring width utilities make it easy to use custom focus rings by adding `focus:` to the beginning of any `ring-{width}` utility.
+The ring width utilities make it easy to use custom focus rings by adding `focus:` to the beginning of any `ring-*` utility.
 
 ```html {{ example: { hint: 'Focus this button to see the ring appear' } }}
 <div class="flex justify-center max-w-md mx-auto gap-4 text-white text-sm text-center font-bold leading-6">

--- a/src/pages/docs/rotate.mdx
+++ b/src/pages/docs/rotate.mdx
@@ -23,7 +23,7 @@ export const classes = {
 
 ### Rotating an element
 
-Use the `rotate-{angle}` utilities to rotate an element.
+Use the `rotate-*` utilities to rotate an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/saturate.mdx
+++ b/src/pages/docs/saturate.mdx
@@ -22,7 +22,7 @@ export const classes = {
 
 ### Changing element saturation
 
-Use the `saturate-{amount}` utilities to control an element's saturation.
+Use the `saturate-*` utilities to control an element's saturation.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex justify-start sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/scale.mdx
+++ b/src/pages/docs/scale.mdx
@@ -27,7 +27,7 @@ export const classes = {
 
 ### Scaling an element
 
-Use the `scale-{percentage}`, `scale-x-{percentage}`, and `scale-y-{percentage}` utilities to scale an element.
+Use the `scale-*`, `scale-x-*`, and `scale-y-*` utilities to scale an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/scroll-behavior.mdx
+++ b/src/pages/docs/scroll-behavior.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Adding smooth scrolling
 
-Use the `scroll-smooth` utilities to enable smooth scrolling within an element.
+Use the `scroll-smooth` utility to enable smooth scrolling within an element.
 
 ```html
 <html class="scroll-smooth">

--- a/src/pages/docs/scroll-margin.mdx
+++ b/src/pages/docs/scroll-margin.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the scroll margin
 
-Use the `scroll-m{side}-{size}` utilities to set the scroll offset around items within a snap container.
+Use the `scroll-mt-*`, `scroll-mr-*`, `scroll-mb-*`, and `scroll-ml-*` utilities to set the scroll offset around items within a snap container.
 
 ```html {{ example: { p: 'none', hint: 'Scroll in the grid of images to see the expected behaviour' } }}
 <div class="w-full flex gap-12 snap-x overflow-x-auto py-14">

--- a/src/pages/docs/scroll-padding.mdx
+++ b/src/pages/docs/scroll-padding.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the scroll padding
 
-Use the `scroll-p{side}-{size}` utilities to set the scroll offset of an element within a snap container.
+Use the `scroll-pt-*`, `scroll-pr-*`, `scroll-pb-*`, and `scroll-pl-*` utilities to set the scroll offset of an element within a snap container.
 
 ```html {{ example: { p: 'none', hint: 'Scroll in the grid of images to see the expected behaviour' } }}
 <div class="bg-stripes-pink w-6 absolute left-0 top-0 bottom-0 rounded-l-lg"></div>

--- a/src/pages/docs/size.mdx
+++ b/src/pages/docs/size.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Fixed sizes
 
-Use `size-{number}` or `size-px` to set an element to a fixed width and height at the same time.
+Use utilities like `size-px`, `size-1`, and `size-64` to set an element to a fixed width and height at the same time.
 
 ```html {{ example: true }}
 <div class="grid grid-flow-col justify-center gap-4 font-mono font-bold text-xs text-center text-white">

--- a/src/pages/docs/skew.mdx
+++ b/src/pages/docs/skew.mdx
@@ -27,7 +27,7 @@ export const classes = {
 
 ### Skewing an element
 
-Use the `skew-x-{amount}` and `skew-y-{amount}` utilities to skew an element.
+Use the `skew-x-*` and `skew-y-*` utilities to skew an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/space.mdx
+++ b/src/pages/docs/space.mdx
@@ -39,7 +39,7 @@ export const classes = {
 
 ### Add horizontal space between children
 
-Control the horizontal space between elements using the `space-x-{amount}` utilities.
+Control the horizontal space between elements using the `space-x-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex justify-start font-mono text-white text-sm font-bold leading-6">
@@ -61,7 +61,7 @@ Control the horizontal space between elements using the `space-x-{amount}` utili
 
 ### Add vertical space between children
 
-Control the vertical space between elements using the `space-y-{amount}` utilities.
+Control the vertical space between elements using the `space-y-*` utilities.
 
 ```html {{ example: true }}
 <div class="flex flex-col justify-center text-center w-full font-mono text-white text-sm font-bold leading-6">
@@ -183,4 +183,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="space-{x|y}" featuredClass="space-y-[5px]" />
+<ArbitraryValues property={<><code>space-x</code> or <code>space-y</code></>} featuredClass="space-y-[5px]" />

--- a/src/pages/docs/space.mdx
+++ b/src/pages/docs/space.mdx
@@ -39,7 +39,7 @@ export const classes = {
 
 ### Add horizontal space between children
 
-Control the horizontal space between elements using the `space-x-*` utilities.
+Use the `space-x-*` utilities to control the horizontal space between elements.
 
 ```html {{ example: true }}
 <div class="flex justify-start font-mono text-white text-sm font-bold leading-6">
@@ -61,7 +61,7 @@ Control the horizontal space between elements using the `space-x-*` utilities.
 
 ### Add vertical space between children
 
-Control the vertical space between elements using the `space-y-*` utilities.
+Use the `space-y-*` utilities to control the vertical space between elements.
 
 ```html {{ example: true }}
 <div class="flex flex-col justify-center text-center w-full font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/space.mdx
+++ b/src/pages/docs/space.mdx
@@ -183,4 +183,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property={<><code>space-x</code> or <code>space-y</code></>} featuredClass="space-y-[5px]" />
+<ArbitraryValues name="space" featuredClass="space-y-[5px]" />

--- a/src/pages/docs/stroke-width.mdx
+++ b/src/pages/docs/stroke-width.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the stroke width
 
-Use the `stroke-{width}` utilities to set the stroke width of an SVG.
+Use the `stroke-*` utilities to set the stroke width of an SVG.
 
 ```html {{ example: true }}
 <div class="flex items-center justify-center space-x-8">

--- a/src/pages/docs/stroke.mdx
+++ b/src/pages/docs/stroke.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the stroke color
 
-Use the `stroke-{color}` utilities to change the stroke color of an SVG.
+Use the `stroke-*` utilities to change the stroke color of an SVG.
 
 ```html {{ example: true }}
 <div class="flex items-center justify-center">

--- a/src/pages/docs/text-align.mdx
+++ b/src/pages/docs/text-align.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the text alignment
 
-Control the text alignment of an element using the `text-left`, `text-center`, `text-right`, and `text-justify` utilities.
+Use the `text-left`, `text-center`, `text-right`, and `text-justify` utilities to control the text alignment of an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="px-4 sm:px-0">

--- a/src/pages/docs/text-color.mdx
+++ b/src/pages/docs/text-color.mdx
@@ -48,7 +48,7 @@ Use the `text-*` utilities to control the text color of an element.
 
 ### Changing the opacity
 
-Control the opacity of an element's text color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's text color.
 
 ```html {{ example: true }}
 <div class="text-xl font-medium leading-6 space-y-4">

--- a/src/pages/docs/text-color.mdx
+++ b/src/pages/docs/text-color.mdx
@@ -34,7 +34,7 @@ export const classes = {
 
 ### Setting the text color
 
-Control the text color of an element using the `text-{color}` utilities.
+Use the `text-*` utilities to control the text color of an element.
 
 ```html {{ example: true }}
 <div class="relative text-xl text-center font-medium leading-6">

--- a/src/pages/docs/text-decoration-color.mdx
+++ b/src/pages/docs/text-decoration-color.mdx
@@ -36,7 +36,7 @@ Use the `decoration-*` utilities to change the color of an element's [text decor
 
 ### Changing the opacity
 
-Control the opacity of an element's text decoration color using the color opacity modifier.
+Use the color opacity modifier to control the opacity of an element's text decoration color.
 
 ```html {{ example: { p: 'none' } }}
 <div class="bg-white p-8 text-slate-900 shadow-lg max-w-sm mx-auto text-sm leading-6 sm:text-base sm:leading-7 dark:bg-slate-800 dark:text-slate-400">

--- a/src/pages/docs/text-decoration-color.mdx
+++ b/src/pages/docs/text-decoration-color.mdx
@@ -15,7 +15,7 @@ export const classes = { utilities }
 
 ### Setting the text decoration color
 
-Use the `decoration-{color}` utilities to change the color of an element's [text decoration](/docs/text-decoration).
+Use the `decoration-*` utilities to change the color of an element's [text decoration](/docs/text-decoration).
 
 ```html {{ example: { p: 'none' } }}
 <div class="bg-white p-8 text-slate-900 shadow-lg max-w-sm mx-auto text-sm leading-6 sm:text-base sm:leading-7 dark:bg-slate-800 dark:text-slate-400">

--- a/src/pages/docs/text-decoration-style.mdx
+++ b/src/pages/docs/text-decoration-style.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the text decoration style
 
-Use the `decoration-{style}` utilities to change the style of an element's [text decoration](/docs/text-decoration).
+Use the `decoration-*` utilities to change the style of an element's [text decoration](/docs/text-decoration).
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8 text-slate-900 dark:text-slate-200">

--- a/src/pages/docs/text-decoration-thickness.mdx
+++ b/src/pages/docs/text-decoration-thickness.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the text decoration thickness
 
-Use the `decoration-{width}` utilities to change the thickness of an element's [text decoration](/docs/text-decoration).
+Use the `decoration-*` utilities to change the thickness of an element's [text decoration](/docs/text-decoration).
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8 text-slate-900 dark:text-slate-200">
@@ -61,7 +61,7 @@ Use the `decoration-{width}` utilities to change the thickness of an element's [
 
 ### Customizing your theme
 
-You can customize the `decoration-{width}` utilities by editing `theme.textDecorationThickness` or `theme.extend.textDecorationThickness` in your `tailwind.config.js` file.
+You can customize the `text-decoration-thickness` utilities by editing `theme.textDecorationThickness` or `theme.extend.textDecorationThickness` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/text-decoration-thickness.mdx
+++ b/src/pages/docs/text-decoration-thickness.mdx
@@ -61,7 +61,7 @@ Use the `decoration-*` utilities to change the thickness of an element's [text d
 
 ### Customizing your theme
 
-You can customize the `text-decoration-thickness` utilities by editing `theme.textDecorationThickness` or `theme.extend.textDecorationThickness` in your `tailwind.config.js` file.
+You can customize the `decoration-*` utilities by editing `theme.textDecorationThickness` or `theme.extend.textDecorationThickness` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/text-indent.mdx
+++ b/src/pages/docs/text-indent.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Adding a text indent
 
-Use the `indent-{width}` utilities to set the amount of empty space (indentation) that's shown before text in a block.
+Use the `indent-*` utilities to set the amount of empty space (indentation) that's shown before text in a block.
 
 ```html {{ example: { p: 'none' } }}
 <div class="bg-white p-8 shadow-xl text-slate-700 max-w-md mx-auto overflow-auto leading-6 dark:bg-slate-800 dark:text-slate-400">

--- a/src/pages/docs/text-underline-offset.mdx
+++ b/src/pages/docs/text-underline-offset.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Setting the underline offset
 
-Use the `underline-offset-{width}` utilities to change the offset of a text underline.
+Use the `underline-offset-*` utilities to change the offset of a text underline.
 
 ```html {{ example: true }}
 <div class="flex flex-col gap-8 text-slate-900 dark:text-slate-200">
@@ -66,7 +66,7 @@ Use the `underline-offset-{width}` utilities to change the offset of a text unde
 
 ### Customizing your theme
 
-You can customize the `underline-offset-{width}` utilities by editing `theme.textUnderlineOffset` or `theme.extend.textUnderlineOffset` in your `tailwind.config.js` file.
+You can customize the `text-underline-offset` utilities by editing `theme.textUnderlineOffset` or `theme.extend.textUnderlineOffset` in your `tailwind.config.js` file.
 
 ```diff-js {{ filename: 'tailwind.config.js' }}
   module.exports = {

--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -222,7 +222,7 @@ module.exports = {
 }
 ```
 
-After adding this to your theme you can use it just like any other `font-{family}` utility:
+After adding this to your theme you can use it just like any other font family utility:
 
 ```html
 <h1 class="**font-display**">

--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Placing a positioned element
 
-Use the `{top|right|bottom|left|inset}-{size}` utilities to set the horizontal or vertical position of a [positioned element](/docs/position).
+Use the `top-*`, `right-*`, `bottom-*`, `left-*`, and `inset-*` utilities to set the horizontal or vertical position of a [positioned element](/docs/position).
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 grid-rows-3 place-items-center gap-4 font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -206,4 +206,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="top/right/bottom/left" featuredClass="top-[3px]" />
+<ArbitraryValues name="position" featuredClass="top-[3px]" />

--- a/src/pages/docs/touch-action.mdx
+++ b/src/pages/docs/touch-action.mdx
@@ -26,7 +26,7 @@ export const classes = {
 
 ### Setting the touch action
 
-Use the `touch-{action}` utilities to control how an element can be scrolled (panned) and zoomed (pinched) on touchscreens.
+Use the `touch-*` utilities to control how an element can be scrolled (panned) and zoomed (pinched) on touchscreens.
 
 ```html {{ example: { hint: 'Try panning these images on a touchscreen' } }}
 <div class="grid sm:grid-cols-2 gap-x-6 gap-y-14 font-mono font-bold">

--- a/src/pages/docs/transform-origin.mdx
+++ b/src/pages/docs/transform-origin.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Changing the transform origin
 
-Specify an element's transform origin using the `origin-{keyword}` utilities.
+Specify an element's transform origin using the `origin-*` utilities.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">

--- a/src/pages/docs/transition-delay.mdx
+++ b/src/pages/docs/transition-delay.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Delaying transitions
 
-Use the `delay-{amount}` utilities to control an element's transition-delay.
+Use the `delay-*` utilities to control an element's transition-delay.
 
 ```html {{ example: { hint: 'Hover each button to see the expected behaviour' } }}
 <div class="flex flex-col sm:flex-row gap-8 sm:gap-0 justify-around text-white text-sm font-bold leading-6">

--- a/src/pages/docs/transition-duration.mdx
+++ b/src/pages/docs/transition-duration.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Changing transition duration
 
-Use the `duration-{amount}` utilities to control an element's transition-duration.
+Use the `duration-*` utilities to control an element's transition-duration.
 
 ```html {{ example: { hint: 'Hover each button to see the expected behaviour' } }}
 <div class="flex flex-col sm:flex-row gap-8 sm:gap-0 justify-around text-white text-sm font-bold leading-6">

--- a/src/pages/docs/transition-property.mdx
+++ b/src/pages/docs/transition-property.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Controlling transitioned properties
 
-Use the `transition-{properties}` utilities to specify which properties should transition when they change.
+Use the `transition-*` utilities to specify which properties should transition when they change.
 
 ```html {{ example: { hint: 'Hover the button to see the expected behaviour' } }}
 <div class="flex justify-around text-white text-sm font-bold leading-6">

--- a/src/pages/docs/transition-timing-function.mdx
+++ b/src/pages/docs/transition-timing-function.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Controlling the easing curve
 
-Use the `ease-{timing}` utilities to control an element's easing curve.
+Use the `ease-*` utilities to control an element's easing curve.
 
 ```html {{ example: { hint: 'Hover each button to see the expected behaviour' } }}
 <div class="flex flex-col sm:flex-row gap-8 sm:gap-0 justify-around text-white text-sm font-bold leading-6">

--- a/src/pages/docs/translate.mdx
+++ b/src/pages/docs/translate.mdx
@@ -27,7 +27,7 @@ export const classes = {
 
 ### Translating an element
 
-Use the `translate-x-{amount}` and `translate-y-{amount}` utilities to translate an element.
+Use the `translate-x-*` and `translate-y-*` utilities to translate an element.
 
 ```html {{ example: { p: 'none' } }}
 <div class="flex sm:block overflow-scroll sm:overflow-visible scroll-p-8">
@@ -144,4 +144,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property="translate" featuredClass="translate-y-[17rem]" />
+<ArbitraryValues property={<><code>translateX</code> or <code>translateY</code></>} featuredClass="translate-y-[17rem]" />

--- a/src/pages/docs/translate.mdx
+++ b/src/pages/docs/translate.mdx
@@ -144,4 +144,4 @@ Learn more about customizing the default theme in the [theme customization](/doc
 
 ### Arbitrary values
 
-<ArbitraryValues property={<><code>translateX</code> or <code>translateY</code></>} featuredClass="translate-y-[17rem]" />
+<ArbitraryValues name="translate" featuredClass="translate-y-[17rem]" />

--- a/src/pages/docs/upgrade-guide.mdx
+++ b/src/pages/docs/upgrade-guide.mdx
@@ -178,7 +178,7 @@ While there's no harm in leaving them in your HTML, they can safely be removed â
 
 ### New opacity modifier syntax
 
-The new engine introduces [a new syntax](/docs/background-color#changing-the-opacity) for changing the opacity of color utilities that we recommend migrating to from utilities like `bg-opacity-{value}`:
+The new engine introduces [a new syntax](/docs/background-color#changing-the-opacity) for changing the opacity of color utilities that we recommend migrating to from utilities like `bg-opacity-*`:
 
 ```diff-html
 - <div class="bg-black bg-opacity-25">
@@ -404,7 +404,7 @@ Learn more in the [ordering stacked modifiers](/docs/hover-focus-and-other-state
 
 ### Fill and stroke use color palette
 
-The `fill-{color}` and `stroke-{color}` utilities mirror your `theme.colors` key by default now. This isn't a breaking change if you haven't customized your color palette, but if you have, the `fill-current` and `stroke-current` classes may not work if you don't have `current` included in your own custom color palette.
+The `fill-*` and `stroke-*` utilities mirror your `theme.colors` key by default now. This isn't a breaking change if you haven't customized your color palette, but if you have, the `fill-current` and `stroke-current` classes may not work if you don't have `current` included in your own custom color palette.
 
 Add `current` to your custom color palette to resolve this:
 

--- a/src/pages/docs/visibility.mdx
+++ b/src/pages/docs/visibility.mdx
@@ -13,7 +13,7 @@ export const classes = { utilities }
 
 ### Making elements invisible
 
-Use `invisible` to hide an element, but still maintain its place in the DOM, affecting the layout of other elements (compare with `hidden` from the [display](/docs/display#hidden) documentation).
+Use the `invisible` utility to hide an element, but still maintain its place in the DOM, affecting the layout of other elements (compare with `hidden` from the [display](/docs/display#hidden) documentation).
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 font-mono text-white text-sm font-bold leading-6">
@@ -33,7 +33,7 @@ Use `invisible` to hide an element, but still maintain its place in the DOM, aff
 
 ### Collapsing elements
 
-Use `collapse` to hide table rows, row groups, columns, and column groups as if they were set to `display: none`, but without impacting the size of other rows and columns.
+Use the `collapse` utility to hide table rows, row groups, columns, and column groups as if they were set to `display: none`, but without impacting the size of other rows and columns.
 
 This makes it possible to dynamically toggle rows and columns without affecting the table layout.
 
@@ -154,7 +154,7 @@ This makes it possible to dynamically toggle rows and columns without affecting 
 
 ### Making elements visible
 
-Use `visible` to make an element visible. This is mostly useful for undoing the `invisible` utility at different screen sizes.
+Use the `visible` utility to make an element visible. This is mostly useful for undoing the `invisible` utility at different screen sizes.
 
 ```html {{ example: true }}
 <div class="grid grid-cols-3 gap-4 font-mono text-white text-sm font-bold leading-6">

--- a/src/pages/docs/width.mdx
+++ b/src/pages/docs/width.mdx
@@ -18,7 +18,7 @@ export const classes = {
 
 ### Fixed widths
 
-Use `w-{number}` or `w-px` to set an element to a fixed width.
+Use utilities like `w-px`, `w-1`, and `w-64` to set an element to a fixed width.
 
 ```html {{ example: true }}
 <div class="flex justify-center">
@@ -46,7 +46,7 @@ Use `w-{number}` or `w-px` to set an element to a fixed width.
 
 ### Percentage widths
 
-Use `w-{fraction}` or `w-full` to set an element to a percentage based width.
+Use utilities like `w-full`, `w-1/2`, and `w-2/5` to set an element to a percentage based width.
 
 ```html {{ example: true }}
 <div class="space-y-4 font-mono font-bold text-xs text-white">

--- a/src/pages/docs/z-index.mdx
+++ b/src/pages/docs/z-index.mdx
@@ -14,7 +14,7 @@ export const classes = { utilities }
 
 ### Setting the z-index
 
-Control the stack order (or three-dimensional positioning) of an element in Tailwind, regardless of order it has been displayed, using the `z-{index}` utilities.
+Use the `z-*` utilities to control the stack order (or three-dimensional positioning) of an element, regardless of order it has been displayed.
 
 ```html {{ example: true }}
 <div class="flex justify-center -space-x-3 font-mono text-white text-sm font-bold leading-6">


### PR DESCRIPTION
Resolves #1793

This PR updates the documentation to use the `utility-*` format everywhere instead of the `utility-{unit}` format. This is the format we've generally used on newer documentation pages as it's a little shorter, and also removes any confusion about whether the curly brackets are required in some way when using Tailwind CSS.

While working through this I also made a bunch of consistency improvements, likely using the same sentence format between each documentation page, making sure that the arbitrary value sections are all using the CSS property and not the utility name, etc.