### PR TITLE
remove z-index on beam

### DIFF
--- a/src/components/home/EditorTools.js
+++ b/src/components/home/EditorTools.js
@@ -338,7 +338,7 @@ export function EditorTools() {
               decoding="async"
               src={require('@/img/beams/overlay.webp').default.src}
               alt=""
-              className="absolute z-10 bottom-0 -left-80 w-[45.0625rem] pointer-events-none dark:hidden"
+              className="absolute bottom-0 -left-80 w-[45.0625rem] pointer-events-none dark:hidden"
             />
             <CodeWindow className="!h-[39.0625rem]">
               <div className="flex-auto flex min-h-0">


### PR DESCRIPTION
Before:
<img width="1000" alt="Screenshot 2024-11-28 at 14 09 23" src="https://github.com/user-attachments/assets/ff954543-16cf-4bc9-a284-5840da147dee">


After:
<img width="1402" alt="Screenshot 2024-11-28 at 14 09 06" src="https://github.com/user-attachments/assets/9b52b19f-938f-4618-ba15-bda0aaf46e48">


No idea why this class was there tbh