### PR TITLE
Note that `@layer` CSS at-rule will not be output.

### DIFF
--- a/src/pages/docs/functions-and-directives.mdx
+++ b/src/pages/docs/functions-and-directives.mdx
@@ -83,6 +83,8 @@ Any custom CSS added to a layer will only be included in the final build if that
 
 Wrapping any custom CSS with `@layer` also makes it possible to use modifiers with those rules, like `hover:` and `focus:` or responsive modifiers like `md:` and `lg:`.
 
+Note that the native `@layer` CSS at-rule will not be output.
+
 ### @apply
 
 Use `@apply` to inline any existing utility classes into your own custom CSS.


### PR DESCRIPTION
Returning to Tailwind after some time of using the native `@layer` system, I lost an hour of work thinking that something with my PostCSS setup was stripping my `@layer` at-rules.  I think the at-rule has matured to the point where people that haven't been using Tailwind for a while (or never had) might expect to see it output.  I see v4 will output this, but v3 simply reorders the rules for maximum compatibility.

I have read the documentation here multiple times and I feel if this statement was here it would click in my head sooner that  Tailwind v3 does not actually output the `@layer` at-rules and instead tracks and reorders them.  It was only when I started testing the outputs in the playground did I realize this distinction.

Feel free to reword and thanks for the otherwise great docs and css framework!