### PR TITLE
Fix capitalisation in a demo in overflow.mdx

### DIFF
--- a/src/pages/docs/overflow.mdx
+++ b/src/pages/docs/overflow.mdx
@@ -419,7 +419,7 @@ Use the `overflow-scroll` utility to add scrollbars to an element. Unlike `overf
     <!-- Calendar contents -->
     <div class="row-start-[2] col-start-3 row-span-4 bg-blue-400/20 dark:bg-sky-600/50 border border-blue-700/10 dark:border-sky-500 rounded-lg m-1 p-1 flex flex-col">
       <span class="text-xs text-blue-600 dark:text-sky-100">5 AM</span>
-      <span class="text-xs font-medium text-blue-600 dark:text-sky-100">Flight to vancouver</span>
+      <span class="text-xs font-medium text-blue-600 dark:text-sky-100">Flight to Vancouver</span>
       <span class="text-xs text-blue-600 dark:text-sky-100">Toronto YYZ</span>
     </div>
     <div class="row-start-[3] col-start-[4] row-span-4 bg-purple-400/20 dark:bg-fuchsia-600/50 border border-purple-700/10 dark:border-fuchsia-500 rounded-lg m-1 p-1 flex flex-col">


### PR DESCRIPTION
'Flight to vancouver' corrected to 'Flight to Vancouver'