### PR TITLE
add overflow auto to fix show more expand list

### DIFF
--- a/src/app/(docs)/layout.tsx
+++ b/src/app/(docs)/layout.tsx
@@ -18,7 +18,7 @@ export default async function Layout({
           <DocsSidebar />
         </MobileNav>
       </div>
-      <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] pt-26.25 lg:grid-cols-[var(--container-2xs)_2.5rem_minmax(0,1fr)_2.5rem] lg:pt-14.25 xl:grid-cols-[var(--container-2xs)_2.5rem_minmax(0,1fr)_2.5rem]">
+      <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] pt-26.25 lg:grid-cols-[var(--container-2xs)_2.5rem_minmax(0,1fr)_2.5rem] lg:pt-14.25 xl:grid-cols-[var(--container-2xs)_2.5rem_minmax(0,1fr)_2.5rem] overflow-y-auto">
         {/* Sidebar */}
         <div className="relative col-start-1 row-span-full row-start-1 max-lg:hidden">
           <div className="absolute inset-0">


### PR DESCRIPTION
add overflow-y-auto to fix show more expand list when it overflow the content over the footer

![image](https://github.com/user-attachments/assets/97ec7612-bfb1-4ab7-8bbe-d51e36c18571)
