### PR TITLE
doc: add migration steps

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -62,6 +62,8 @@ export default defineConfig({
 });
 ```
 
+Migrating from PostCSS is as simple as removing the postcss.config.js file and removing the autoprefixer and postcss packages.
+
 ### Using Tailwind CLI
 
 In v4, Tailwind CLI lives in a dedicated `@tailwindcss/cli` package. Update any of your build commands to use the new package instead:


### PR DESCRIPTION
it was not clear to me that the migration tool would not perform this migration. The docs make it sounds like the choice is to use the migration tool or perform these manual steps. But even after running the migration tool, these steps are still recommended.