### PR TITLE
fix: updated the margin logical properties example code

### DIFF
--- a/src/docs/margin.mdx
+++ b/src/docs/margin.mdx
@@ -239,26 +239,22 @@ Use `ms-<number>` and `me-<number>` utilities like `ms-4` and `me-8` to set the 
         <p className="text-sm font-medium">Left-to-right</p>
         <div className="relative flex rounded-lg font-mono text-sm leading-6 font-bold text-white">
           <Stripes border className="absolute min-h-full w-full rounded-lg" />
-          <div className="min-h-full w-8" />
-          <div className="relative rounded-lg bg-indigo-500 p-4">ms-8</div>
+          <div className="relative ms-8 rounded-lg bg-indigo-500 p-4">ms-8</div>
         </div>
         <div className="relative mt-4 flex rounded-lg font-mono text-sm leading-6 font-bold text-white">
           <Stripes border className="absolute min-h-full w-full rounded-lg" />
-          <div className="relative rounded-lg bg-indigo-500 p-4">me-8</div>
-          <div className="min-h-full w-8" />
+          <div className="relative me-8 rounded-lg bg-indigo-500 p-4">me-8</div>
         </div>
       </div>
       <div className="flex flex-col items-start gap-y-4" dir="rtl">
         <p className="text-sm font-medium">Right-to-left</p>
         <div className="relative flex rounded-lg font-mono text-sm leading-6 font-bold text-white">
           <Stripes border className="absolute min-h-full w-full rounded-lg" />
-          <div className="relative rounded-lg bg-indigo-500 p-4">ms-8</div>
-          <div className="min-h-full w-8" />
+          <div className="relative ms-8 rounded-lg bg-indigo-500 p-4">ms-8</div>
         </div>
         <div className="relative mt-4 flex rounded-lg font-mono text-sm leading-6 font-bold text-white">
           <Stripes border className="absolute min-h-full w-full rounded-lg" />
-          <div className="min-h-full w-8" />
-          <div className="relative rounded-lg bg-indigo-500 p-4">me-8</div>
+          <div className="relative me-8 rounded-lg bg-indigo-500 p-4">me-8</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Page: [margin - Spacing](https://tailwindcss.com/docs/margin#using-logical-properties)

Fixes the margin logical properties example where it doesn't reflect the difference when `dir="rtl"` is set. The example also utilises the `ms-8` & `me-8` classes.