### PR TITLE
use `tailwindcss@3` in v3 docs

### DIFF
--- a/src/pages/docs/guides/adonisjs.js
+++ b/src/pages/docs/guides/adonisjs.js
@@ -29,7 +29,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/angular.js
+++ b/src/pages/docs/guides/angular.js
@@ -28,7 +28,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init',
     },
   },
   {

--- a/src/pages/docs/guides/create-react-app.js
+++ b/src/pages/docs/guides/create-react-app.js
@@ -31,7 +31,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss@3\nnpx tailwindcss init',
     },
   },
   {

--- a/src/pages/docs/guides/emberjs.js
+++ b/src/pages/docs/guides/emberjs.js
@@ -33,7 +33,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/gatsby.js
+++ b/src/pages/docs/guides/gatsby.js
@@ -33,7 +33,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer gatsby-plugin-postcss\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer gatsby-plugin-postcss\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/laravel.js
+++ b/src/pages/docs/guides/laravel.js
@@ -39,7 +39,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {
@@ -137,7 +137,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init',
         },
       },
       {

--- a/src/pages/docs/guides/meteor.js
+++ b/src/pages/docs/guides/meteor.js
@@ -28,7 +28,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/nextjs.js
+++ b/src/pages/docs/guides/nextjs.js
@@ -29,7 +29,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/nuxtjs.js
+++ b/src/pages/docs/guides/nuxtjs.js
@@ -38,7 +38,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init',
         },
       },
       {

--- a/src/pages/docs/guides/parcel.js
+++ b/src/pages/docs/guides/parcel.js
@@ -29,7 +29,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss@3 postcss\nnpx tailwindcss init',
     },
   },
   {

--- a/src/pages/docs/guides/qwik.js
+++ b/src/pages/docs/guides/qwik.js
@@ -28,7 +28,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/remix.js
+++ b/src/pages/docs/guides/remix.js
@@ -28,7 +28,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init --ts -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init --ts -p',
     },
   },
   {

--- a/src/pages/docs/guides/rspack.js
+++ b/src/pages/docs/guides/rspack.js
@@ -38,7 +38,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {
@@ -167,7 +167,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {

--- a/src/pages/docs/guides/solidjs.js
+++ b/src/pages/docs/guides/solidjs.js
@@ -29,7 +29,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/sveltekit.js
+++ b/src/pages/docs/guides/sveltekit.js
@@ -32,7 +32,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/symfony.js
+++ b/src/pages/docs/guides/symfony.js
@@ -44,7 +44,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
+      code: 'npm install -D tailwindcss@3 postcss postcss-loader autoprefixer\nnpx tailwindcss init -p',
     },
   },
   {

--- a/src/pages/docs/guides/vite.js
+++ b/src/pages/docs/guides/vite.js
@@ -35,7 +35,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {
@@ -139,7 +139,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {
@@ -238,7 +238,7 @@ let tabs = [
         code: {
           name: 'Terminal',
           lang: 'terminal',
-          code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init -p',
+          code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init -p',
         },
       },
       {

--- a/src/pages/docs/installation/index.js
+++ b/src/pages/docs/installation/index.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss@3\nnpx tailwindcss init',
     },
   },
   {

--- a/src/pages/docs/installation/using-postcss.js
+++ b/src/pages/docs/installation/using-postcss.js
@@ -15,7 +15,7 @@ let steps = [
     code: {
       name: 'Terminal',
       lang: 'terminal',
-      code: 'npm install -D tailwindcss postcss autoprefixer\nnpx tailwindcss init',
+      code: 'npm install -D tailwindcss@3 postcss autoprefixer\nnpx tailwindcss init',
     },
   },
   {


### PR DESCRIPTION
This PR uses `tailwindcss@3` in the installation instructions. 

Fixes: #2018
