### PR TITLE
fix: text in accent-color input's label

### DIFF
--- a/src/docs/accent-color.mdx
+++ b/src/docs/accent-color.mdx
@@ -76,11 +76,11 @@ Use the color opacity modifier to control the opacity of an element's accent col
     <div className="flex flex-wrap justify-center gap-6">
       <label className="flex items-center space-x-2">
         <input type="checkbox" defaultChecked className="accent-purple-500/25" />
-        <div className="text-sm font-semibold text-gray-900 dark:text-gray-200">accent-black/25</div>
+        <div className="text-sm font-semibold text-gray-900 dark:text-gray-200">accent-purple-500/25</div>
       </label>
       <label className="flex items-center space-x-2">
         <input type="checkbox" className="accent-purple-500/75" defaultChecked />
-        <div className="text-sm font-semibold text-gray-900 dark:text-gray-200">accent-black/75</div>
+        <div className="text-sm font-semibold text-gray-900 dark:text-gray-200">accent-purple-500/75</div>
       </label>
     </div>
   }


### PR DESCRIPTION
In the opacity setting of the accent color, the black color that is not in the code in the example is being used.
I modified it to purple just like the example code.
- AS-IS
![as-is](https://github.com/user-attachments/assets/ad26d876-a196-46cf-a7b3-5257a302675e)
- TO-BE
![to-be](https://github.com/user-attachments/assets/9ed06284-4522-4688-9f74-613da60d6613)
