### PR TITLE
docs: Fixing typo of postcss.config.mjs

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -322,7 +322,7 @@ If your project uses PostCSS or you're using a framework like Next.js that suppo
 $ npm install tailwindcss@next @tailwindcss/postcss@next
 ```
 
-Next, add our PostCSS plugin to your `postcss.config.js` file:
+Next, add our PostCSS plugin to your `postcss.config.mjs` file:
 
 ```js {{ filename: 'postcss.config.mjs' }}
   export default {


### PR DESCRIPTION
```diff
- Next, add our PostCSS plugin to your `postcss.config.js` file:
+ Next, add our PostCSS plugin to your `postcss.config.mjs` file:
```

Because the file below is a `.mjs` file with modules