### PR TITLE
Add `lang="postcss"` to SvelteKit guide example

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/sveltekit.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/sveltekit.tsx
@@ -140,7 +140,7 @@ export let steps: Step[] = [
           Hello world!
         </h1>
 
-        <style>
+        <style lang="postcss">
           /* [!code highlight:2] */
           @reference "tailwindcss/theme";
 


### PR DESCRIPTION
This is necessary to silence linter warnings from VSCode’s CSS language server.

Closes https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1147

Without this you'll see this in a Svelte document that uses `<style>` tags and `@reference`:

<img width="565" alt="Screenshot 2025-02-11 at 13 50 24" src="https://github.com/user-attachments/assets/bfd98e4c-924a-412e-8ac2-bdcbd0cb1f06" />

After you'll see the diagnostic is gone:

<img width="524" alt="Screenshot 2025-02-11 at 13 50 30" src="https://github.com/user-attachments/assets/6744f8ea-5144-427e-b052-ee9ee09ec5dd" />
