### PR TITLE
Add clarification about preserving the same `to-*` color stop

### DIFF
--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -207,6 +207,8 @@ Gradients fade out to transparent by default, without requiring you to add `to-t
 </button>
 ```
 
+To preserve the same `to-*` color, redefine that color for the same variant modifiers used on the `from-*` color stop.
+
 </HoverFocusAndOtherStates>
 
 ### <Heading ignore>Breakpoints and media queries</Heading>

--- a/src/pages/docs/gradient-color-stops.mdx
+++ b/src/pages/docs/gradient-color-stops.mdx
@@ -207,7 +207,13 @@ Gradients fade out to transparent by default, without requiring you to add `to-t
 </button>
 ```
 
-To preserve the same `to-*` color, redefine that color for the same variant modifiers used on the `from-*` color stop.
+Note that conditionally setting the `from-*` color resets the entire gradient, so if you want to keep the same `to-*` color you need to specify it again for that condition.
+
+```html
+<div class="from-teal-400 to-blue-500 **hover:from-purple-500 hover:to-blue-500** ...">
+  <!-- ... -->
+</div>
+```
 
 </HoverFocusAndOtherStates>
 


### PR DESCRIPTION
This PR adds a short sentence outlining the fact that `to-*` color stops need to be redefined when a variant modifier is used on the `from-*` color.

Explaining why this happens — the intelligent transparency fade calculation (RGB with 0 alpha) — is probably "too much info", but I thought it was useful to just mention the behaviour.