### PR TITLE
docs: fix link to new angular docs

### DIFF
--- a/src/pages/docs/guides/angular.js
+++ b/src/pages/docs/guides/angular.js
@@ -8,8 +8,7 @@ let steps = [
     body: () => (
       <p>
         Start by creating a new Angular project if you don’t have one set up already. The most
-        common approach is to use
-        <a href="https://angular.dev/tools/cli">Angular CLI</a>.
+        common approach is to use <a href="https://angular.dev/tools/cli">Angular CLI</a>.
       </p>
     ),
     code: {

--- a/src/pages/docs/guides/angular.js
+++ b/src/pages/docs/guides/angular.js
@@ -8,7 +8,8 @@ let steps = [
     body: () => (
       <p>
         Start by creating a new Angular project if you don’t have one set up already. The most
-        common approach is to use <a href="https://angular.io/cli">Angular CLI</a>.
+        common approach is to use
+        <a href="https://angular.dev/tools/cli">Angular CLI</a>.
       </p>
     ),
     code: {


### PR DESCRIPTION
## What is the current behavior?

On the page for installing Tailwind in an Angular project, the link to the Angular CLI redirects to an old version of the Angular docs.

``<a href="https://angular.io/cli">Angular CLI</a>``

## What is the new behavior?

Update the link to new Angular docs.

`<a href="https://angular.dev/tools/cli">Angular CLI</a>`