### PR TITLE
Update Phoenix framework guide

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/phoenix.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/phoenix.tsx
@@ -72,6 +72,7 @@ export let steps: Step[] = [
               --input=assets/css/app.css
               --output=priv/static/assets/app.css
             ),
+            # [!code highlight:2]
             cd: Path.expand("..", __DIR__)
           ]
       `,

--- a/src/app/(docs)/docs/installation/framework-guides/phoenix.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/phoenix.tsx
@@ -45,7 +45,7 @@ export let steps: Step[] = [
           [
             # …
             # [!code highlight:2]
-            {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},
+            {:tailwind, "~> 0.3", runtime: Mix.env() == :dev},
           ]
         end
       `,
@@ -69,10 +69,10 @@ export let steps: Step[] = [
           myproject: [
             args: ~w(
               # [!code highlight:3]
-              --input=css/app.css
-              --output=../priv/static/assets/app.css
+              --input=assets/css/app.css
+              --output=priv/static/assets/app.css
             ),
-            cd: Path.expand("../assets", __DIR__)
+            cd: Path.expand("..", __DIR__)
           ]
       `,
     },
@@ -137,15 +137,14 @@ export let steps: Step[] = [
     title: "Import Tailwind CSS",
     body: (
       <p>
-        Add an <code>@import</code> to <code>./assets/css/app.css</code> that imports Tailwind CSS. Additionally, tell
-        Tailwind CSS where to scan for utilities.
+        Add an <code>@import</code> to <code>./assets/css/app.css</code> that imports Tailwind CSS.
       </p>
     ),
     code: {
       name: "app.css",
       lang: "css",
       code: css`
-        @import "tailwindcss" source("../..");
+        @import "tailwindcss";
       `,
     },
   },


### PR DESCRIPTION
Hey! I updated the Phoenix Framework installation instructions:
- Bump the `tailwind` plugin version to 0.3, as previous versions do not support Tailwind v4
- Changed paths so you no longer need to tell Tailwind CSS where to look for utilities

The installation instructions are now consistent with the instructions from the plugin README: https://github.com/phoenixframework/tailwind