### PR TITLE
Update font-weight.mdx

### DIFF
--- a/src/docs/font-weight.mdx
+++ b/src/docs/font-weight.mdx
@@ -88,4 +88,4 @@ Use utilities like `font-thin` and `font-bold` to set the font weight of an elem
 
 ## Customizing your theme
 
-<CustomizingYourTheme utility="font" name="font weight" customValue="1000" customName="extrablack" />
+<CustomizingYourTheme utility="font-weight" name="font weight" customValue="1000" customName="extrablack" />

--- a/src/docs/font-weight.mdx
+++ b/src/docs/font-weight.mdx
@@ -88,4 +88,4 @@ Use utilities like `font-thin` and `font-bold` to set the font weight of an elem
 
 ## Customizing your theme
 
-<CustomizingYourTheme utility="font-weight" name="font weight" customValue="1000" customName="extrablack" />
+<CustomizingYourTheme utility="font" themeKey="font-weight" name="font weight" customValue="1000" customName="extrablack" />


### PR DESCRIPTION
The documentation says to use the `--font-*` theme variables to customize the font weight utilities in your project:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/523330ea-f98d-4694-8fdb-ee0454211008" />

But for `---font-800: 800` that actually creates a `font-family: 800` rule instead of the intended `font-weight: 800` one.

The "Theme variables namespace" is mentioning the correct `--font-weight-*` one: https://tailwindcss.com/docs/theme#theme-variable-namespaces
