### PR TITLE
fix color from colors in the theme() replacement with var()

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1942,7 +1942,7 @@ Since Tailwind CSS v4.0 includes CSS variables for all of your theme values, we 
 
   .my-class {
 -   background-color: theme(colors.red.500);
-+   background-color: var(--colors-red-500);
++   background-color: var(--color-red-500);
   }
 ```
 


### PR DESCRIPTION
In the 4.0 beta documentation there in the section:

Since Tailwind CSS v4.0 includes CSS variables for all of your theme values, we recommend using those variables instead of the theme() function whenever possible:

We have:
```css
@import "tailwindcss";

.my-class {
  background-color: theme(colors.red.500);
  background-color: var(--colors-red-500);
}
```

But i suppose that `var(--colors-red-500);` should be `var(--color-red-500);`
(color without the 's')