### PR TITLE
Fix `create astro` link

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/astro.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/astro.tsx
@@ -20,7 +20,7 @@ export let steps: Step[] = [
     body: (
       <p>
         Start by creating a new Astro project if you don't have one set up already. The most common approach is to use{" "}
-        <a href="https://docs.astro.build/en/getting-started/#start-your-first-project">create astro</a>.
+        <a href="https://docs.astro.build/en/install-and-setup/#install-from-the-cli-wizard">create astro</a>.
       </p>
     ),
     code: {


### PR DESCRIPTION
The first step of the [Astro framework guide](https://tailwindcss.com/docs/installation/framework-guides/astro) links to the Astro documentation for `create astro` using a link to the docs landing page and an anchor that doesn't exist on this page.

After discussing with the Astro docs team, this PR updates the link to point to https://docs.astro.build/en/install-and-setup/#install-from-the-cli-wizard which is a more appropriate link for the `create astro` command.