### PR TITLE
Fix `padding` documentation

### DIFF
--- a/src/docs/padding.mdx
+++ b/src/docs/padding.mdx
@@ -22,7 +22,7 @@ export const description = "Utilities for controlling an element's padding.";
     ["pl", "padding-left"],
   ].flatMap(([prefix, property]) => [
     [`${prefix}-<number>`, `${property}: calc(var(--spacing) * <number>);`],
-    [`${prefix}-px`, `${property}: calc(var(--spacing) * 1px);`],
+    [`${prefix}-px`, `${property}: 1px;`],
     [`${prefix}-(<custom-property>)`, `${property}: var(<custom-property>);`],
     [`${prefix}-[<value>]`, `${property}: <value>;`],
   ])}


### PR DESCRIPTION
The `padding` docs say that e.g. `p-px` translates to `padding: calc(var(--spacing) * 1px);` which is not true.

As with the `margin` utilities, `p-px` translates to `padding: 1px;`.