### PR TITLE
Fix incorrect custom key in columns.mdx

### DIFF
--- a/src/docs/columns.mdx
+++ b/src/docs/columns.mdx
@@ -303,7 +303,7 @@ Learn more about the gap utilities in the [gap documentation](/docs/gap).
 
 <CustomizingYourTheme
   utility="columns"
-  themeKey="container"
+  themeKey="columns"
   name="fixed-width column"
   customName="4xs"
   customValue="14rem"


### PR DESCRIPTION
The page incorrectly references the container key on the columns page.