### PR TITLE
Fix: typo error in justify-content

### DIFF
--- a/src/docs/justify-content.mdx
+++ b/src/docs/justify-content.mdx
@@ -225,7 +225,7 @@ Use `justify-stretch` to allow content items to fill the available space along t
 
 ```html
 <!-- [!code classes:justify-stretch] -->
-<div class="grid grid-flow-col ...">
+<div class="flex justify-stretch ...">
   <div>01</div>
   <div>02</div>
   <div>03</div>


### PR DESCRIPTION
Fix issue [#2009 ](https://github.com/tailwindlabs/tailwindcss.com/issues/2009)