### PR TITLE
Document font-family example using Google Fonts

### DIFF
--- a/src/docs/font-family.mdx
+++ b/src/docs/font-family.mdx
@@ -103,4 +103,16 @@ If needed, use the [@font-face](https://developer.mozilla.org/en-US/docs/Web/CSS
 }
 ```
 
+If you want to use Google Fonts, you can use an import at the top of your CSS
+file:
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap'); /* [!code highlight] */
+@import "tailwindcss";
+
+@theme {
+  --font-roboto: 'Roboto', sans-serif; /* [!code highlight] */
+}
+```
+
 </CustomizingYourTheme>

--- a/src/docs/font-family.mdx
+++ b/src/docs/font-family.mdx
@@ -103,8 +103,7 @@ If needed, use the [@font-face](https://developer.mozilla.org/en-US/docs/Web/CSS
 }
 ```
 
-If you want to use Google Fonts, you can use an import at the top of your CSS
-file:
+If you're loading a font from a service like [Google Fonts](https://fonts.google.com/), make sure to put the `@import` at the very top of your CSS file:
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap'); /* [!code highlight] */
@@ -114,5 +113,7 @@ file:
   --font-roboto: 'Roboto', sans-serif; /* [!code highlight] */
 }
 ```
+
+Browsers require that `@import` statements come before any other rules, so URL imports need to be above imports like `@import "tailwindcss"` which are inlined in the compiled CSS.
 
 </CustomizingYourTheme>


### PR DESCRIPTION
This PR adds an example for the `font-family` utilities using Google Fonts.

The main reason for this example is just to showcase that you have to put the `@import url(…)` at the top of the file (above the `@import "tailwindcss";`). Not sure if documentation by example in this scenario is _enough_.

We could also document this behavior in another spot, but I think an example like this is more helpful.

If we want to document it somewhere else, we could put it on this page: https://tailwindcss.com/docs/styling-with-utility-classes
