### PR TITLE
Fix random typo in index.mdx

### DIFF
--- a/src/blog/tailwindcss-v4/index.mdx
+++ b/src/blog/tailwindcss-v4/index.mdx
@@ -338,7 +338,7 @@ Even spacing utilities like `px-*`, `mt-*`, `w-*`, `h-*`, and more are now dynam
 
 @layer utilities {
   .mt-8 {
-    margin-top: calc(var(--spacing) * 17);
+    margin-top: calc(var(--spacing) * 8);
   }
   .w-17 {
     width: calc(var(--spacing) * 17);


### PR DESCRIPTION
An example had 17 where it should have 8