### PR TITLE
Documents `overflow-wrap` utilties

### DIFF
--- a/src/app/(docs)/docs/index.tsx
+++ b/src/app/(docs)/docs/index.tsx
@@ -104,6 +104,7 @@ export default {
     ["vertical-align", "/docs/vertical-align"],
     ["white-space", "/docs/white-space"],
     ["word-break", "/docs/word-break"],
+    ["overflow-wrap", "/docs/overflow-wrap"],
     ["hyphens", "/docs/hyphens"],
     ["content", "/docs/content"],
   ] as const,

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -1,0 +1,99 @@
+import { ApiTable } from "@/components/api-table.tsx";
+import { Example } from "@/components/example.tsx";
+import { Figure } from "@/components/figure.tsx";
+import { ResponsiveDesign } from "@/components/content.tsx";
+
+export const title = "overflow-wrap";
+export const description = "Utilities for controlling line breaks in an overflowing element.";
+
+<ApiTable
+  rows={[
+    ["wrap-normal", "overflow-wrap: normal;"],
+    ["wrap-anywhere", "overflow-wrap: anywhere;"],
+    ["wrap-break-word", "overflow-wrap: break-word;"],
+  ]}
+/>
+
+## Examples
+
+### Normal
+
+Use the `wrap-normal` utility to only allow line breaks at hard wrap opportunities, like spaces and hyphens:
+
+<Figure>
+
+<Example padding={false}>
+  {
+    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 [overflow-wrap:normal] text-gray-900 dark:text-gray-200">
+      The longest word in any of the major English language dictionaries is{" "}
+      <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
+      disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
+      is the same as silicosis.
+    </p>
+  }
+</Example>
+
+```html
+<!-- [!code classes:wrap-normal] -->
+<p class="wrap-normal">The longest word in any of the major...</p>
+```
+
+</Figure>
+
+### Break Word
+
+Use the `wrap-break-word` utility to allow line breaks at soft wrap opportunities, like between letters in a word, if needed:
+
+<Figure>
+
+<Example padding={false}>
+  {
+    <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
+      The longest word in any of the major English language dictionaries is{" "}
+      <span className="font-bold [overflow-wrap:break-word]">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a
+      word that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from
+      a volcano; medically, it is the same as silicosis.
+    </p>
+  }
+</Example>
+
+```html
+<!-- [!code classes:wrap-break-word] -->
+<p class="w-min">
+  The longest word... <span class="wrap-break-word font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+</p>
+```
+
+</Figure>
+
+### Anywhere
+
+Use the `wrap-anywhere` utility to allow line breaks at soft wrap opportunities, like between letters in a word, if needed:
+
+<Figure>
+
+<Example padding={false} className="max-h-96">
+  {
+    <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
+      The longest word in any of the major English language dictionaries is{" "}
+      <span className="font-bold [overflow-wrap:anywhere]">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word
+      that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a
+      volcano; medically, it is the same as silicosis.
+    </p>
+  }
+</Example>
+
+```html
+<!-- [!code classes:wrap-anywhere] -->
+<p class="w-min">
+  The longest word... <span class="wrap-anywhere font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+</p>
+```
+
+</Figure>
+
+Unlike the `wrap-break-word`, `wrap-anywhere` allows the browser to factor in mid-word line breaks when calculating the intrinsic `min-content` size of the element.
+
+### Responsive design
+
+<ResponsiveDesign element="p" property="wrap" defaultClass="normal" featuredClass="break-word" />

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -4,19 +4,19 @@ import { Figure } from "@/components/figure.tsx";
 import { ResponsiveDesign } from "@/components/content.tsx";
 
 export const title = "overflow-wrap";
