### PR TITLE
overscroll behaviour fixed

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,6 +11,7 @@ html {
 
 body {
   min-height: 100%;
+  overscroll-behavior-y: none;
 }
 
 abbr[title] {


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-07-23 at 3 53 00 PM" src="https://github.com/user-attachments/assets/8c5e21e9-36e7-4919-8dac-fd5873757508">

Browser : Chrome
OS: macOS,

fixed the overscroll behaviour on the y axis using overscroll-behaviour-y on body to be none.