### PR TITLE
Update Header.js in `v2` to mention `v4` (instead of `v3`) 

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -188,7 +188,7 @@ export function Header({ navIsOpen, onNavToggle }) {
                 href="https://tailwindcss.com"
                 className="text-sm text-white font-bold underline sm:hidden"
               >
-                Go to Tailwind CSS v3 &rarr;
+                Go to Tailwind CSS v4 &rarr;
               </a>
             </div>
             <span


### PR DESCRIPTION
Fix link to latest verson in v2 documentation