-export const description = "Utilities for controlling line breaks in an overflowing element.";
+export const description = "Utilities for controlling line breaks within words in an overflowing element.";
 
 <ApiTable
   rows={[
     ["wrap-normal", "overflow-wrap: normal;"],
-    ["wrap-anywhere", "overflow-wrap: anywhere;"],
     ["wrap-break-word", "overflow-wrap: break-word;"],
+    ["wrap-anywhere", "overflow-wrap: anywhere;"],
   ]}
 />
 
 ## Examples
 
-### Normal
+### Wrapping normally
 
 Use the `wrap-normal` utility to only allow line breaks at natural wrapping points, like spaces, hyphens, and punctuation:
 
@@ -40,7 +40,7 @@ Use the `wrap-normal` utility to only allow line breaks at natural wrapping poin
 
 </Figure>
 
-### Break Word
+### Wrapping mid-word
 
 Use the `wrap-break-word` utility to allow line breaks between letters in a word if needed:
 
@@ -60,15 +60,15 @@ Use the `wrap-break-word` utility to allow line breaks between letters in a word
 ```html
 <!-- [!code classes:wrap-break-word] -->
 <p class="w-min">
-  The longest word... <span class="font-bold wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+  The longest word... <span class="wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
 </p>
 ```
 
 </Figure>
 
-### Anywhere
+### Wrapping anywhere
 
-Use the `wrap-anywhere` utility to allow line breaks between letters in a word if needed:
+The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that the browser factors in mid-word line breaks when calculating the intrinsic `min-content` size of the element:
 
 <Figure>
 
@@ -86,14 +86,12 @@ Use the `wrap-anywhere` utility to allow line breaks between letters in a word i
 ```html
 <!-- [!code classes:wrap-anywhere] -->
 <p class="w-min">
-  The longest word... <span class="font-bold wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+  The longest word... <span class="wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
 </p>
 ```
 
 </Figure>
 
-Unlike the `wrap-break-word`, `wrap-anywhere` allows the browser to factor in mid-word line breaks when calculating the intrinsic `min-content` size of the element.
-
 ### Responsive design
 
-<ResponsiveDesign element="p" property="wrap" defaultClass="normal" featuredClass="break-word" />
+<ResponsiveDesign element="p" property="overflow-wrap" defaultClass="wrap-normal" featuredClass="wrap-break-word" />

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -18,7 +18,7 @@ export const description = "Utilities for controlling line breaks in an overflow
 
 ### Normal
 
-Use the `wrap-normal` utility to only allow line breaks at hard wrap opportunities, like spaces and hyphens:
+Use the `wrap-normal` utility to only allow line breaks at natural wrapping points, like spaces, hyphens, and punctuation:
 
 <Figure>
 
@@ -42,7 +42,7 @@ Use the `wrap-normal` utility to only allow line breaks at hard wrap opportuniti
 
 ### Break Word
 
-Use the `wrap-break-word` utility to allow line breaks at soft wrap opportunities, like between letters in a word, if needed:
+Use the `wrap-break-word` utility to allow line breaks between letters in a word if needed:
 
 <Figure>
 
@@ -68,7 +68,7 @@ Use the `wrap-break-word` utility to allow line breaks at soft wrap opportunitie
 
 ### Anywhere
 
-Use the `wrap-anywhere` utility to allow line breaks at soft wrap opportunities, like between letters in a word, if needed:
+Use the `wrap-anywhere` utility to allow line breaks between letters in a word if needed:
 
 <Figure>
 

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -52,25 +52,25 @@ The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that 
 
 <div>
   <p className="mb-3 text-center font-mono text-sm font-medium text-gray-500 dark:text-gray-400">wrap-break-word</p>
-  <div className="mx-auto flex max-w-sm items-center rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
+  <div className="mx-auto flex max-w-sm items-center gap-4 rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
     <img
-      className="size-16 rounded-full ring ring-black/15 dark:ring-white/25"
+      className="size-16 rounded-full outline -outline-offset-1 outline-black/10 dark:outline-white/10"
       src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
       alt=""
     />
