### PR TITLE
[chore]: use install as dev dependencies for cli

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
@@ -27,7 +27,7 @@ const steps: Step[] = [
     code: {
       name: "Terminal",
       lang: "shell",
-      code: "npm install tailwindcss @tailwindcss/cli",
+      code: "npm install -D tailwindcss @tailwindcss/cli",
     },
   },
   {


### PR DESCRIPTION
Closes #2074 

Very tiny change. As stated in the issue, these don't need to be production dependencies.