### PR TITLE
Fix missing color: on doc example

### DIFF
--- a/src/docs/colors.mdx
+++ b/src/docs/colors.mdx
@@ -461,7 +461,7 @@ Colors are exposed as CSS variables in the `--color-*` namespace, so you can ref
     a {
       color: var(--color-blue-500);
       &:hover {
-        var(--color-blue-800);
+        color: var(--color-blue-800);
       }
     }
   }


### PR DESCRIPTION
Fixed a missing `color:` on a `&:hover` example in: https://tailwindcss.com/docs/colors#referencing-in-css