### PR TITLE
Fix typo in theme page example

### DIFF
--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -42,8 +42,8 @@ Tailwind also generates regular CSS variables for your theme variables so you ca
 
 ```html
 <!-- [!code filename:HTML] -->
-<!-- [!code word:var(--bg-mint-500)] -->
-<div style="background-color: var(--bg-mint-500)">
+<!-- [!code word:var(--color-mint-500)] -->
+<div style="background-color: var(--color-mint-500)">
   <!-- ... -->
 </div>
 ```


### PR DESCRIPTION
Updated the CSS variable from `var(--bg-mint-500)` to `var(--color-mint-500)` in the div element.