### PR TITLE
Update ThemeReference.js to accurate text color css property

### DIFF
--- a/src/components/ThemeReference.js
+++ b/src/components/ThemeReference.js
@@ -7,6 +7,7 @@ const descriptions = {
   container: 'Configuration for the `container` plugin',
   inset: 'Values for the `top`, `right`, `bottom`, and `left` properties',
   keyframes: 'Keyframe values used in the `animation` plugin',
+  textColor: 'Values for the `color` property',
   ...Object.fromEntries(
     [
       'placeholderColor',


### PR DESCRIPTION
- added a line to the description Array to ensure the `textColor` theme property is translated to `color` in the docs table, since `text-color` is not a valid CSS property