### PR TITLE
Fix code copying in Firefox

### DIFF
--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -179,8 +179,7 @@ export function RawHighlightedCode({
             "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word_+_&]:before:rounded-l-none",
         }),
       ],
-    })
-    .replaceAll("\n", "");
+    });
 
   return <div className={className} dangerouslySetInnerHTML={{ __html: code }} />;
 }

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -179,7 +179,13 @@ export function RawHighlightedCode({
             "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word_+_&]:before:rounded-l-none",
         }),
       ],
-    });
+    })
+    // Remove extra newlines from `[!code]` highlighter lines. Actual code empty
+    // lines are wrapped in `<span class="line"></span>` so this won't remove
+    // intentional empty lines.
+    .replaceAll(/\n{2,}/g, "\n")
+    // Remove newline from `[!code]` highlighter line at the start of the code snippet.
+    .replaceAll(/(<code[^>]*>)\n/g, '$1');
 
   return <div className={className} dangerouslySetInnerHTML={{ __html: code }} />;
 }

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -135,7 +135,7 @@ export function HighlightedCode({
       example={example}
       className={clsx(
         "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:overflow-auto *:rounded-lg *:bg-white/10! *:p-5 dark:*:bg-white/5!",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:not-last:min-h-[1lh]",
         "*:inset-ring *:inset-ring-white/10 dark:*:inset-ring-white/5",
         className,
       )}

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -161,13 +161,13 @@ export function RawHighlightedCode({
       theme: theme.name,
       transformers: [
         transformerNotationHighlight({
-          classActiveLine: "-mx-5 inline-block pl-[calc(var(--spacing)*5-2px)] border-l-2 pr-5 border-sky-400 bg-sky-300/15",
+          classActiveLine: "-mx-5 inline-block w-[calc(100%+(var(--spacing)*10))] pl-[calc(var(--spacing)*5-2px)] border-l-2 pr-5 border-sky-400 bg-sky-300/15",
         }),
         transformerNotationDiff({
           classLineAdd:
-            "relative -mx-5 inline-block border-l-4 border-teal-400 bg-teal-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-teal-400 before:content-['+']",
+            "relative -mx-5 inline-block w-[calc(100%+(var(--spacing)*10))] border-l-4 border-teal-400 bg-teal-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-teal-400 before:content-['+']",
           classLineRemove:
-            "relative -mx-5 inline-block border-l-4 border-red-400 bg-red-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-red-400 before:content-['-']",
+            "relative -mx-5 inline-block w-[calc(100%+(var(--spacing)*10))] border-l-4 border-red-400 bg-red-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-red-400 before:content-['-']",
           classActivePre: "[:where(&_.line)]:pl-4",
         }),
         transformerNotationWordHighlight({

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -161,13 +161,13 @@ export function RawHighlightedCode({
       theme: theme.name,
       transformers: [
         transformerNotationHighlight({
-          classActiveLine: "-mx-5 pl-[calc(var(--spacing)*5-2px)] border-l-2 pr-5 border-sky-400 bg-sky-300/15",
+          classActiveLine: "-mx-5 inline-block pl-[calc(var(--spacing)*5-2px)] border-l-2 pr-5 border-sky-400 bg-sky-300/15",
         }),
         transformerNotationDiff({
           classLineAdd:
-            "relative -mx-5 border-l-4 border-teal-400 bg-teal-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-teal-400 before:content-['+']",
+            "relative -mx-5 inline-block border-l-4 border-teal-400 bg-teal-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-teal-400 before:content-['+']",
           classLineRemove:
-            "relative -mx-5 border-l-4 border-red-400 bg-red-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-red-400 before:content-['-']",
+            "relative -mx-5 inline-block border-l-4 border-red-400 bg-red-300/15 pr-5 pl-8 before:absolute before:left-4 before:text-red-400 before:content-['-']",
           classActivePre: "[:where(&_.line)]:pl-4",
         }),
         transformerNotationWordHighlight({


### PR DESCRIPTION
Seems to be related to the text not having newline characters. Testing with v3 docs with `<code>` elements:
```js
$0.textContent.replace('\n','\\n');
```
V3:

```html
<!doctype html>\\n<html>\\n<head>\\n  <meta charset="UTF-8">\\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\\n  <link href="./output.css" rel="stylesheet">\\n</head>\\n<body>\\n  <h1 class="text-3xl font-bold underline">\\n    Hello world!\\n  </h1>\\n</body>\\n</html>\\n'
```
V4
```html
<!doctype html><html><head>  <meta charset="UTF-8">  <meta name="viewport" content="width=device-width, initial-scale=1.0">  <link href="/src/styles.css" rel="stylesheet"></head><body>  <h1 class="text-3xl font-bold underline">    Hello world!  </h1></body></html>'
```

This PR:

- Brings back the newline characters.
- Post-processes the code snippets to remove extra newlines left over from the highlighter transforms.
- Removes the `display: block` on the `.line` elements since we can now rely on the newline characters within the `<pre>` parent element's `white-space: preserve` behavior.

Tested in Firefox and Chrome on Windows for no visual regressions. Please test on Safari as I don't have access to that browser.

Fixes #1972.
