### PR TITLE
docs: missing import in checkbox example

### DIFF
--- a/src/pages/blog/headless-ui-v2/index.mdx
+++ b/src/pages/blog/headless-ui-v2/index.mdx
@@ -96,7 +96,7 @@ We've added a new headless `Checkbox` component to complement our existing `Radi
 <CheckboxExample />
 
 ```jsx
-  import { Field, Label, Checkbox } from '@headlessui/react'
+  import { Checkbox, Description, Field, Label } from '@headlessui/react'
   import { CheckmarkIcon } from './icons/checkmark'
   import clsx from 'clsx'
 


### PR DESCRIPTION
In the new checkbox component example there is a missing import of the `Description` component. This PR adds it and sorts the imports alphabetically