### PR TITLE
`background-size` arbitrary value type hint

### DIFF
--- a/src/components/content.tsx
+++ b/src/components/content.tsx
@@ -51,6 +51,7 @@ export function UsingACustomValue({
   value,
   variable,
   dataType,
+  valueDataType,
   element = "div",
   elementAttributes = {},
   children,
@@ -61,6 +62,7 @@ export function UsingACustomValue({
   value?: string;
   variable?: string;
   dataType?: string;
+  valueDataType?: string;
   element?: string;
   elementAttributes?: Record<string, string>;
   children?: React.ReactNode;
@@ -72,6 +74,7 @@ export function UsingACustomValue({
   }
 
   utility = utility || utilities![0];
+  let arbitraryTypeHint = valueDataType ? `${valueDataType}:` : null;
 
   return (
     <>
@@ -83,7 +86,7 @@ export function UsingACustomValue({
               <Fragment key={index}>
                 {utilities.length > 1 && index === utilities.length - 1 ? " and " : ""}
                 <code>
-                  {name}-[<var>{"<value>"}</var>]
+                  {name}-[{arbitraryTypeHint}<var>{"<value>"}</var>]
                 </code>
                 {index === utilities.length - 1 || utilities.length < 3 ? "" : ","}
               </Fragment>
@@ -93,7 +96,7 @@ export function UsingACustomValue({
           <>
             Use the{" "}
             <code>
-              {utility}-[<var>{"<value>"}</var>]
+              {utility}-[{arbitraryTypeHint}<var>{"<value>"}</var>]
             </code>{" "}
             syntax
           </>
@@ -109,10 +112,10 @@ export function UsingACustomValue({
                 code: htmlSnippet({
                   elementName: element,
                   attributes: {
-                    class: `${utility}-[${value}] ...`,
+                    class: `${utility}-[${arbitraryTypeHint}${value}] ...`,
                     ...elementAttributes,
                   },
-                  featuredClass: `${utility}-[${value}]`,
+                  featuredClass: `${utility}-[${arbitraryTypeHint}${value}]`,
                 }),
               }}
             />

--- a/src/docs/background-size.mdx
+++ b/src/docs/background-size.mdx
@@ -13,7 +13,7 @@ export const description = "Utilities for controlling the background size of an 
     ["bg-cover", "background-size: cover;"],
     ["bg-contain", "background-size: contain;"],
     ["bg-(length:<custom-property>)", "background-size: var(<custom-property>);"],
-    ["bg-[<value>]", "background-size: <value>;"],
+    ["bg-[length:<value>]", "background-size: <value>;"],
   ]}
 />
 
@@ -93,7 +93,7 @@ Use the `bg-auto` utility to display the background image at its default size:
 
 ### Using a custom value
 
-<UsingACustomValue utility="bg" value="200px_100px" name="background image size" variable="image-size" />
+<UsingACustomValue utility="bg" value="200px_100px" name="background image size" variable="image-size" dataType="length" valueDataType="length" />
 
 ### Responsive design
 


### PR DESCRIPTION
The example would emit `background-position` instead of `background-size`. Although the type-hint would not be needed if you used `auto` as one of the two values, I've added the type-hint unilaterally to keep things simple.

| Before | After |
| --- | --- |
|  ![image](https://github.com/user-attachments/assets/123e4cc6-a6c5-45cc-a38b-bea88cf02b28) |  ![image](https://github.com/user-attachments/assets/dc94e80d-0968-48c5-ba0d-42f7ace85769) |
| ![image](https://github.com/user-attachments/assets/0c6d23e3-79d1-4178-8e54-a858b0fa894c) |  ![image](https://github.com/user-attachments/assets/980c218a-4ceb-4f1f-bca1-bfcdbbee5097) | 

Instigated by https://github.com/tailwindlabs/tailwindcss/issues/15880#issuecomment-2635917784