### PR TITLE
Fix object-none example in docs

### DIFF
--- a/src/docs/object-fit.mdx
+++ b/src/docs/object-fit.mdx
@@ -122,7 +122,7 @@ Use the `object-none` utility to display an element's content at its original si
 <Example>
   {
     <img
-      className="mx-auto h-48 w-96 rounded-lg"
+      className="mx-auto h-48 w-96 rounded-lg object-none"
       src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
     />
   }


### PR DESCRIPTION
The doc about the `object-fit` property seems to display a wrong example of the `object-none` class.

The example image seems to be stretched instead of being displayed at its original size.

# Example

![Screenshot 2025-02-15 at 00 03 39](https://github.com/user-attachments/assets/4aaf52d3-ee3b-434f-8468-536ab1a79c6b)

# Original image
![Screenshot 2025-02-15 at 00 04 00](https://github.com/user-attachments/assets/c615b8fe-d167-418e-9bbb-0238c8f8941b)
