### PR TITLE
fix(docs): install tailwind as a dev dependency

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
@@ -28,7 +28,7 @@ const steps: Step[] = [
       name: "Terminal",
       lang: "shell",
       code: dedent`
-        npm install tailwindcss @tailwindcss/vite
+        npm install tailwindcss @tailwindcss/vite --save-dev
       `,
     },
   },


### PR DESCRIPTION
On v4 vite plugin docs doesn't include --save-dev command during install, is this a mistake or a breaking change from v3 to v4? 

Is tailwind a runtime dependency now?

If not, I changed the docs of vite plugin install page to include --save-dev command

<img width="1011" alt="Screenshot 2025-02-16 at 16 21 07" src="https://github.com/user-attachments/assets/208be2bb-6010-48aa-b6f7-18458fd927f1" />
