### PR TITLE
Add missing type hints in usage examples

### DIFF
--- a/src/docs/background-position.mdx
+++ b/src/docs/background-position.mdx
@@ -164,7 +164,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-left-top` to control the pos
 
 ### Using a custom value
 
-<UsingACustomValue utility="bg" value="center_top_1rem" name="background position" variable="bg-position" />
+<UsingACustomValue utility="bg" value="center_top_1rem" name="background position" variable="bg-position" dataType="position"/>
 
 ### Responsive design
 

--- a/src/docs/font-family.mdx
+++ b/src/docs/font-family.mdx
@@ -66,7 +66,7 @@ Use utilities like `font-sans` and `font-mono` to set the font family of an elem
 
 ### Using a custom value
 
-<UsingACustomValue utility="font" name="font family" value="Open_Sans" element="p" />
+<UsingACustomValue utility="font" name="font family" value="Open_Sans" element="p" dataType="family-name"/>
 
 ### Responsive design
 


### PR DESCRIPTION
Some *Using a custom value* sections are missing type hints for CSS variable usage examples. This PR adds them in.