### PR TITLE
docs: add missing --save-dev option

### DIFF
--- a/src/pages/blog/tailwindcss-1-9/index.mdx
+++ b/src/pages/blog/tailwindcss-1-9/index.mdx
@@ -189,10 +189,10 @@ Tailwind CSS v1.9 is a non-breaking minor release, so to upgrade all you need to
 
 ```bash
 # npm
-npm install tailwindcss@^1.9
+npm install -D tailwindcss@^1.9
 
 # yarn
-yarn add tailwindcss@^1.9
+yarn add -D tailwindcss@^1.9
 ```
 
 We have promoted two previously experimental features (`defaultLineHeights` and `standardFontWeights`) to `future`, so we also recommend [opting-in to those changes now](/docs/upcoming-changes#default-line-heights-for-font-size-utilities) to simplify the upgrade to Tailwind CSS v2.0 later this fall.

--- a/src/pages/blog/tailwindcss-2-1/index.mdx
+++ b/src/pages/blog/tailwindcss-2-1/index.mdx
@@ -107,7 +107,7 @@ I also highly recommend [this great article by Josh Comeau](https://www.joshwcom
 Tailwind CSS v2.1 is an incremental upgrade with no breaking changes, so to upgrade you just need to run:
 
 ```bash
-npm install tailwindcss@latest
+npm install -D tailwindcss@latest
 ```
 
 If you were previously using `@tailwindcss/jit`, you can now switch back to `tailwindcss` and update your PostCSS configuration accordingly.

--- a/src/pages/blog/tailwindcss-v3-1/index.mdx
+++ b/src/pages/blog/tailwindcss-v3-1/index.mdx
@@ -43,7 +43,7 @@ So here it is — Tailwind CSS v3.1! For a complete list of every fix and improv
 Upgrade your projects by installing the latest version of `tailwindcss` from npm:
 
 ```shell
-npm install tailwindcss@latest
+npm install -D tailwindcss@latest
 ```
 
 Or spin up a [Tailwind Play](https://play.tailwindcss.com) to play around with all of the new goodies right in the browser.
@@ -663,7 +663,7 @@ Play with them a bit and I'll bet you find they are a great tool when the situat
 So that's Tailwind CSS v3.1! It's only a minor version change, so there are no breaking changes and you should be able to update your project by just installing the latest version:
 
 ```shell
-npm install tailwindcss@latest
+npm install -D tailwindcss@latest
 ```
 
 For the complete list of changes including bug fixes and a few minor improvements I didn't talk about here, dig in to the [release notes](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0) on GitHub.

--- a/src/pages/blog/tailwindcss-v3-4/index.mdx
+++ b/src/pages/blog/tailwindcss-v3-4/index.mdx
@@ -40,7 +40,7 @@ All the good stuff is in that list, but check out the [release notes](https://gi
 Upgrade your projects by installing the latest version of `tailwindcss` from npm:
 
 ```bash
-$ npm install tailwindcss@latest
+$ npm install -D tailwindcss@latest
 ```
 
 Or try out all of the new features on [Tailwind Play](https://play.tailwindcss.com), right in your browser.
@@ -428,7 +428,7 @@ We'd originally slated those improvements for v3.4, but we have a few things sti
 In the mean time, dig in to Tailwind CSS v3.4 by updating to the latest version with npm:
 
 ```bash
-$ npm install tailwindcss@latest
+$ npm install -D tailwindcss@latest
 ```
 
 With `:has()` and the new `*` variant, your HTML is about to get more out of control than ever.

--- a/src/pages/blog/tailwindcss-v4-alpha/index.mdx
+++ b/src/pages/blog/tailwindcss-v4-alpha/index.mdx
@@ -265,7 +265,7 @@ If you find an issue, please [let us know on GitHub](https://github.com/tailwind
 Install the Tailwind CSS v4 alpha and our new Vite plugin:
 
 ```bash
-$ npm install tailwindcss@next @tailwindcss/vite@next
+$ npm install -D tailwindcss@next @tailwindcss/vite@next
 ```
 
 Then add our plugin to your `vite.config.ts` file:
@@ -290,7 +290,7 @@ Finally, import Tailwind in your main CSS file:
 Install the Tailwind CSS v4 alpha and the separate PostCSS plugin package:
 
 ```bash
-$ npm install tailwindcss@next @tailwindcss/postcss@next
+$ npm install -D tailwindcss@next @tailwindcss/postcss@next
 ```
 
 Then add our plugin to your `postcss.config.js` file:
@@ -314,7 +314,7 @@ Finally, import Tailwind in your main CSS file:
 Install the Tailwind CSS v4 alpha and the separate CLI package:
 
 ```bash
-$ npm install tailwindcss@next @tailwindcss/cli@next
+$ npm install -D tailwindcss@next @tailwindcss/cli@next
 ```
 
 Next, import Tailwind in your main CSS file:

--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -292,7 +292,7 @@ If you run into any snags, [let us know on GitHub](https://github.com/tailwindla
 If you're using Vite or a Vite-powered framework like SvelteKit or Remix, install Tailwind along with our new dedicated Vite plugin:
 
 ```bash {{ filename: 'Terminal' }}
-$ npm install tailwindcss@next @tailwindcss/vite@next
+$ npm install -D tailwindcss@next @tailwindcss/vite@next
 ```
 
 Next, add our Vite plugin to your `vite.config.ts` file:
@@ -319,7 +319,7 @@ Finally, import Tailwind into your main CSS file:
 If your project uses PostCSS or you're using a framework like Next.js that supports PostCSS plugins, install Tailwind along with our new dedicated PostCSS plugin:
 
 ```bash {{ filename: 'Terminal' }}
-$ npm install tailwindcss@next @tailwindcss/postcss@next
+$ npm install -D tailwindcss@next @tailwindcss/postcss@next
 ```
 
 Next, add our PostCSS plugin to your `postcss.config.js` file:
@@ -343,7 +343,7 @@ Finally, import Tailwind into your main CSS file:
 If you want to use our dedicated CLI tool, install Tailwind along with our new dedicated CLI package:
 
 ```bash {{ filename: 'Terminal' }}
-$ npm install tailwindcss@next @tailwindcss/cli@next
+$ npm install -D tailwindcss@next @tailwindcss/cli@next
 ```
 
 Next, import Tailwind into your main CSS file:


### PR DESCRIPTION
## Description

The most of install command of tailwindcss have `-D, --save-dev` option.
However, some docs don't have it.
So, appended it to them.