### PR TITLE
docs: remove duplicate info for breakpoint range

### DIFF
--- a/src/pages/docs/responsive-design.mdx
+++ b/src/pages/docs/responsive-design.mdx
@@ -114,18 +114,6 @@ Tailwind generates a corresponding `max-*` modifier for each breakpoint, so out 
 | `max-xl` | `@media not all and (min-width: 1280px) { ... }` |
 | `max-2xl` | `@media not all and (min-width: 1536px) { ... }` |
 
-### Targeting a single breakpoint
-
-To target a single breakpoint, target the range for that breakpoint by stacking a responsive modifier like `md` with the `max-*` modifier for the next breakpoint:
-
-```html
-<div class="md:max-lg:flex">
-  <!-- ... -->
-</div>
-```
-
-Read about [targeting breakpoint ranges](#targeting-a-breakpoint-range) to learn more.
-
 ---
 
 ## Using custom breakpoints


### PR DESCRIPTION
The explanation of [[Targeting a breakpoint range](https://tailwindcss.com/docs/responsive-design#targeting-a-breakpoint-range)](https://tailwindcss.com/docs/responsive-design#targeting-a-breakpoint-range) seems already explaining the purpose, while [Targeting a single breakpoint](https://tailwindcss.com/docs/responsive-design#targeting-a-single-breakpoint) seems explaining the same concept.

I propose to remove it to reduce overhead on reading this part of doc.