### PR TITLE
Fix `show more` link sitting on top of the mobile navbar

### DIFF
--- a/src/components/api-table.tsx
+++ b/src/components/api-table.tsx
@@ -68,7 +68,7 @@ export function ApiTable({ rows }: { rows: [string, string][] }) {
   );
 
   return (
-    <div id="quick-reference" className="not-prose relative scroll-mt-16">
+    <div id="quick-reference" className="not-prose relative isolate scroll-mt-16">
       <div className="w-full overflow-x-auto whitespace-nowrap">
         <table className="grid w-full grid-cols-[auto_auto] border-b border-gray-900/10 dark:border-white/10">
           <thead className="col-span-2 grid grid-cols-subgrid">


### PR DESCRIPTION
This PR fixes an issue where the `show more` link was sitting on top of the
mobile navbar.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7d92d518-a277-42ab-82ad-9dbb1a409500) | ![image](https://github.com/user-attachments/assets/b593cbc9-5025-43cc-8ff0-8fccc4660d75) |