### PR TITLE
Typo fix: Change `theme()` to `var()`

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1952,7 +1952,7 @@ For cases where you still need to use the `theme()` function (like in media quer
   @import "tailwindcss";
 
 - @media (width >= theme(screens.xl)) {
-+ @media (width >= theme(--breakpoint-xl)) {
++ @media (width >= var(--breakpoint-xl)) {
     /* ... */
   }
 ```


### PR DESCRIPTION
Minor typo in the docs:

Should be `var(--breakpoint-xl)` not `theme(--breakpoint-xl)`

<img width="480" alt="Screenshot 2024-12-05 at 7 00 53 PM" src="https://github.com/user-attachments/assets/63de5b9b-e5d2-40e5-8501-3aab6336295f">
