### PR TITLE
Fix grammar in reusing-styles.mdx

### DIFF
--- a/src/pages/docs/reusing-styles.mdx
+++ b/src/pages/docs/reusing-styles.mdx
@@ -60,7 +60,7 @@ If the styles you need to reuse only need to be reused within a single file, mul
 
 ### Multi-cursor editing
 
-When duplication is localized to a group of elements in a single file, the easiest way to deal with it to use [multi-cursor editing](https://code.visualstudio.com/docs/editor/codebasics#_multiple-selections-multicursor) to quickly select and edit the class list for each element at once:
+When duplication is localized to a group of elements in a single file, the easiest way to deal with it is to use [multi-cursor editing](https://code.visualstudio.com/docs/editor/codebasics#_multiple-selections-multicursor) to quickly select and edit the class list for each element at once:
 
 <MultiCursorDemo />
 


### PR DESCRIPTION
Fixed a grammar issue in the ‘Multi-cursor editing’ section by adding the verb ‘is’ to make the sentence sound more grammatically correct.