### PR TITLE
Clarify usage of outline utilities in documentation

### DIFF
--- a/src/docs/outline-width.mdx
+++ b/src/docs/outline-width.mdx
@@ -19,7 +19,7 @@ export const description = "Utilities for controlling the width of an element's 
 
 ### Basic example
 
-Use `outline` and `outline-<number>` utilities like `outline-2` and `outline-4` to set the width of an element's outline:
+Use `outline` or `outline-<number>` utilities like `outline-2` and `outline-4` to set the width of an element's outline:
 
 <Figure>
 


### PR DESCRIPTION
This pull request includes a small change to the `src/docs/outline-width.mdx` file. The change modifies the description to clarify the usage of `outline` utilities.

* [`src/docs/outline-width.mdx`](diffhunk://#diff-a7a0467902b75954570708cc09d471f346011c3bce60b92e96aaa0c8b21f56daL22-R22): Changed "and" to "or" in the description to clarify that either `outline` or `outline-<number>` utilities can be used to set the width of an element's outline.