### PR TITLE
Fix bg-linear custom variable typo

### DIFF
--- a/src/docs/background-image.mdx
+++ b/src/docs/background-image.mdx
@@ -34,7 +34,7 @@ export const description = "Utilities for controlling an element's background im
     ["bg-linear-<angle>", "background-image: linear-gradient(<angle> in oklab, var(--tw-gradient-stops));"],
     ["-bg-linear-<angle>", "background-image: linear-gradient(-<angle> in oklab, var(--tw-gradient-stops));"],
     [
-      "bg-linear(<custom-property>)",
+      "bg-linear-(<custom-property>)",
       "background-image: linear-gradient(var(--tw-gradient-stops, var(<custom-property>)));",
     ],
     ["bg-linear-[<value>]", "background-image: linear-gradient(var(--tw-gradient-stops, <value>));"],


### PR DESCRIPTION
Fix a missing hyphen for custom background image linear gradient.