### PR TITLE
Update sveltekit installation guide

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -18,7 +18,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm create svelte@latest my-project\ncd my-project',
+      code: 'npx sv create my-project\ncd my-project',
     },
   },
   {


### PR DESCRIPTION
Updated to the new way of creating a svelte project.

Refer to [https://svelte.dev/docs/kit/creating-a-project](https://svelte.dev/docs/kit/creating-a-project) for more details.