### PR TITLE
Fix version tag for upgrade tool

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -11,7 +11,7 @@ If you'd like to try upgrading a project from v3 to v4, you can use our upgrade 
 
 ```sh
   # [!code filename:Terminal]
-$ npx @tailwindcss/upgrade@latest
+$ npx @tailwindcss/upgrade
 ```
 
 For most projects, the upgrade tool will automate the entire migration process including updating your dependencies, migrating your configuration file to CSS, and handling any changes to your template files.

--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -11,7 +11,7 @@ If you'd like to try upgrading a project from v3 to v4, you can use our upgrade 
 
 ```sh
   # [!code filename:Terminal]
-$ npx @tailwindcss/upgrade@next
+$ npx @tailwindcss/upgrade@latest
 ```
 
 For most projects, the upgrade tool will automate the entire migration process including updating your dependencies, migrating your configuration file to CSS, and handling any changes to your template files.


### PR DESCRIPTION
`latest` is getting new versions, while `next` isn't.

https://www.npmjs.com/package/@tailwindcss/upgrade?activeTab=versions