### PR TITLE
Fix `adding-custom-styles` documentation

### DIFF
--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -482,10 +482,10 @@ Modifiers are handled using the `--modifier()` function which works exactly like
 /* [!code filename:CSS] */
 @utility text-* {
   /* prettier-ignore */
-  font-size: --value(--font-size-*, [length]);
+  font-size: --value(--text-*, [length]);
   /* [!code highlight:2] */
   /* prettier-ignore */
-  line-height: --modifier(--line-height-*, [length], [*]);
+  line-height: --modifier(--leading-*, [length], [*]);
 }
 ```
 


### PR DESCRIPTION
Correct CSS variable names in modifiers example

- Changed `--font-size-*` to `--text-*`
- Changed `--line-height-*` to `--leading-*`

https://tailwindcss.com/docs/adding-custom-styles#modifiers