### PR TITLE
Update docs (play-cdn page)

### DIFF
--- a/src/pages/docs/installation/play-cdn.js
+++ b/src/pages/docs/installation/play-cdn.js
@@ -117,7 +117,7 @@ let steps = [
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
->   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
+>   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp,container-queries"></script>
   </head>
   <body>
 >   <div class="prose">


### PR DESCRIPTION
Update docs (play-cdn page) to include container queries plugin in cdn link.

Docs can be updated because https://github.com/tailwindlabs/tailwindcss/issues/12667 was fixed, and now can show on docs page that CDN allows user to play with this plugin too.