### PR TITLE
Replace usage of `theme()` to `var()` as recommended by Tailwind v4

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -413,7 +413,7 @@ You probably won't even notice this change (it might even make your project look
 @layer base {
   input::placeholder,
   textarea::placeholder {
-    color: theme(--color-gray-400);
+    color: var(--color-gray-400);
   }
 }
 ```


### PR DESCRIPTION
At the [Using the theme() function](https://tailwindcss.com/docs/upgrade-guide#using-the-theme-function) section docs advice to use `var()` over `theme()`, but there is a part of code where `theme()` is still used