### PR TITLE
Adds support to multiple frameworks on code blocks

### DIFF
--- a/src/components/Guides/FrameworkContext.js
+++ b/src/components/Guides/FrameworkContext.js
@@ -1,0 +1,33 @@
+import React, { createContext, useState, useContext, useEffect } from 'react';
+
+const FrameworkContext = createContext();
+
+export function FrameworkProvider({ children, initialFramework = 'npm' }) {
+  const [selectedFramework, setSelectedFramework] = useState(initialFramework);
+
+  useEffect(() => {
+    const savedFramework = localStorage.getItem('selectedFramework');
+    if (savedFramework) {
+      setSelectedFramework(savedFramework);
+    }
+  }, []);
+
+  const updateSelectedFramework = (framework) => {
+    setSelectedFramework(framework);
+    localStorage.setItem('selectedFramework', framework);
+  };
+
+  return (
+    <FrameworkContext.Provider value={{ selectedFramework, setSelectedFramework: updateSelectedFramework }}>
+      {children}
+    </FrameworkContext.Provider>
+  );
+}
+
+export function useFramework() {
+  const context = useContext(FrameworkContext);
+  if (context === undefined) {
+    return { selectedFramework: 'npm', setSelectedFramework: () => { } };
+  }
+  return context;
+}

--- a/src/components/Guides/Snippets.js
+++ b/src/components/Guides/Snippets.js
@@ -4,19 +4,32 @@ import { highlightCode } from '../../../remark/utils'
  * @typedef {object} CodeSnippet
  * @property {string} lang
  * @property {string} code
