### PR TITLE
docs: Corrected HTML end-tag typo

### DIFF
--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -143,13 +143,13 @@ Use the `start-*` and `end-*` utilities to set the `inset-inline-start` and `ins
   <div class="relative h-32 w-32 ...">
     <div class="absolute h-14 w-14 top-0 **start-0** ..."></div>
   </div>
-<div>
+</div>
 
 <div dir="**rtl**">
   <div class="relative h-32 w-32 ...">
     <div class="absolute h-14 w-14 top-0 **start-0** ..."></div>
   </div>
-<div>
+</div>
 ```
 
 For more control, you can also use the [LTR and RTL modifiers](/docs/hover-focus-and-other-states#rtl-support) to conditionally apply specific styles depending on the current text direction.


### PR DESCRIPTION
issue: HTML Element is missing end tag.
solution: Corrected typo where the "/" character was missing in the end-tag.