### PR TITLE
Ensure headers are visible on mobile

### DIFF
--- a/src/app/typography.css
+++ b/src/app/typography.css
@@ -89,7 +89,10 @@
   }
 
   :is(h2, h3, h4):where(:not(.not-prose, .not-prose *)) {
-    scroll-margin-top: calc(var(--spacing) * 18);
+    scroll-margin-top: calc(var(--spacing) * 32);
+    @variant lg {
+      scroll-margin-top: calc(var(--spacing) * 18);
+    }
   }
 
   ul:where(:not(.not-prose, .not-prose *)) {


### PR DESCRIPTION
This PR fixes an issue where if you click on a link that goes to a specific header in the current page, then the header you scroll to is not visible on mobile

We already used `scroll-margin-top` on desktop, but we didn't take the second navbar (with breadcrumbs) into account.

If you visit this link: https://tailwindcss.com/docs/scroll-padding#using-logical-properties, then you will see the following:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/20667556-4729-42f1-9bce-8125ea9df9b1) | ![image](https://github.com/user-attachments/assets/08bec67e-06d2-41c0-a06d-a7475fcc147d) |
