### PR TITLE
Update @tailwind/cli installation guide to include config loading

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
@@ -44,6 +44,20 @@ const steps: Step[] = [
     },
   },
   {
+    title: "Import Tailwind config in your CSS",
+    body: (
+      <p>
+        Add the <code>@config "../tailwind.config.js</code> to your main CSS file to load your tailwind config. The path
+        to the config is relative from your main CSS file.
+      </p>
+    ),
+    code: {
+      name: "src/input.css",
+      lang: "css",
+      code: '@config "../tailwind.config.js";',
+    },
+  },
+  {
     title: "Start the Tailwind CLI build process",
     body: <p>Run the CLI tool to scan your source files for classes and build your CSS.</p>,
     code: {


### PR DESCRIPTION
Updated the installation docs since you need to explicitly define the config location now. I believe the old version just loaded the config automatically.

Example of loading from tests:
https://github.com/tailwindlabs/tailwindcss/blob/7e20c3b58750f769d9b6e35bf283689c86341b1d/integrations/cli/config.test.ts#L31