-    <div className="ml-4 wrap-break-word">
+    <div className="wrap-break-word">
       <p className="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
       <p className="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
     </div>
   </div>
   <p className="mt-8 mb-3 text-center font-mono text-sm font-medium text-gray-500 dark:text-gray-400">wrap-anywhere</p>
-  <div className="mx-auto flex max-w-sm items-center rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
+  <div className="mx-auto flex max-w-sm items-center gap-4 rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
     <img
-      className="size-16 rounded-full ring ring-black/15 dark:ring-white/25"
+      className="size-16 rounded-full outline -outline-offset-1 outline-black/10 dark:outline-white/10"
       src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
       alt=""
     />
-    <div className="ml-4 wrap-anywhere">
+    <div className="wrap-anywhere">
       <p className="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
       <p className="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
     </div>
@@ -82,18 +82,18 @@ The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that 
 
 ```html
 <!-- [!code classes:wrap-anywhere,wrap-break-word] -->
-<div class="flex max-w-sm py-4">
-  <img class="h-10 w-10 rounded-full" src="/img/profile.jpg" alt="" />
-  <div class="ml-4 wrap-break-word">
-    <p class="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
-    <p class="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+<div class="flex max-w-sm">
+  <img class="size-16 rounded-full" src="/img/profile.jpg" />
+  <div class="wrap-break-word">
+    <p class="font-medium">Jay Riemenschneider</p>
+    <p>jason.riemenschneider@vandelayindustries.com</p>
   </div>
 </div>
-<div class="flex max-w-sm py-4">
-  <img class="h-10 w-10 rounded-full" src="/img/profile.jpg" alt="" />
-  <div class="ml-4 wrap-anywhere">
-    <p class="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
-    <p class="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+<div class="flex max-w-sm">
+  <img class="size-16 rounded-full" src="/img/profile.jpg" />
+  <div class="wrap-anywhere">
+    <p class="font-medium">Jay Riemenschneider</p>
+    <p>jason.riemenschneider@vandelayindustries.com</p>
   </div>
 </div>
 ```

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -8,37 +8,13 @@ export const description = "Utilities for controlling line breaks within words i
 
 <ApiTable
   rows={[
-    ["wrap-normal", "overflow-wrap: normal;"],
     ["wrap-break-word", "overflow-wrap: break-word;"],
     ["wrap-anywhere", "overflow-wrap: anywhere;"],
+    ["wrap-normal", "overflow-wrap: normal;"],
   ]}
 />
 
 ## Examples
-
-### Wrapping normally
-
-Use the `wrap-normal` utility to only allow line breaks at natural wrapping points, like spaces, hyphens, and punctuation:
-
-<Figure>
-
-<Example padding={false}>
-  {
-    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 wrap-normal text-gray-900 dark:text-gray-200">
-      The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
-      disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
-      is the same as silicosis.
-    </p>
-  }
-</Example>
-
-```html
-<!-- [!code classes:wrap-normal] -->
-<p class="wrap-normal">The longest word in any of the major...</p>
-```
-
-</Figure>
 
 ### Wrapping mid-word
 
@@ -125,6 +101,30 @@ The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that 
 </Figure>
 
 This is useful for wrapping text inside of `flex` containers, where you would usually need to set `min-width: 0` on the child element to allow it to shrink below its content size.
