### PR TITLE
Fix: Fixing `@astro/` typo -> `@astrojs`

### DIFF
--- a/src/pages/docs/guides/astro.js
+++ b/src/pages/docs/guides/astro.js
@@ -26,7 +26,7 @@ let steps = [
     body: () => (
       <p>
         Run the <code>astro add</code> command to install both <code>tailwindcss</code> and{' '}
-        <code>@astro/tailwind</code> as well as generate a <code>tailwind.config.cjs</code> file.
+        <code>@astrojs/tailwind</code> as well as generate a <code>tailwind.config.cjs</code> file.
       </p>
     ),
     code: {


### PR DESCRIPTION
The docs [currently state](https://tailwindcss.com/docs/guides/astro) that running `npx astro add tailwind` will add `@astro/tailwind`. This is incorrect, it is actually `@astrojs/tailwind`. See attached screenshot of terminal output.

<img width="832" alt="Screenshot 2024-12-31 at 9 39 52 AM" src="https://github.com/user-attachments/assets/6e2c183f-5b45-4d88-b862-eb2f114878dd" />
