### PR TITLE
Fix type error in docs

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -519,7 +519,7 @@ module.exports = {
     files: ['./src/**/*.{html,wtf}'],
     extract: {
       wtf: (content) => {
-        return content.match(/[^<>"'`\s]*/g)
+        return content.match(/[^<>"'`\s]*/g) ?? []
       }
     }
   },


### PR DESCRIPTION
content extraction example was not valid according to tailwind's typscript types. The type is:

```ts
type ExtractorFn = (content: string) => string[]
```

which means that this is not allowed:

```ts
extract: {
      wtf: (content) => {
        return content.match(/[^<>"'`\s]*/g)
      }
    }
```

Ie, `ExtractorFn` does not allow null, but `Regexp.prototype.match` is typed as retuning `string[] | null`.