+
+### Wrapping normally
+
+Use the `wrap-normal` utility to only allow line breaks at natural wrapping points, like spaces, hyphens, and punctuation:
+
+<Figure>
+
+<Example padding={false}>
+  {
+    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 wrap-normal text-gray-900 dark:text-gray-200">
+      The longest word in any of the major English language dictionaries is{" "}
+      <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
+      disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
+      is the same as silicosis.
+    </p>
+  }
+</Example>
+
+```html
+<!-- [!code classes:wrap-normal] -->
+<p class="wrap-normal">The longest word in any of the major...</p>
+```
+
+</Figure>
 
 ### Responsive design
 

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -48,49 +48,83 @@ Use the `wrap-break-word` utility to allow line breaks between letters in a word
 
 <Example padding={false}>
   {
-    <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
+    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 wrap-break-word text-gray-900 dark:text-gray-200">
       The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that
-      refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a
-      volcano; medically, it is the same as silicosis.
+      <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
+      disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
+      is the same as silicosis.
     </p>
   }
 </Example>
 
 ```html
 <!-- [!code classes:wrap-break-word] -->
-<p class="w-min">
-  The longest word... <span class="wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
-</p>
+<p class="wrap-break-word">The longest word in any of the major...</p>
 ```
 
 </Figure>
 
 ### Wrapping anywhere
 
-The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that the browser factors in mid-word line breaks when calculating the intrinsic `min-content` size of the element:
+The `wrap-anywhere` utility behaves similarly to `wrap-break-word`, except that the browser factors in mid-word line breaks when calculating the intrinsic size of the element:
 
 <Figure>
 
-<Example padding={false} className="max-h-96">
-  {
-    <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
-      The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers
-      to a lung disease contracted from the inhalation of very fine silica particles, specifically from a volcano;
-      medically, it is the same as silicosis.
-    </p>
-  }
+<Example>
+
+{
+
+<div>
+  <p className="mb-3 text-center font-mono text-sm font-medium text-gray-500 dark:text-gray-400">wrap-break-word</p>
+  <div className="mx-auto flex max-w-sm items-center rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
+    <img
+      className="size-16 rounded-full ring ring-black/15 dark:ring-white/25"
+      src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+      alt=""
+    />
+    <div className="ml-4 wrap-break-word">
+      <p className="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+    </div>
+  </div>
+  <p className="mt-8 mb-3 text-center font-mono text-sm font-medium text-gray-500 dark:text-gray-400">wrap-anywhere</p>
+  <div className="mx-auto flex max-w-sm items-center rounded-xl bg-white p-3 shadow-sm ring ring-black/2.5 dark:bg-black/10 dark:ring-white/10">
+    <img
+      className="size-16 rounded-full ring ring-black/15 dark:ring-white/25"
+      src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+      alt=""
+    />
+    <div className="ml-4 wrap-anywhere">
+      <p className="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+    </div>
+  </div>
+</div>
+}
+
 </Example>
 
 ```html
-<!-- [!code classes:wrap-anywhere] -->
-<p class="w-min">
-  The longest word... <span class="wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
-</p>
+<!-- [!code classes:wrap-anywhere,wrap-break-word] -->
+<div class="flex max-w-sm py-4">
+  <img class="h-10 w-10 rounded-full" src="/img/profile.jpg" alt="" />
+  <div class="ml-4 wrap-break-word">
+    <p class="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+  </div>
+</div>
+<div class="flex max-w-sm py-4">
+  <img class="h-10 w-10 rounded-full" src="/img/profile.jpg" alt="" />
+  <div class="ml-4 wrap-anywhere">
+    <p class="text-sm font-medium text-gray-900 dark:text-white">Jay Riemenschneider</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">jason.riemenschneider@vandelayindustries.com</p>
+  </div>
+</div>
 ```
 
 </Figure>
+
+This is useful for wrapping text inside of `flex` containers, where you would usually need to set `min-width: 0` on the child element to allow it to shrink below its content size.
 
 ### Responsive design
 

