### PR TITLE
Update docs for Svelte 5

### DIFF
--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -107,9 +107,10 @@ let steps = [
       lang: 'html',
       code: `<script>
   import "../app.css";
+  let { children } = $props();
 </script>
 
-<slot />`,
+{@render children()}`,
     },
   },
   {


### PR DESCRIPTION
Recently, Svelte version 5 released introducing the runes system. Part of this included changing the `<slot/>` tag to `{@render children()}`. This PR makes the [SvelteKit install guide](https://tailwindcss.com/docs/guides/sveltekit) reflect those changes.

### Before
```svelte
<script>
  import "../app.css";
</script>

<slot />
```

### Proposed Change
```svelte
<script>
  import "../app.css";
  let { children } = $props();
</script>

{@render children()}
```