### PR TITLE
Fix preflight stylesheet link

### DIFF
--- a/src/docs/preflight.mdx
+++ b/src/docs/preflight.mdx
@@ -19,7 +19,7 @@ When you import `tailwindcss` into your project, Preflight is automatically inje
 
 While most of the styles in Preflight are meant to go unnoticed—they simply make things behave more like you'd expect them to—some are more opinionated and can be surprising when you first encounter them.
 
-For a complete reference of all the styles applied by Preflight, [see the stylesheet](https://github.com/tailwindlabs/tailwindcss/blob/next/packages/tailwindcss/preflight.css).
+For a complete reference of all the styles applied by Preflight, [see the stylesheet](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css).
 
 ### Margins are removed
 


### PR DESCRIPTION
Changed the Preflight stylesheet link to the correct branch on GitHub.

Not sure if you want to keep the link pointed to GitHub, or use [a link to unpkg](https://unpkg.com/tailwindcss@^4/preflight.css) like the [v3 docs](https://v3.tailwindcss.com/docs/preflight) did.