### PR TITLE
Update angular.tsx

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/angular.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/angular.tsx
@@ -50,6 +50,22 @@ export let steps: Step[] = [
     },
   },
   {
+    title: "Install Tailwind CSS Typography",
+    body: (
+      <p>
+        Install <code>@tailwindcss/typography</code> to enable intellisense.
+      </p>
+    ),
+
+    code: {
+      name: "Terminal",
+      lang: "shell",
+      code: shell`
+        npm install @tailwindcss/typography -D
+      `,
+    },
+  },
+  {
     title: "Configure PostCSS Plugins",
     body: (
       <p>
@@ -74,14 +90,14 @@ export let steps: Step[] = [
     title: "Import Tailwind CSS",
     body: (
       <p>
-        Add an <code>@import</code> to <code>./src/styles.css</code> that imports Tailwind CSS.
+        Add an <code>@use</code> to <code>./src/styles.css</code> that imports Tailwind CSS.
       </p>
     ),
     code: {
       name: "styles.css",
       lang: "css",
       code: css`
-        @import "tailwindcss";
+        @use "tailwindcss";
       `,
     },
   },


### PR DESCRIPTION
- Add step to install required types for editors intellisense to work
- Use `@use` keyword insteadl of `@import` due to this warning `Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.`