### PR TITLE
fix: css link in Vite installation dist -> src

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
@@ -106,7 +106,7 @@ const steps: Step[] = [
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
           <!-- [!code highlight:2] -->
-          <link href="/dist/styles.css" rel="stylesheet">
+          <link href="/src/styles.css" rel="stylesheet">
         </head>
         <body>
           <!-- [!code highlight:4] -->


### PR DESCRIPTION
It should be `src` instead of `dist`

After building with `vite build`, the output in `dist/` might look like:

`<link href="/assets/styles-abc123.css" rel="stylesheet">`

Thanks for the new v4 release, it works like a charm! 🔥