### PR TITLE
feat(docs): adds selector for color notations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.0",
         "cheerio": "^1.0.0-rc.12",
         "clsx": "^1.1.1",
+        "color-convert": "^2.0.1",
         "debounce": "^1.2.0",
         "dlv": "^1.1.3",
         "exec-sh": "^0.3.4",
@@ -3153,22 +3154,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@zachleat/spider-pig/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@zachleat/spider-pig/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@zachleat/spider-pig/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -3309,6 +3294,19 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -4212,15 +4210,20 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5368,24 +5371,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -6308,22 +6293,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/glyphhanger/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/glyphhanger/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/glyphhanger/node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "autoprefixer": "^10.4.0",
     "cheerio": "^1.0.0-rc.12",
     "clsx": "^1.1.1",
+    "color-convert": "^2.0.1",
     "debounce": "^1.2.0",
     "dlv": "^1.1.3",
     "exec-sh": "^0.3.4",

--- a/src/components/ColorPaletteReference.js
+++ b/src/components/ColorPaletteReference.js
@@ -2,22 +2,88 @@ import { useEffect, useState } from 'react'
 import colorPalette from 'tailwindcss/colors'
 import { kebabToTitleCase } from '@/utils/kebabToTitleCase'
 import dlv from 'dlv'
-import { Transition } from '@headlessui/react'
+import {
+  Transition,
+  Listbox,
+  ListboxButton,
+  ListboxOptions,
+  ListboxOption,
+} from '@headlessui/react'
+
+import * as colorConvert from 'color-convert'
+
+const colorTypes = ['HEX', 'RGB', 'HSL']
 
 export function ColorPaletteReference({ colors }) {
+  const [selectedColorType, setSelectedColorType] = useState('HEX')
+
   return (
     <div className="grid grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] gap-x-2 gap-y-8 sm:grid-cols-1">
-      {colors.map((color, i) => {
-        let title = Array.isArray(color) ? color[0] : kebabToTitleCase(color)
-        let value = Array.isArray(color) ? color[1] : color
+      <Listbox
+        value={selectedColorType}
+        onChange={setSelectedColorType}
+        as="div"
+        className="relative ml-auto"
+      >
+        <ListboxButton className="text-xs leading-5 font-semibold bg-slate-400/10 rounded-full py-1 px-3 flex items-center space-x-2 hover:bg-slate-400/20 dark:highlight-white/5">
+          {selectedColorType}
+          <svg width="6" height="3" className="ml-2 overflow-visible" aria-hidden="true">
+            <path
+              d="M0 0L3 3L6 0"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </ListboxButton>
+        <ListboxOptions
+          anchor="bottom end"
+          className="absolute z-50 top-full mt-1 py-2 w-24 rounded-lg bg-white shadow ring-1 ring-slate-900/5 text-sm leading-6 font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:highlight-white/5"
+        >
+          {colorTypes.map((type) => (
+            <ListboxOption
+              key={type}
+              value={type}
+              className="w-full text-left block px-3 py-1 data-[selected]:bg-slate-50 data-[focus]:bg-slate-50 data-[selected]:text-slate-900 data-[focus]:text-slate-900 data-[selected]:dark:bg-slate-600/30 data-[focus]:dark:bg-slate-600/30 data-[selected]:dark:text-white data-[focus]:dark:text-white"
+              as="button"
+            >
+              {type}
+            </ListboxOption>
+          ))}
+        </ListboxOptions>
+      </Listbox>
 
-        let palette =
-          typeof value === 'string'
-            ? [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950].map((variant) => ({
-                name: variant,
-                value: dlv(colorPalette, [value, variant]),
-              }))
-            : Object.keys(value).map((name) => ({ name, value: value[name] }))
+      {colors.map((color, i) => {
+        let title = kebabToTitleCase(color)
+        let value = color
+
+        let palette = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950].map((variant) => {
+          let colorValue
+
+          switch (selectedColorType) {
+            case 'HEX':
+              colorValue = dlv(colorPalette, [value, variant])
+              break
+
+            case 'RGB':
+              colorValue = colorConvert.hex.rgb(dlv(colorPalette, [value, variant])).join(' ')
+              break
+
+            case 'HSL':
+              colorValue = colorConvert.hex.hsl(dlv(colorPalette, [value, variant])).join(' ')
+              break
+
+            default:
+              colorValue = dlv(colorPalette, [value, variant])
+              break
+          }
+
+          return {
+            name: variant,
+            value: colorValue,
+          }
+        })
 
         return (
           <div key={title} className="2xl:contents">
@@ -110,3 +176,5 @@ function ColorPalette({ name, value }) {
     </div>
   )
 }
+
+function ColorTypeSelector({}) {}


### PR DESCRIPTION
Hi all,

when copying colors from the docs, I often find myself needing the colors noted not in HEX but, for instance, in HSL. One example is [changing color themes in shadcn](https://ui.shadcn.com/docs/installation/manual#configure-styles) where, by default, colors are defined in HSL notation. I can see some designers appreciating such a feedback.

Let me know what you think.

## Demo

https://github.com/tailwindlabs/tailwindcss.com/assets/74593656/508d77da-6744-49a5-9387-219d29dc3406


