### PR TITLE
Fix typo on homepage build anything section's simple tab show code editor and output Classic Utility Jacket

### DIFF
--- a/src/components/home/BuildAnything.js
+++ b/src/components/home/BuildAnything.js
@@ -22,7 +22,7 @@ const code = {
   </div>
   <form class="flex-auto p-6">
     <div class="flex flex-wrap">
-      <h1 class="flex-auto text-lg font-semibold text-slate-900">Utility Jacket</h1>
+      <h1 class="flex-auto text-lg font-semibold text-slate-900">Classic Utility Jacket</h1>
       <div class="text-lg font-semibold text-slate-500">$110.00</div>
       <div class="w-full flex-none text-sm font-medium text-slate-700 mt-2">In stock</div>
     </div>
@@ -222,7 +222,7 @@ const classes = {
 }
 
 const content = {
-  Simple: ['/classic-utility-jacket.jpg', 'Utility Jacket', '$110.00'],
+  Simple: ['/classic-utility-jacket.jpg', 'Classic Utility Jacket', '$110.00'],
   Playful: ['/kids-jumpsuit.jpg', 'Kids Jumpsuit', '$39.00'],
   Elegant: ['/dogtooth-style-jacket.jpg', 'DogTooth Style Jacket', '$350.00'],
   Brutalist: ['/retro-shoe.jpg', 'Retro Shoe', '$89.00'],


### PR DESCRIPTION

![Screenshot 2024-10-28 174727](https://github.com/user-attachments/assets/f2870f26-9d80-4b96-8825-64697337ee72)

Tailwind css website homepage build anything section's simple tab contain output image and code editor but in code, developer's forget to write complete words "Classic Utility Jacket". So i'm just write correct words as you can check/compare before and after changes🙂.


Sorry, if i am wrong otherewise please add my changes into your website.

Thank You,

beginner developer