### PR TITLE
Fix mislead: update angular cli set up guide link

### DIFF
--- a/src/pages/docs/guides/angular.js
+++ b/src/pages/docs/guides/angular.js
@@ -8,7 +8,7 @@ let steps = [
     body: () => (
       <p>
         Start by creating a new Angular project if you don’t have one set up already. The most
-        common approach is to use <a href="https://angular.io/cli">Angular CLI</a>.
+        common approach is to use <a href="https://angular.dev/tools/cli">Angular CLI</a>.
       </p>
     ),
     code: {


### PR DESCRIPTION
1. Angular official website is changed
2. The old link(https://angular.io/cli) will mislead user to install angular cli with fixed version(17)
![Xnip2024-11-12_12-58-51](https://github.com/user-attachments/assets/a2bbbfd3-0953-426e-abb1-7bf99bfc6a6c)
3. So I create this PR to update the angular cli set up guide link

