### PR TITLE
Document the `important` option

### DIFF
--- a/src/docs/styling-with-utility-classes.mdx
+++ b/src/docs/styling-with-utility-classes.mdx
@@ -945,7 +945,8 @@ When you really need to force a specific utility class to take effect and have n
 ```html
 <!-- [!code filename:HTML] -->
 <!-- [!code classes:bg-red-500!] -->
-<div class="bg-blue-500 bg-red-500!">
+<!-- prettier-ignore -->
+<div class="bg-teal-500 bg-red-500!">
   <!-- ... -->
 </div>
 ```
@@ -953,11 +954,11 @@ When you really need to force a specific utility class to take effect and have n
 ```css
 /* [!code filename: Generated CSS] */
 /* [!code word:!important] */
-.bg-blue-500 {
-  background-color: var(--color-blue-500);
-}
 .bg-red-500\! {
   background-color: var(--color-red-500) !important;
+}
+.bg-teal-500 {
+  background-color: var(--color-teal-500);
 }
 ```
 

--- a/src/docs/styling-with-utility-classes.mdx
+++ b/src/docs/styling-with-utility-classes.mdx
@@ -894,3 +894,101 @@ Here's what a `btn-primary` class might look like, using [theme variables](/docs
 </Figure>
 
 Again though, for anything that's more complicated than just a single HTML element, we highly recommend using template partials so the styles and structure can be encapsulated in one place.
+
+## Managing style conflicts
+
+{/* All of the styles in Tailwind have fairly low specificity which can lead to style conflicts */}
+
+### Conflicting utility classes
+
+When you add two classes that target the same CSS property, the class that appears later in the stylesheet wins. So in this example, the element will receive `display: grid` even though `flex` comes last in the actual `class` attribute:
+
+<CodeExampleStack>
+
+```html
+<!-- [!code filename:HTML] -->
+<!-- prettier-ignore -->
+<div class="grid flex">
+  <!-- ... -->
+</div>
+```
+
+```css
+/* [!code filename: CSS] */
+.flex {
+  display: flex;
+}
+.grid {
+  display: grid;
+}
+```
+
+</CodeExampleStack>
+
+In general, you should just never add two conflicting classes to the same element — only ever add the one you actually want to take effect:
+
+```jsx
+// [!code word:gridLayout\ \?\ \"grid\"\ \:\ \"flex\"]
+function Example({ gridLayout }) {
+  return <div className={gridLayout ? "grid" : "flex"}>{/* ... */}</div>;
+}
+```
+
+Using component-based libraries like React or Vue, this often means exposing specific props for styling customizations instead of letting consumers add extra classes from outside of a component, since those styles will often conflict.
+
+### Using the important modifier
+
+When you really need to force a specific utility class to take effect and have no other means of managing the specificity, you can add `!` to the end of the class name to make all of the declarations `!important`:
+
+<CodeExampleStack>
+
+```html
+<!-- [!code filename:HTML] -->
+<!-- [!code classes:bg-red-500!] -->
+<div class="bg-blue-500 bg-red-500!">
+  <!-- ... -->
+</div>
+```
+
+```css
+/* [!code filename: Generated CSS] */
+/* [!code word:!important] */
+.bg-blue-500 {
+  background-color: var(--color-blue-500);
+}
+.bg-red-500\! {
+  background-color: var(--color-red-500) !important;
+}
+```
+
+</CodeExampleStack>
+
+### Using the important flag
+
+If you're adding Tailwind to a project that has existing complex CSS with high specificity rules, you can use the `important` flag when importing Tailwind to mark _all_ utilities as `!important`:
+
+<CodeExampleStack>
+
+```css
+/* [!code filename:app.css] */
+/* [!code word:important] */
+@import "tailwindcss" important;
+```
+
+```css
+/* [!code filename:Compiled CSS] */
+/* [!code word:!important] */
+@layer utilities {
+  .flex {
+    display: flex !important;
+  }
+  .gap-4 {
+    gap: 1rem !important;
+  }
+  .underline {
+    text-decoration-line: underline !important;
+  }
+}
+```
+
+</CodeExampleStack>

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -531,39 +531,6 @@ Then you can use `@import` to include your theme variables in other projects:
 
 You can put shared theme variables like this in their own package in monorepo setups or even publish them to NPM and import them just like any other third-party CSS files.
 
-### Important
-
-The `important` option can be used to make all utilities have a 
-
-To generate utilities as `!important`, set the important option on the Tailwind
-CSS import:
-
-```css
-/* [!code filename:app.css] */
-/* [!code word:important] */
-@import "tailwindcss" important;
-```
-
-To generate individual utilities as `!important`, use the `!` syntax at the end of a utility class:
-
-<CodeExampleStack>
-
-```html
-<!-- [!code filename:index.html] -->
-<!-- [!code word:!] -->
-<div class="bg-red-500!"></div>
-```
-
-```css
-/* [!code filename: Generated CSS] */
-/* [!code word:!important] */
-.bg-red-500\! {
-  background-color: var(--color-red-500) !important;
-}
-```
-
-</CodeExampleStack>
-
 ## Using your theme variables
 
 All of your theme variables are turned into regular CSS variables when you compile your CSS:

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -1,3 +1,4 @@
+import { CodeExampleStack } from "@/components/code-example";
 import { TipGood, TipBad, TipInfo } from "@/components/tips";
 import { Iframe } from "@/components/iframe";
 import { Example } from "@/components/example";
@@ -529,6 +530,39 @@ Then you can use `@import` to include your theme variables in other projects:
 ```
 
 You can put shared theme variables like this in their own package in monorepo setups or even publish them to NPM and import them just like any other third-party CSS files.
+
+### Important
+
+The `important` option can be used to make all utilities have a 
+
+To generate utilities as `!important`, set the important option on the Tailwind
+CSS import:
+
+```css
+/* [!code filename:app.css] */
+/* [!code word:important] */
+@import "tailwindcss" important;
+```
+
+To generate individual utilities as `!important`, use the `!` syntax at the end of a utility class:
+
+<CodeExampleStack>
+
+```html
+<!-- [!code filename:index.html] -->
+<!-- [!code word:!] -->
+<div class="bg-red-500!"></div>
+```
+
+```css
+/* [!code filename: Generated CSS] */
+/* [!code word:!important] */
+.bg-red-500\! {
+  background-color: var(--color-red-500) !important;
+}
+```
+
+</CodeExampleStack>
 
 ## Using your theme variables
 


### PR DESCRIPTION
This PR adds documentation for the `important` option on the `@import "tailwindcss";` at-rule.

Remaining questions:

- [ ] Is this the correct spot to document this? (We redirect `/docs/configuration` to `/docs/theme`, so not 100% sure)
- [ ] Should we document a solution for the `#app` selector strategy that is mentioned in the v3 docs?

Fixes: https://github.com/tailwindlabs/tailwindcss.com/issues/2028
