### PR TITLE
Allow quick search via ?q=... search param

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -49,6 +49,16 @@ export function SearchProvider({ children }) {
   })
 
   useEffect(() => {
+    // trigger search on first load if the URL contains ?q=...
+    const q = new URLSearchParams(window.location.search).get('q')
+    if (!q) {
+      return
+    }
+    setIsOpen(true)
+    setInitialQuery(q)
+  }, [])
+
+  useEffect(() => {
     // Prepend "Components" to Tailwind UI results that are shown in the "recent" view
     if (!isOpen) {
       let key = `__DOCSEARCH_RECENT_SEARCHES__${INDEX_NAME}`


### PR DESCRIPTION
Reviving of #107 (requested in #789)

This is a minimal change, so that when the URL contains `?q=search-term`:
- the search-box is automatically opened
- the given `search-term` is automatically searched for

Preview: https://tailwindcss-com-git-fork-oliverpool-master-tailwindlabs.vercel.app/?q=collapse
