### PR TITLE
Add `--spacing-*` to namespace-reference table ( v4 docs )

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1340,6 +1340,7 @@ Since we've dramatically [simplified theme configuration](#simplified-theme-conf
 | ------------------ | -------------------------------------------------------------------------------------- |
 | `--color-*`        | Color utilities like `bg-white`, `text-black`, or `fill-blue-500`                      |
 | `--font-*`         | Font family utilities like `font-sans`                                                 |
+| `--spacing-*`      | Spacing utilities like `mt-2`, `px-4`                                                  |
 | `--text-*`         | Font size utilities like `text-sm`                                                     |
 | `--font-weight-*`  | Font weight utilities like `font-bold`                                                 |
 | `--tracking-*`     | Letter spacing utilities like `tracking-tight`                                         |

--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1340,7 +1340,7 @@ Since we've dramatically [simplified theme configuration](#simplified-theme-conf
 | ------------------ | -------------------------------------------------------------------------------------- |
 | `--color-*`        | Color utilities like `bg-white`, `text-black`, or `fill-blue-500`                      |
 | `--font-*`         | Font family utilities like `font-sans`                                                 |
-| `--spacing-*`      | Spacing utilities like `mt-2`, `px-4`                                                  |
+| `--spacing-*`      | Spacing utilities like `mt-2`, `p-4`                                                   |
 | `--text-*`         | Font size utilities like `text-sm`                                                     |
 | `--font-weight-*`  | Font weight utilities like `font-bold`                                                 |
 | `--tracking-*`     | Letter spacing utilities like `tracking-tight`                                         |
@@ -1369,6 +1369,10 @@ Since we've dramatically [simplified theme configuration](#simplified-theme-conf
     <tr>
       <td className='whitespace-nowrap'>`--font-*`</td>
       <td>Font family utilities like <code>font-sans</code></td>
+    </tr>
+    <tr>
+      <td className='whitespace-nowrap'>`--spacing-*`</td>
+      <td>Spacing utilities like <code>mt-2</code> or <code>p-4</code></td>
     </tr>
     <tr>
       <td className='whitespace-nowrap'>`--text-*`</td>


### PR DESCRIPTION
I was reading the document on v4-beta and at the table I wasn't able to see that `--spacing-*` namespace. At first I thought maybe it has been removed due to the fact that `mt-21` is now available ( mentioned earlier in document ). But soon I realized maybe it was just missed out in table. So, that's it.