+ * @property {Array<{name: string, code: string}>} [frameworks]
  */
 
 /**
  * @param {{code: CodeSnippet|CodeSnippet[]}[]} steps
- * @returns {(string|string[])[]}
+ * @returns {(string|string[]|Object)[]}
  */
 export function highlightedCodeSnippets(steps) {
   /**
    * @param {CodeSnippet} code
-   * @returns {string}
+   * @returns {Object}
    */
   function highlight(code) {
-    return code.lang && code.lang === 'terminal' ? code.code : highlightCode(code.code, code.lang)
+    const highlightFramework = (fw) => ({
+      name: fw.name,
+      code: code.lang === 'terminal' ? fw.code : highlightCode(fw.code, code.lang)
+    });
+
+    return {
+      name: code.name,
+      lang: code.lang,
+      frameworks: code.frameworks ? code.frameworks.map(highlightFramework) : [{
+        name: 'default',
+        code: code.lang === 'terminal' ? code.code : highlightCode(code.code, code.lang)
+      }]
+    };
   }
 
   return steps.map(({ code }) => {

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -1,53 +1,93 @@
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import redent from 'redent'
+import { useFramework } from '@/components/Guides/FrameworkContext';
+import { FrameworkProvider } from '@/components/Guides/FrameworkContext';
+import { ChevronDownIcon } from '@heroicons/react/20/solid'
+import { Field, Select, Transition } from '@headlessui/react'
 import { SnippetGroup } from '@/components/SnippetGroup'
 import { Editor } from '@/components/Editor'
-import { Transition } from '@headlessui/react'
 
 export function Steps({ intro, steps, code, level = 2 }) {
   let StepHeading = `h${level}`
 
   return (
-    <>
-      <div className="hidden sm:block absolute -z-10 top-0 left-[15%] pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
-        <img
-          src={require('@/img/beams/installation.jpg').default.src}
-          alt=""
-          className="w-[52.6875rem] max-w-none"
-          decoding="async"
-        />
-      </div>
-      {intro && (
-        <div className="relative z-10 max-w-3xl mb-16 prose prose-slate dark:prose-dark">
-          {intro()}
+    <FrameworkProvider initialFramework="npm">
+      <>
+        <div className="hidden sm:block absolute -z-10 top-0 left-[15%] pt-[40%] 2xl:left-[40%] 2xl:pt-[8%] dark:hidden">
+          <img
+            src={require('@/img/beams/installation.jpg').default.src}
+            alt=""
+            className="w-[52.6875rem] max-w-none"
+            decoding="async"
+          />
         </div>
-      )}
-      <ol className="relative space-y-2 mb-16" style={{ counterReset: 'step' }}>
-        {steps.map((step, index) => (
-          <li
-            key={step.title}
-            className={clsx(
-              'relative pl-10 xl:grid grid-cols-5 gap-16 before:content-[counter(step)] before:absolute before:left-0 before:flex before:items-center before:justify-center before:w-[calc(1.375rem+1px)] before:h-[calc(1.375rem+1px)] before:text-[0.625rem] before:font-bold before:text-slate-700 before:rounded-md before:shadow-sm before:ring-1 before:ring-slate-900/5 dark:before:bg-slate-700 dark:before:text-slate-200 dark:before:ring-0 dark:before:shadow-none dark:before:highlight-white/5',
-              index !== steps.length - 1 &&
+        {intro && (
+          <div className="relative z-10 max-w-3xl mb-16 prose prose-slate dark:prose-dark">
+            {intro()}
+          </div>
+        )}
+        <ol className="relative space-y-2 mb-16" style={{ counterReset: 'step' }}>
+          {steps.map((step, index) => (
+            <li
+              key={step.title}
+              className={clsx(
+                'relative pl-10 xl:grid grid-cols-5 gap-16 before:content-[counter(step)] before:absolute before:left-0 before:flex before:items-center before:justify-center before:w-[calc(1.375rem+1px)] before:h-[calc(1.375rem+1px)] before:text-[0.625rem] before:font-bold before:text-slate-700 before:rounded-md before:shadow-sm before:ring-1 before:ring-slate-900/5 dark:before:bg-slate-700 dark:before:text-slate-200 dark:before:ring-0 dark:before:shadow-none dark:before:highlight-white/5',
+                index !== steps.length - 1 &&
                 'pb-8 after:absolute after:top-[calc(1.875rem+1px)] after:bottom-0 after:left-[0.6875rem] after:w-px after:bg-slate-200 dark:after:bg-slate-200/5'
-            )}
-            style={{ counterIncrement: 'step' }}
-          >
-            <div className="mb-6 col-span-2 xl:mb-0">
-              <StepHeading className="text-sm leading-6 text-slate-900 font-semibold mb-2 dark:text-slate-200">
-                {step.title}
-              </StepHeading>
-              <div className="prose prose-slate prose-sm dark:prose-dark">
-                <step.body />
+              )}
+              style={{ counterIncrement: 'step' }}
+            >
+              <div className="mb-6 col-span-2 xl:mb-0">
+                <StepHeading className="text-sm leading-6 text-slate-900 font-semibold mb-2 dark:text-slate-200">
+                  {step.title}
+                </StepHeading>
+                <div className="prose prose-slate prose-sm dark:prose-dark">
+                  <step.body />
+                </div>
               </div>
-            </div>
-            {step.code && <Snippet code={step.code} highlightedCode={code[index]} />}
-          </li>
-        ))}
-      </ol>
-    </>
+              {Array.isArray(code) ? (
+                <Snippet code={code[index]} />
+              ) : (
+                <Snippet code={code.steps[index].code} highlightedCode={code.steps[index].code.frameworks[0].code} />
+              )}
+            </li>
+          ))}
+        </ol>
+      </>
+    </FrameworkProvider>
   )
+}
+
+export default function CodeLanguageButton({ frameworks, selected, setSelected }) {
+  return (
+    <div className="w-full max-w-md z-50 pl-4">
+      <Field>
+        <div className="relative">
+          <Select
+            value={selected}
+            onChange={(event) => setSelected(event.target.value)}
+            className={clsx(
+              'block w-full appearance-none rounded-md border border-white/10 bg-white/20 py-0.5 px-1.5 pr-5 text-xs text-slate-200',
+              'focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500',
+              'hover:cursor-pointer hover:border-white/40',
+              '*:text-black'
+            )}
+          >
+            {frameworks.map((framework) => (
+              <option key={framework} value={framework}>
+                {framework}
+              </option>
+            ))}
+          </Select>
+          <ChevronDownIcon
+            className="pointer-events-none absolute top-[1px] right-0.5 h-5 w-5 fill-gray-400"
+            aria-hidden="true"
+          />
+        </div>
+      </Field>
+    </div>
+  );
 }
 
 function CopyButton({ code }) {
@@ -151,32 +191,64 @@ function Code({ code, lang, pad }) {
 }
 
 function Snippet({ code, highlightedCode }) {
-  if (Array.isArray(code)) {
-    return (
-      <div className="col-span-3">
-        <SnippetGroup
-          actions={({ selectedIndex }) => <CopyButton code={code[selectedIndex].code} />}
-        >
-          {code.map(({ name, lang }, index) => (
-            <Editor key={name} filename={name}>
-              <Code code={highlightedCode[index]} lang={lang} />
-            </Editor>
-          ))}
-        </SnippetGroup>
-      </div>
-    )
-  }
+  const { selectedFramework: contextFramework, setSelectedFramework } = useFramework();
+  const [currentFramework, setCurrentFramework] = useState(contextFramework);
+
+  useEffect(() => {
+    setCurrentFramework(contextFramework);
+  }, [contextFramework]);
+
+  // No longer neded. I think the code can probably be optimized, in terms of identifying if there's any framework available.
+  // if (Array.isArray(code)) {
+  //   return (
+  //     <div className="col-span-3">
+  //       <SnippetGroup
+  //         actions={({ selectedIndex }) => <CopyButton code={code[selectedIndex].code} />}
+  //       >
+  //         {code.map(({ name, lang }, index) => (
+  //           <Editor key={name} filename={name}>
+  //             <Code code={highlightedCode[index]} lang={lang} />
+  //           </Editor>
+  //         ))}
+  //       </SnippetGroup>
+  //     </div>
+  //   );
+  // }
+
+  const frameworks = code.frameworks || [{ name: 'default', code: code.code }];
+  const hasMultipleFrameworks = frameworks.length > 1;
+
+  const getDisplayedCode = () => {
+    const framework = frameworks.find(fw => fw.name === currentFramework) || frameworks[0];
+    return framework.code;
+  };
+
+  const handleFrameworkChange = (framework) => {
+    setCurrentFramework(framework);
+    setSelectedFramework(framework);
+  };
 
   return (
     <div className="relative z-10 -ml-10 col-span-3 bg-slate-800 rounded-xl shadow-lg xl:ml-0 dark:shadow-none dark:ring-1 dark:ring-inset dark:ring-white/10">
       <TabBar name={code.name}>
-        <CopyButton code={code.code} />
+        <CopyButton code={getDisplayedCode()} />
+        {hasMultipleFrameworks && (
+          <CodeLanguageButton
+            frameworks={frameworks.map(fw => fw.name)}
+            selected={currentFramework}
+            setSelected={handleFrameworkChange}
+          />
+        )}
       </TabBar>
       <div className="relative">
-        <Code code={highlightedCode} lang={code.lang} pad={true} />
+        <Code
+          code={getDisplayedCode()}
+          lang={code.lang}
+          pad={true}
+        />
       </div>
     </div>
-  )
+  );
 }
 
 function TabBar({ name, children }) {

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -69,7 +69,6 @@ export default function CodeLanguageButton({ frameworks, selected, setSelected }
             onChange={(event) => setSelected(event.target.value)}
             className={clsx(
               'block w-full appearance-none rounded-md border border-white/10 bg-white/20 py-0.5 px-1.5 pr-5 text-xs text-slate-200',
-              'focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500',
               'hover:cursor-pointer hover:border-white/40',
               '*:text-black'
             )}

--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -24,7 +24,16 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npx nuxi init my-project\ncd my-project',
+          frameworks: [
+            {
+              name: 'npm',
+              code: 'npm run dev',
+            },
+            {
+              name: 'bun',
+              code: 'bun run dev',
+            },
+          ],
         },
       },
       {
@@ -38,7 +47,16 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+          frameworks: [
+            {
+              name: 'npm',
+              code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+            },
+            {
+              name: 'bun',
+              code: 'bun install -D tailwindcss postcss autoprefixer\nbunx tailwindcss init',
+            },
+          ],
         },
       },
       {
@@ -177,7 +195,16 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npx nuxi init my-project\ncd my-project',
+          frameworks: [
+            {
+              name: 'npm',
+              code: 'npx nuxi init my-project\ncd my-project',
+            },
+            {
+              name: 'bun',
+              code: 'bunx nuxi init my-project\ncd my-project',
+            },
+          ],
         },
       },
       {
@@ -247,9 +274,28 @@ export default function UsingNuxtJs({ code }) {
 export function getStaticProps() {
   let { highlightedCodeSnippets } = require('@/components/Guides/Snippets.js')
 
+  const serializableSteps = (steps) => {
+    return steps.map(step => ({
+      ...step,
+      // Convert the body function to a string representation
+      body: step.body.toString(),
+      code: step.code
+    }))
+  }
+
   return {
     props: {
-      code: tabs.map((tab) => highlightedCodeSnippets(tab.steps)),
+      code: tabs.map((tab) => {
+        const highlightedSteps = highlightedCodeSnippets(serializableSteps(tab.steps))
+        return {
+          ...tab,
+          steps: tab.steps.map((step, index) => ({
+            ...step,
+            body: step.body.toString(), // Convert function to string
+            code: highlightedSteps[index]
+          }))
+        }
+      }),
     },
   }
 }

--- a/src/pages/docs/installation/index.js
+++ b/src/pages/docs/installation/index.js
@@ -58,7 +58,16 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npx tailwindcss -i ./src/input.css -o ./src/output.css --watch',
+      frameworks: [
+        {
+          name: 'npm',
+          code: 'npx tailwindcss -i ./src/input.css -o ./src/output.css --watch',
+        },
+        {
+          name: 'bun',
+          code: 'bunx tailwindcss -i ./src/input.css -o ./src/output.css --watch',
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Hi!

This is a work in progress since the way I am handling different frameworks might not yet be optimal and could be clearer, specifically in the way I'm changing the `getStaticProps` function. **Right now, I want to understand if this feature is even useful.**

## Motivation:
Some websites (e.g., [nuxt.com](https://nuxt.com/)) have code blocks similar to those found on [tailwindcss.com](https://tailwindcss.com/docs/installation), but with the option to select different frameworks (e.g., `npm`, `yarn`, `pnpm`, `bun`) instead of just `npm`.

## Design:

New button (displayed only when the code block has different framework configurations):
> <img width="800" alt="unselected-state" src="https://github.com/user-attachments/assets/91cf585e-b683-450b-bdb1-b8323e3cccaa">

Different framework selected (`bun ➜ npm`):
> <img width="806" alt="changed-state" src="https://github.com/user-attachments/assets/3ef1818a-ac62-4e30-9dcd-09c532f3c60d">

No changes if a code block doesn't have a specified framework:
> <img width="809" alt="one-has-other-doesnt-sate" src="https://github.com/user-attachments/assets/d4857c41-950d-4e45-b2ed-6bb520c42b6f">

## Usage:

**Before:**

```javascript
code: {
  name: 'Terminal',
  lang: 'terminal',
  code: 'npx nuxi init my-project\ncd my-project',
},
```

**After:**

```javascript
code: {
  name: 'Terminal',
  lang: 'terminal',
  frameworks: [
    {
      name: 'npm',
      code: 'npx nuxi init my-project\ncd my-project',
    },
    {
      name: 'bun',
      code: 'bunx nuxi init my-project\ncd my-project',
    },
  ],
},
```

**If you do not want to add more frameworks for a specific block, no changes are needed!**

## Changes:
This Pull Request adds:
- A local storage variable (`selectedFramework`) used to keep track of the selected framework (and uses React context to keep everything live).
- A `CodeLanguageButton` component that acts as the button to change the framework (uses `@headlessui/react` components).
- Updates to the `Snippet` and `Steps` components to support the new behavior.
- Updates to the `getStaticProps` function in `src/pages/docs/guides/nuxtjs.js` (updates on this file were made to test these changes).

> [!WARNING]  
> I only updated the `nuxtjs.js` page to test things out. If this Pull Request moves forward, I can either update no page (and just add the new logic) or update all relevant pages.
