### PR TITLE
Clean up `flex` docs

### DIFF
--- a/src/pages/docs/flex.mdx
+++ b/src/pages/docs/flex.mdx
@@ -26,7 +26,7 @@ Use `flex-initial` to allow a flex item to shrink but not grow, taking into acco
 
 ```html
 <div class="flex">
-  <div class="flex-none w-14 h-14">
+  <div class="flex-none w-14 ...">
     01
   </div>
   <div class="**flex-initial** w-64 ...">
@@ -52,7 +52,7 @@ Use `flex-1` to allow a flex item to grow and shrink as needed, ignoring its ini
 
 ```html
 <div class="flex">
-  <div class="flex-none ...">
+  <div class="flex-none w-14 ...">
     01
   </div>
   <div class="**flex-1** w-64 ...">
@@ -78,7 +78,7 @@ Use `flex-auto` to allow a flex item to grow and shrink, taking into account its
 
 ```html
 <div class="flex ...">
-  <div class="flex-none ...">
+  <div class="flex-none w-14 ...">
     01
   </div>
   <div class="**flex-auto** w-64 ...">
@@ -97,12 +97,12 @@ Use `flex-none` to prevent a flex item from growing or shrinking:
 ```html {{ example: { resizable: true } }}
 <div class="flex gap-4 text-white text-sm font-bold font-mono leading-6 bg-stripes-indigo rounded-lg">
   <div class="flex-none last:pr-8 sm:last:pr-0">
-    <div class="p-4 w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-300 dark:bg-indigo-800 dark:text-indigo-400">
+    <div class="p-4 w-14 h-14 rounded-lg flex items-center justify-center bg-indigo-500">
       01
     </div>
   </div>
   <div class="flex-none last:pr-8 sm:last:pr-0">
-    <div class="p-4 w-72 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">
+    <div class="p-4 w-32 rounded-lg flex items-center justify-center bg-indigo-500 shadow-lg">
       02
     </div>
   </div>
@@ -116,10 +116,10 @@ Use `flex-none` to prevent a flex item from growing or shrinking:
 
 ```html
 <div class="flex ...">
-  <div class="flex-none w-14 h-14 ...">
+  <div class="**flex-none** w-14 ...">
     01
   </div>
-  <div class="**flex-none** ...">
+  <div class="**flex-none** w-32 ...">
     02
   </div>
   <div class="flex-1 ...">


### PR DESCRIPTION
Resolves #1803

This PR cleans up the [flex documentation](https://tailwindcss.com/docs/flex) a little by making the `flex-none` example make more sense.

Previously we weren't highlighting both the `flex-none` boxes, plus we only showed the size on one:

<kbd><img width="814" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/cae6f93c-5439-4f8f-af60-bb22111b4fad"></kbd>

Now both of these boxes are highlighted in the dark indigo, and both have a size set:

<kbd><img width="811" alt="image" src="https://github.com/tailwindlabs/tailwindcss.com/assets/882133/7839d7dd-7f50-42f1-bc8a-58081f7cdc12"></kbd>

I also updated some of the other flex examples to always have `w-14` for the first item (which is always set to `flex-none`).