### PR TITLE
Fix v4 prerelease docs typo

### DIFF
--- a/src/pages/docs/v4-beta.mdx
+++ b/src/pages/docs/v4-beta.mdx
@@ -1767,7 +1767,7 @@ The `rounded` utility will still work for backward compatibility, but `rounded-s
 
 In v3, borders used your configured `gray-200` color by default. We've updated this in v4 to be just `currentColor`, which matches the default behavior of all browsers.
 
-To update your project for this change, make sure anywhere you're using a border color utility anywhere you're using the `border` utility, or add these lines of CSS to your project to preserve the v3 behavior:
+To update your project for this change, make sure you're using a border color utility anywhere you're using the `border` utility, or add these lines of CSS to your project to preserve the v3 behavior:
 
 ```css
   @import "tailwindcss";


### PR DESCRIPTION
Fixes a small typo in the v4 docs related to the default border color change. It currently says:
> To update your project for this change, make sure anywhere you're using a border color utility anywhere you're using the `border` utility, or add these lines of CSS to your project to preserve the v3 behavior:

This is hard to read, and it seems your intention is to inform users migrating to "add a border color utility wherever they use the `border` utility". Changed phrasing:
```diff
- make sure anywhere you’re using a border color utility anywhere you’re using the `border` utility
+ make sure you're using a border color utility anywhere you're using the `border` utility
```

Excited for the v4 launch today! Good luck team!