### PR TITLE
Add missing arbitrary value option to `flex` API table

### DIFF
--- a/src/docs/flex.mdx
+++ b/src/docs/flex.mdx
@@ -14,7 +14,8 @@ export const description = "Utilities for controlling how flex items both grow a
     ["flex-auto", "flex: 1 1 auto;"],
     ["flex-initial", "flex: 0 1 auto;"],
     ["flex-none", "flex: none;"],
-    ["flex-[<value>]", "flex: <value>;"]
+    ["flex-[<value>]", "flex: <value>;"],
+    ["flex-[<custom-property>]", "flex: var(<custom-property>);"]
   ]}
 />
 

--- a/src/docs/flex.mdx
+++ b/src/docs/flex.mdx
@@ -14,6 +14,7 @@ export const description = "Utilities for controlling how flex items both grow a
     ["flex-auto", "flex: 1 1 auto;"],
     ["flex-initial", "flex: 0 1 auto;"],
     ["flex-none", "flex: none;"],
+    ["flex-[<value>]", "flex: <value>;"]
   ]}
 />
 


### PR DESCRIPTION
The arbitrary value is discussed further down the page but missing in the API table.