### PR TITLE
Fix page description for "Detecting classes in source files"

### DIFF
--- a/src/docs/detecting-classes-in-source-files.mdx
+++ b/src/docs/detecting-classes-in-source-files.mdx
@@ -4,7 +4,7 @@ import { Example } from "@/components/example";
 import { Figure } from "@/components/figure";
 
 export const title = "Detecting classes in source files";
-export const description = "Using variants to style your site in dark mode.";
+export const description = "Understanding and customizing how Tailwind scans your source files.";
 
 ## Overview
 


### PR DESCRIPTION
It looks like this page description was copypasted from [the dark-mode page](https://github.com/tailwindlabs/tailwindcss.com/blob/af7b452ad5ccf09f47961d09420663ebdd606140/src/docs/dark-mode.mdx?plain=1#L7).