### PR TITLE
Fix typo in the Remix installation guide

### DIFF
--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -71,7 +71,7 @@ let steps = [
     body: () => (
       <p>
         Import the newly-created <code>./app/tailwind.css</code> file in your{' '}
-        <code>./app/root.jsx</code> file.
+        <code>./app/root.tsx</code> file.
       </p>
     ),
     code: {


### PR DESCRIPTION
In the [Remix installation guide](https://tailwindcss.com/docs/guides/remix), the file name in the documentation are inconsistent with the file name in the code block. This PR fixed it.
<img width="1075" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/20807713/f80ca7e9-3118-4fc4-925b-65716d5c3990">
