### PR TITLE
Fix: docs field sizing typo

### DIFF
--- a/src/docs/field-sizing.mdx
+++ b/src/docs/field-sizing.mdx
@@ -42,7 +42,7 @@ Use the `field-sizing-content` utility to allow a form control to adjust it's si
 
 ### Using a fixed size
 
-Use the `field-sizing-fixed` utility to make a from control use a fixed size:
+Use the `field-sizing-fixed` utility to make a form control use a fixed size:
 
 <Figure hint="Type in the input below to see the size remain the same">
 

--- a/src/docs/field-sizing.mdx
+++ b/src/docs/field-sizing.mdx
@@ -25,7 +25,7 @@ Use the `field-sizing-content` utility to allow a form control to adjust it's si
   {
     <textarea
       rows="2"
-      defaultValue="Latex Salesman, Vandelay Industries"
+      defaultValue="Latex Salesman, Vanderlay Industries"
       className="mx-auto block field-sizing-content rounded-md p-2 text-sm text-gray-950 outline-1 outline-gray-900/10 focus:outline-2 focus:outline-gray-900 dark:bg-gray-950/25 dark:text-white dark:outline-1 dark:outline-white/5 dark:focus:outline-white/20"
     />
   }
@@ -34,7 +34,7 @@ Use the `field-sizing-content` utility to allow a form control to adjust it's si
 ```html
 <!-- [!code classes:field-sizing-content] -->
 <textarea class="field-sizing-content ..." rows="2">
-  Latex Salesman, Vandelay Industries
+  Latex Salesman, Vanderlay Industries
 </textarea>
 ```
 
@@ -50,7 +50,7 @@ Use the `field-sizing-fixed` utility to make a form control use a fixed size:
   {
     <textarea
       rows="2"
-      defaultValue="Latex Salesman, Vandelay Industries"
+      defaultValue="Latex Salesman, Vanderlay Industries"
       className="mx-auto block field-sizing-fixed w-80 rounded-md p-2 text-sm text-gray-950 outline-1 outline-gray-900/10 focus:outline-2 focus:outline-gray-900 dark:bg-gray-950/25 dark:text-white dark:outline-1 dark:outline-white/5 dark:focus:outline-white/20"
     />
   }
@@ -59,7 +59,7 @@ Use the `field-sizing-fixed` utility to make a form control use a fixed size:
 ```html
 <!-- [!code classes:field-sizing-fixed] -->
 <textarea class="field-sizing-fixed w-80 ..." rows="2">
-  Latex Salesman, Vandelay Industries
+  Latex Salesman, Vanderlay Industries
 </textarea>
 ```
 

--- a/src/docs/field-sizing.mdx
+++ b/src/docs/field-sizing.mdx
@@ -25,7 +25,7 @@ Use the `field-sizing-content` utility to allow a form control to adjust it's si
   {
     <textarea
       rows="2"
-      defaultValue="Latex Salesman, Vanderlay Industries"
+      defaultValue="Latex Salesman, Vandelay Industries"
       className="mx-auto block field-sizing-content rounded-md p-2 text-sm text-gray-950 outline-1 outline-gray-900/10 focus:outline-2 focus:outline-gray-900 dark:bg-gray-950/25 dark:text-white dark:outline-1 dark:outline-white/5 dark:focus:outline-white/20"
     />
   }
@@ -34,7 +34,7 @@ Use the `field-sizing-content` utility to allow a form control to adjust it's si
 ```html
 <!-- [!code classes:field-sizing-content] -->
 <textarea class="field-sizing-content ..." rows="2">
-  Latex Salesman, Vanderlay Industries
+  Latex Salesman, Vandelay Industries
 </textarea>
 ```
 
@@ -50,7 +50,7 @@ Use the `field-sizing-fixed` utility to make a form control use a fixed size:
   {
     <textarea
       rows="2"
-      defaultValue="Latex Salesman, Vanderlay Industries"
+      defaultValue="Latex Salesman, Vandelay Industries"
       className="mx-auto block field-sizing-fixed w-80 rounded-md p-2 text-sm text-gray-950 outline-1 outline-gray-900/10 focus:outline-2 focus:outline-gray-900 dark:bg-gray-950/25 dark:text-white dark:outline-1 dark:outline-white/5 dark:focus:outline-white/20"
     />
   }
@@ -59,7 +59,7 @@ Use the `field-sizing-fixed` utility to make a form control use a fixed size:
 ```html
 <!-- [!code classes:field-sizing-fixed] -->
 <textarea class="field-sizing-fixed w-80 ..." rows="2">
-  Latex Salesman, Vanderlay Industries
+  Latex Salesman, Vandelay Industries
 </textarea>
 ```
 


### PR DESCRIPTION
Fixes a minor typo on the `field-sizing.mdx` and fixes the company name so it's congruent with `hover-focus-and-other-states.mdx`