### PR TITLE
Update reusing-styles.mdx

### DIFF
--- a/src/pages/docs/reusing-styles.mdx
+++ b/src/pages/docs/reusing-styles.mdx
@@ -213,7 +213,7 @@ Unless a component is a single HTML element, the information needed to define it
     <img class="chat-notification-logo" src="/img/logo.svg" alt="ChitChat Logo">
   </div>
   <div class="chat-notification-content">
-    <h4 class="chat-notification-title">ChitChat</h4>
+    <div class="chat-notification-title">ChitChat</div>
     <p class="chat-notification-message">You have a new message!</p>
   </div>
 </div>
@@ -241,7 +241,7 @@ Components and template partials solve this problem much better than CSS-only ab
       <svg class="h-12 w-12" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="a"><stop stop-color="#2397B3" offset="0%"/><stop stop-color="#13577E" offset="100%"/></linearGradient><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="b"><stop stop-color="#73DFF2" offset="0%"/><stop stop-color="#47B1EB" offset="100%"/></linearGradient></defs><g fill="none" fill-rule="evenodd"><path d="M28.872 22.096c.084.622.128 1.258.128 1.904 0 7.732-6.268 14-14 14-2.176 0-4.236-.496-6.073-1.382l-6.022 2.007c-1.564.521-3.051-.966-2.53-2.53l2.007-6.022A13.944 13.944 0 0 1 1 24c0-7.331 5.635-13.346 12.81-13.95A9.967 9.967 0 0 0 13 14c0 5.523 4.477 10 10 10a9.955 9.955 0 0 0 5.872-1.904z" fill="url(#a)" transform="translate(1 1)"/><path d="M35.618 20.073l2.007 6.022c.521 1.564-.966 3.051-2.53 2.53l-6.022-2.007A13.944 13.944 0 0 1 23 28c-7.732 0-14-6.268-14-14S15.268 0 23 0s14 6.268 14 14c0 2.176-.496 4.236-1.382 6.073z" fill="url(#b)" transform="translate(1 1)"/><path d="M18 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM24 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM30 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" fill="#FFF"/></g></svg>
     </div>
     <div>
-      <h4 class="text-base sm:text-xl font-medium text-black">ChitChat</h4>
+      <div class="text-base sm:text-xl font-medium text-black">ChitChat</div>
       <p class="text-sm sm:text-base text-slate-500">You have a new message!</p>
     </div>
   </div>
@@ -256,7 +256,7 @@ function Notification({ imageUrl, imageAlt, title, message }) {
         <img className="h-12 w-12" src={imageUrl.src} alt={imageAlt}>
       </div>
       <div>
-        <h4 className="text-xl font-medium text-black">{title}</h4>
+        <div className="text-xl font-medium text-black">{title}</div>
         <p className="text-slate-500">{message}</p>
       </div>
     </div>

--- a/src/pages/docs/reusing-styles.mdx
+++ b/src/pages/docs/reusing-styles.mdx
@@ -241,7 +241,7 @@ Components and template partials solve this problem much better than CSS-only ab
       <svg class="h-12 w-12" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="a"><stop stop-color="#2397B3" offset="0%"/><stop stop-color="#13577E" offset="100%"/></linearGradient><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="b"><stop stop-color="#73DFF2" offset="0%"/><stop stop-color="#47B1EB" offset="100%"/></linearGradient></defs><g fill="none" fill-rule="evenodd"><path d="M28.872 22.096c.084.622.128 1.258.128 1.904 0 7.732-6.268 14-14 14-2.176 0-4.236-.496-6.073-1.382l-6.022 2.007c-1.564.521-3.051-.966-2.53-2.53l2.007-6.022A13.944 13.944 0 0 1 1 24c0-7.331 5.635-13.346 12.81-13.95A9.967 9.967 0 0 0 13 14c0 5.523 4.477 10 10 10a9.955 9.955 0 0 0 5.872-1.904z" fill="url(#a)" transform="translate(1 1)"/><path d="M35.618 20.073l2.007 6.022c.521 1.564-.966 3.051-2.53 2.53l-6.022-2.007A13.944 13.944 0 0 1 23 28c-7.732 0-14-6.268-14-14S15.268 0 23 0s14 6.268 14 14c0 2.176-.496 4.236-1.382 6.073z" fill="url(#b)" transform="translate(1 1)"/><path d="M18 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM24 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM30 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" fill="#FFF"/></g></svg>
     </div>
     <div>
-      <div class="text-base sm:text-xl font-medium text-black">ChitChat</div>
+      <h4 class="text-base sm:text-xl font-medium text-black">ChitChat</h4>
       <p class="text-sm sm:text-base text-slate-500">You have a new message!</p>
     </div>
   </div>

--- a/src/pages/docs/reusing-styles.mdx
+++ b/src/pages/docs/reusing-styles.mdx
@@ -256,7 +256,7 @@ function Notification({ imageUrl, imageAlt, title, message }) {
         <img className="h-12 w-12" src={imageUrl.src} alt={imageAlt}>
       </div>
       <div>
-        <div className="text-xl font-medium text-black">{title}</div>
+        <h4 className="text-xl font-medium text-black">{title}</h4>
         <p className="text-slate-500">{message}</p>
       </div>
     </div>


### PR DESCRIPTION
Replace usage of `<div>` tag with `<h4>` tag, following the provided example from above.