### PR TITLE
Resolve date discrepancy and remove need for tinytime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "simple-functional-loader": "^1.2.1",
         "stringify-object": "^3.3.0",
         "tailwindcss": "^3.4.3",
-        "tinytime": "^0.2.6",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.1",
         "unist-util-visit": "^4.1.2",
@@ -10230,10 +10229,6 @@
     "node_modules/through": {
       "version": "2.3.8",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinytime": {
-      "version": "0.2.6",
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "simple-functional-loader": "^1.2.1",
     "stringify-object": "^3.3.0",
     "tailwindcss": "^3.4.3",
-    "tinytime": "^0.2.6",
     "unified": "^10.1.2",
     "unist-util-filter": "^4.0.1",
     "unist-util-visit": "^4.1.2",

--- a/src/components/PostItem.js
+++ b/src/components/PostItem.js
@@ -3,6 +3,12 @@ import clsx from 'clsx'
 import { Button } from '@/components/Button'
 import { formatDate } from '@/utils/formatDate'
 
+const dateFormat = {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+}
+
 export default function PostItem({ title, category, slug, date, children, wide = false }) {
   return (
     <article
@@ -31,7 +37,7 @@ export default function PostItem({ title, category, slug, date, children, wide =
               'lg:absolute lg:top-0 lg:right-full lg:mr-8 lg:whitespace-nowrap': wide,
             })}
           >
-            <time dateTime={date}>{formatDate(date, '{MMMM} {DD}, {YYYY}')}</time>
+            <time dateTime={date}>{formatDate(date, dateFormat)}</time>
           </dd>
         </dl>
         <svg

--- a/src/layouts/BlogPostLayout.js
+++ b/src/layouts/BlogPostLayout.js
@@ -6,6 +6,15 @@ import { MDXProvider } from '@mdx-js/react'
 import clsx from 'clsx'
 import Link from 'next/link'
 
+const dateFormat = {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+}
+
 export function BlogPostLayout({ children, meta }) {
   return (
     <div className="overflow-hidden">
@@ -50,7 +59,7 @@ export function BlogPostLayout({ children, meta }) {
                     className={clsx('absolute top-0 inset-x-0 text-slate-700 dark:text-slate-400')}
                   >
                     <time dateTime={meta.date}>
-                      {formatDate(meta.date, '{dddd}, {MMMM} {DD}, {YYYY}')}
+                      {formatDate(meta.date, dateFormat)}
                     </time>
                   </dd>
                 </dl>

--- a/src/layouts/JobPostingLayout.js
+++ b/src/layouts/JobPostingLayout.js
@@ -7,6 +7,14 @@ import { mdxComponents } from '@/utils/mdxComponents'
 import { MDXProvider } from '@mdx-js/react'
 import Link from 'next/link'
 
+const dateFormat = {
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric'
+}
+
 function BackgroundBeams() {
   return (
     <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center overflow-hidden">
@@ -203,7 +211,7 @@ export function JobPostingLayout({ children, meta }) {
             <p className="mt-7 text-sm/7 text-slate-500">
               Closes on{' '}
               <time dateTime={meta.dateCloses}>
-                {formatDate(meta.dateCloses, '{MMMM} {Do} at {h}:{mm}{a} ET')}
+                {formatDate(meta.dateCloses, dateFormat)}
               </time>
             </p>
           </div>

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -7,6 +7,12 @@ import { formatDate } from '@/utils/formatDate'
 import buildRss from '@/scripts/build-rss'
 import { renderToStaticMarkup } from 'react-dom/server'
 
+const dateFormat = {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+}
+
 export default function Blog({ posts }) {
   return (
     <main className="max-w-[52rem] mx-auto px-4 pb-28 sm:px-6 md:px-8 xl:px-12 lg:max-w-6xl">
@@ -52,7 +58,7 @@ export default function Blog({ posts }) {
                 <dl className="absolute left-0 top-0 lg:left-auto lg:right-full lg:mr-[calc(6.5rem+1px)]">
                   <dt className="sr-only">Date</dt>
                   <dd className={clsx('whitespace-nowrap text-sm leading-6 dark:text-slate-400')}>
-                    <time dateTime={meta.date}>{formatDate(meta.date, '{MMMM} {DD}, {YYYY}')}</time>
+                    <time dateTime={meta.date}>{formatDate(meta.date, dateFormat)}</time>
                   </dd>
                 </dl>
               </div>

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,29 +1,6 @@
-export const DateTimeFormats = {
-  short: {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  },
-  medium: {
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    year: 'numeric'
-  },
-  BLOG_POST: {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  }
-}
-
-export function formatDate(dateString, options = DateTimeFormats.simple) {
+export function formatDate(dateString, options) {
   const date = new Date(dateString);
-  const defaultTimeZoneOptions = options.hour
+  const defaultTimeZoneOptions = options?.hour
     ? {
       timeZoneName: 'shortGeneric',
       timeZone: 'America/New_York',

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,7 +1,37 @@
-import tinytime from 'tinytime'
+export const DateTimeFormats = {
+  short: {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  },
+  medium: {
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    year: 'numeric'
+  },
+  BLOG_POST: {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }
+}
 
-export function formatDate(date, format) {
-  return tinytime(format)
-    .render(typeof date === 'string' ? new Date(date) : date)
-    .replace('Febuary', 'February')
+export function formatDate(dateString, options = DateTimeFormats.simple) {
+  const date = new Date(dateString);
+  const defaultTimeZoneOptions = options.hour
+    ? {
+      timeZoneName: 'shortGeneric',
+      timeZone: 'America/New_York',
+    }
+    : {};
+
+  return new Intl.DateTimeFormat("en-US", {
+    ...defaultTimeZoneOptions,
+    ...options,
+  }).format(date);
 }


### PR DESCRIPTION
This PR will…

1. **resolve a date mismatch issue caused by `tinytime` not preserving timezone information**
   
   I noticed this when sharing the job app links on Twitter. I'm not sure if this occurs in every time zone, or if I'm only seeing it because I'm currently traveling in Los Angeles.
   
   ![](https://github.com/tailwindlabs/tailwindcss.com/assets/5913254/a9d0ee5b-3254-4df8-ac8c-6e1f046677d8)

2. **refactor and improve the `formatDate` function**
   
   1. **refactor and improve the `formatDate` function to build upon built-in APIs**
      
      Most of what tinytime was being used for can be offloaded to [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), which is natively supported with [great browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility).
      
      The only regression/difference I noticed was that in the case of the job applications usage of `formatDate`, you lose the ordinal day number (e.g. `4` now instead of `4th`). If that's an important difference and you really want the ordinal number there, I have a helper that essentially shims `'ordinal` support for the day number. It would just be a deviation from the built-in `Intl.DateTimeFormatOptions` type, so if you do any TS type checking, you'll want to account for that as well.
      
   2. **removes the—now unused—the `tinytime` dependency**