### PR TITLE
Missing colon and preposition

### DIFF
--- a/src/docs/border-style.mdx
+++ b/src/docs/border-style.mdx
@@ -99,7 +99,7 @@ This is most commonly used to remove a border style that was applied at a smalle
 
 ### Setting the divider style
 
-Use utilities like `divide-dashed` and `divide-dotted` control the border style between child elements
+Use utilities like `divide-dashed` and `divide-dotted` to control the border style between child elements:
 
 <Figure>
 


### PR DESCRIPTION
This PR adds a colon where one would be expected after a code description, and also adds a preposition "to" achieve proper grammar.