### PR TITLE
bug:  nth child example in docs is not correct

### DIFF
--- a/src/pages/docs/plugins.mdx
+++ b/src/pages/docs/plugins.mdx
@@ -488,7 +488,7 @@ module.exports = {
       matchVariant(
         'nth',
         (value) => {
-          return `&:nth-child(${value})`;
+          return `&>*:nth-child(${value})`;
         },
         {
           values: {


### PR DESCRIPTION
Example given in docs is not correct and doesn't work.

❌`&:nth...` 
this should be ✔`&>*:nth...` here in docs `return &:nth-child(${value})`;

We use `nth-child` in parent class to select children's. Code given in example doesn't do this (not selecting children items). 