### PR TITLE
fix: favorite and remove from search history icon no-repeat in docsearch.css

### DIFF
--- a/src/css/docsearch.css
+++ b/src/css/docsearch.css
@@ -446,6 +446,8 @@
 .DocSearch-Hit-action [title='Remove this search from favorites'] {
   width: 1.5rem;
   height: 1.5rem;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .DocSearch-Hit-action [title='Save this search'] svg,


### PR DESCRIPTION
When the browser text size is not set to `16px` some docsearch icons break.

**Before:**
The remove from search and add search to favorites icon is tilled and repeated
![screenshot](https://github.com/tailwindlabs/tailwindcss.com/assets/25524993/e9cc2f74-b859-4393-bc57-7b830a5a7434)


**After:**
The remove from search and add search to favorites icon is centererd and not tilled anymore.
![screenshot](https://github.com/tailwindlabs/tailwindcss.com/assets/25524993/9d15a997-65c0-46fd-9add-39fb2a21eb16)


> [!NOTE]
> You can change the font size setting in chrome in the apperance settings.
> https://support.google.com/chrome/answer/96810#fontsize