### PR TITLE
Fix typo in v4 stacked variants migration example

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1919,7 +1919,7 @@ To update your project for this change, reverse the order of any order-sensitive
 
 ```diff-html
 - <ul class="py-4 first:*:pt-0 last:*:pb-0">
-+ <ul class="py-4 *:first:pt-0 *:first:pb-0">
++ <ul class="py-4 *:first:pt-0 *:last:pb-0">
     <li>One</li>
     <li>Two</li>
     <li>Three</li>


### PR DESCRIPTION
Fix a typo in the v4 migration docs where the v3's `last:*:pb-0` should be `*:last:pb-0` but is (incorrectly) written as `*:first:pb-0`