### PR TITLE
fix: correct syntax for flex custom properties

### DIFF
--- a/src/docs/flex.mdx
+++ b/src/docs/flex.mdx
@@ -15,7 +15,7 @@ export const description = "Utilities for controlling how flex items both grow a
     ["flex-initial", "flex: 0 1 auto;"],
     ["flex-none", "flex: none;"],
     ["flex-[<value>]", "flex: <value>;"],
-    ["flex-[<custom-property>]", "flex: var(<custom-property>);"],
+    ["flex-(<custom-property>)", "flex: var(<custom-property>);"],
   ]}
 />
 


### PR DESCRIPTION
Replaced flex-[<custom-property>] with flex-(<custom-property>) to align with the intended syntax and ensure consistency across the codebase.
![fix](https://github.com/user-attachments/assets/d200eeaf-4dc3-4524-94cd-9cc37e462c46)
