### PR TITLE
show laravel vite plugin import

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
@@ -89,6 +89,7 @@ export let steps: Step[] = [
       lang: "ts",
       code: js`
         import { defineConfig } from 'vite'
+        import laravel from 'laravel-vite-plugin';
         // [!code highlight:2]
         import tailwindcss from '@tailwindcss/vite'
 


### PR DESCRIPTION
to help indicate that both the Laravel AND Tailwind Vite plugins should be installed, and that the Tailwind plugin does not replace the Laravel one.