### PR TITLE
Increase size for search button to improve accessibility on mobile

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -161,7 +161,7 @@ export function Header(props: React.PropsWithChildren) {
           </Link>
         </div>
         <div className="flex items-center gap-2.5 md:hidden">
-          <SearchButton aria-label="Search" className="inline-grid size-7 place-items-center">
+          <SearchButton aria-label="Search" className="inline-grid size-7 place-items-center rounded-md">
             <svg viewBox="0 0 16 16" fill="currentColor" className="size-4">
               <path
                 fillRule="evenodd"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -160,8 +160,8 @@ export function Header(props: React.PropsWithChildren) {
             <GitHubLogo className="size-5 fill-black/40 dark:fill-gray-400" />
           </Link>
         </div>
-        <div className="flex items-center gap-4 md:hidden">
-          <SearchButton aria-label="Search">
+        <div className="flex items-center gap-2.5 md:hidden">
+          <SearchButton aria-label="Search" className="inline-grid size-7 place-items-center">
             <svg viewBox="0 0 16 16" fill="currentColor" className="size-4">
               <path
                 fillRule="evenodd"


### PR DESCRIPTION
Adds the same size for the search button on the header as the menu button next to it.

I searched for other occurrences of `SearchButton` but it's used with it's own padding in all other places, so I didn't change the `SearchButton` component directly.

## Before:
![Screenshot 2025-01-23 at 22 54 18@2x](https://github.com/user-attachments/assets/9fb17d8a-fdc4-413e-90f6-d2b0c221bd7b)
![Screenshot 2025-01-23 at 22 56 11@2x](https://github.com/user-attachments/assets/1c0c35d5-c334-480f-acca-2953d7091529)


## After:
![Screenshot 2025-01-23 at 22 55 32@2x](https://github.com/user-attachments/assets/128522cb-8305-4509-86cc-7eac5921b521)
![Screenshot 2025-01-23 at 22 57 47@2x](https://github.com/user-attachments/assets/14d0db4a-1281-4c61-bf0d-722d0ebb6da4)

