### PR TITLE
Fix #2091: Correct URL syntax in background-repeat docs

### DIFF
--- a/src/docs/background-repeat.mdx
+++ b/src/docs/background-repeat.mdx
@@ -31,7 +31,7 @@ Use the `bg-repeat` utility to repeat the background image both vertically and h
 
 ```html
 <!-- [!code classes:bg-repeat] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-repeat ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-repeat ..."></div>
 ```
 
 </Figure>
@@ -48,7 +48,7 @@ Use the `bg-repeat-x` utility to only repeat the background image horizontally:
 
 ```html
 <!-- [!code classes:bg-repeat-x] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-repeat-x ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-repeat-x ..."></div>
 ```
 
 </Figure>
@@ -65,7 +65,7 @@ Use the `bg-repeat-y` utility to only repeat the background image vertically:
 
 ```html
 <!-- [!code classes:bg-repeat-y] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-repeat-y ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-repeat-y ..."></div>
 ```
 
 </Figure>
@@ -82,7 +82,7 @@ Use the `bg-repeat-space` utility to repeat the background image without clippin
 
 ```html
 <!-- [!code classes:bg-repeat-space] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-repeat-space ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-repeat-space ..."></div>
 ```
 
 </Figure>
@@ -99,7 +99,7 @@ Use the `bg-repeat-round` utility to repeat the background image without clippin
 
 ```html
 <!-- [!code classes:bg-repeat-round] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-repeat-round ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-repeat-round ..."></div>
 ```
 
 </Figure>
@@ -116,7 +116,7 @@ Use the `bg-no-repeat` utility to prevent a background image from repeating:
 
 ```html
 <!-- [!code classes:bg-no-repeat] -->
-<div class="bg-[url(/img/clouds.svg')] bg-center bg-no-repeat ..."></div>
+<div class="bg-[url(/img/clouds.svg)] bg-center bg-no-repeat ..."></div>
 ```
 
 </Figure>


### PR DESCRIPTION
Fixes #2091 
### Summary
- Fixed incorrect URL syntax in `bg-[url()]` by ensuring proper closing of quotes.

### Changes
- Updated `bg-[url(/img/clouds.svg')]` → `bg-[url(/img/clouds.svg)]`
