### PR TITLE
Fix order of Vite plugins in SvelteKit installation guide

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/sveltekit.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/sveltekit.tsx
@@ -63,9 +63,9 @@ export let steps: Step[] = [
 
         export default defineConfig({
           plugins: [
+            sveltekit(),
             // [!code highlight:2]
             tailwindcss(),
-            sveltekit(),
           ],
         });
       `,


### PR DESCRIPTION
The order of Vite plugins matter, as they are run sequentially.
I encountered an issue where classes applied conditionally with the [class: directive](https://svelte.dev/docs/svelte/class#The-class:-directive) would not work unless the `tailwindcss` plugin was run after the `sveltekit` plugin.
This PR reorders the plugins array to correct this behavior.