### PR TITLE
Remove empty Play CDN page

### DIFF
--- a/src/pages/docs/play-cdn.mdx
+++ b/src/pages/docs/play-cdn.mdx
@@ -1,6 +1,0 @@
----
-title: Play CDN
-description: Understanding which browsers Tailwind supports and how to manage vendor prefixes.
----
-
-To do.


### PR DESCRIPTION
I stumbled upon this broken page on the website: https://tailwindcss.com/docs/play-cdn

It doesn't appear to be linked to from anywhere (all links instead go to https://tailwindcss.com/docs/installation/play-cdn), so this seems safe to delete.

 