### PR TITLE
fix: fixed search icon scaling in docsearch.css

### DIFF
--- a/src/css/docsearch.css
+++ b/src/css/docsearch.css
@@ -90,11 +90,11 @@
 }
 
 .DocSearch-MagnifierLabel {
-  @apply flex-none w-6 h-6;
-  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m19 19-3.5-3.5' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle cx='11' cy='11' r='6' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  @apply flex-none w-6 h-6 bg-contain;
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath vector-effect='non-scaling-stroke' d='m19 19-3.5-3.5' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle vector-effect='non-scaling-stroke' cx='11' cy='11' r='6' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 
   .dark & {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m19 19-3.5-3.5' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle cx='11' cy='11' r='6' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath vector-effect='non-scaling-stroke' d='m19 19-3.5-3.5' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Ccircle vector-effect='non-scaling-stroke' cx='11' cy='11' r='6' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   }
 }
 


### PR DESCRIPTION
When the browser text size is not set to `16px` some docsearch icons break.

**Before:**
The search icon is tilled and repeated instead of scaled
![screenshot](https://github.com/tailwindlabs/tailwindcss.com/assets/25524993/3d3b50fc-eb6f-4005-acfe-5105b497fabb)

**After:**
The search icon size is scaled, the stroke width is not scalled and kept the same.
![screenshot](https://github.com/tailwindlabs/tailwindcss.com/assets/25524993/4539e09c-8156-40ca-9fc2-f01a6561c15f)

> [!NOTE]
> You can change the font size setting in chrome in the apperance settings.
> https://support.google.com/chrome/answer/96810#fontsize