--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -24,7 +24,7 @@ Use the `wrap-normal` utility to only allow line breaks at natural wrapping poin
 
 <Example padding={false}>
   {
-    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 [overflow-wrap:normal] text-gray-900 dark:text-gray-200">
+    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 wrap-normal text-gray-900 dark:text-gray-200">
       The longest word in any of the major English language dictionaries is{" "}
       <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
       disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
@@ -50,9 +50,9 @@ Use the `wrap-break-word` utility to allow line breaks between letters in a word
   {
     <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
       The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold [overflow-wrap:break-word]">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a
-      word that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from
-      a volcano; medically, it is the same as silicosis.
+      <span className="font-bold wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that
+      refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a
+      volcano; medically, it is the same as silicosis.
     </p>
   }
 </Example>
@@ -60,7 +60,7 @@ Use the `wrap-break-word` utility to allow line breaks between letters in a word
 ```html
 <!-- [!code classes:wrap-break-word] -->
 <p class="w-min">
-  The longest word... <span class="wrap-break-word font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+  The longest word... <span class="font-bold wrap-break-word">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
 </p>
 ```
 
@@ -76,9 +76,9 @@ Use the `wrap-anywhere` utility to allow line breaks between letters in a word i
   {
     <p className="mx-auto w-min max-w-xs border-x border-x-pink-400/30 py-8 text-gray-900 dark:text-gray-200">
       The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold [overflow-wrap:anywhere]">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word
-      that refers to a lung disease contracted from the inhalation of very fine silica particles, specifically from a
-      volcano; medically, it is the same as silicosis.
+      <span className="font-bold wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers
+      to a lung disease contracted from the inhalation of very fine silica particles, specifically from a volcano;
+      medically, it is the same as silicosis.
     </p>
   }
 </Example>
@@ -86,7 +86,7 @@ Use the `wrap-anywhere` utility to allow line breaks between letters in a word i
 ```html
 <!-- [!code classes:wrap-anywhere] -->
 <p class="w-min">
-  The longest word... <span class="wrap-anywhere font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
+  The longest word... <span class="font-bold wrap-anywhere">pneumonoultramicroscopicsilicovolcanoconiosis,</span>
 </p>
 ```
 

--- a/src/docs/word-break.mdx
+++ b/src/docs/word-break.mdx
@@ -8,7 +8,7 @@ export const description = "Utilities for controlling word breaks in an element.
 
 <ApiTable
   rows={[
-    ["break-normal", "overflow-wrap: normal;\nword-break: normal;"],
+    ["break-normal", "word-break: normal;"],
     ["break-all", "word-break: break-all;"],
     ["break-keep", "word-break: keep-all;"],
   ]}

--- a/src/docs/word-break.mdx
+++ b/src/docs/word-break.mdx
@@ -9,7 +9,6 @@ export const description = "Utilities for controlling word breaks in an element.
 <ApiTable
   rows={[
     ["break-normal", "overflow-wrap: normal;\nword-break: normal;"],
-    ["break-words", "overflow-wrap: break-word;"],
     ["break-all", "word-break: break-all;"],
     ["break-keep", "word-break: keep-all;"],
   ]}
@@ -37,30 +36,6 @@ Use the `break-normal` utility to only add line breaks at normal word break poin
 ```html
 <!-- [!code classes:break-normal] -->
 <p class="break-normal">The longest word in any of the major...</p>
-```
-
-</Figure>
-
-### Break Words
-
-Use the `break-words` utility to add line breaks mid-word if needed:
-
-<Figure>
-
-<Example padding={false}>
-  {
-    <p className="mx-auto max-w-xs border-x border-x-pink-400/30 py-8 break-words text-gray-900 dark:text-gray-200">
-      The longest word in any of the major English language dictionaries is{" "}
-      <span className="font-bold">pneumonoultramicroscopicsilicovolcanoconiosis,</span> a word that refers to a lung
-      disease contracted from the inhalation of very fine silica particles, specifically from a volcano; medically, it
-      is the same as silicosis.
-    </p>
-  }
-</Example>
-
-```html
-<!-- [!code classes:break-words] -->
-<p class="break-words">The longest word in any of the major...</p>
 ```
 
 </Figure>


### PR DESCRIPTION
Also removes `break-words` from the `word-break` docs, although it will still work for backwards compatibility. 