### PR TITLE
Fix copy transition bug

### DIFF
--- a/src/components/ColorPaletteReference.js
+++ b/src/components/ColorPaletteReference.js
@@ -81,8 +81,8 @@ function ColorPalette({ name, value }) {
       <Transition
         show={state === 'copied'}
         enter="transform ease-out duration-200 transition origin-bottom"
-        enterFrom="scale-95 translate-y-0.5 opacity-0"
-        enterTo="scale-100 translate-y-0 opacity-100"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
         leave="transition ease-in duration-100"
         leaveFrom="opacity-100"
         leaveTo="opacity-0"


### PR DESCRIPTION
I fixed a minor bug where the transition was misaligned during the copy functionality on the Customizing Colors page.

- https://tailwindcss.com/docs/customizing-colors

# Before
https://github.com/user-attachments/assets/2641ba97-1c70-4a45-a882-1dc8e7567e88

# After
https://github.com/user-attachments/assets/3a3e62fc-6d39-4b5a-ae3a-4717ef37a3ba

