### PR TITLE
Add link to v4 docs in content-configuration.mdx

### DIFF
--- a/src/pages/docs/content-configuration.mdx
+++ b/src/pages/docs/content-configuration.mdx
@@ -647,3 +647,5 @@ You can use packages like `npm-run-all` or `concurrently` to compile your CSS al
 ```
 
 Either way, please be sure to [check for an existing issue](https://github.com/tailwindlabs/tailwindcss/issues) or [open a new one](https://github.com/tailwindlabs/tailwindcss/issues/new/choose) so we can figure out the problem and try to improve compatibility with whatever tool you are using.
+
+Finally, double check that you are using Tailwind v3 as Tailwind v4 ignores `tailwind.config.js` altogether, and follow the [relevant documentation for Tailwind v4](https://tailwindcss.com/docs/detecting-classes-in-source-files) if applicable.


### PR DESCRIPTION
For folks very stuck on content configuration who might be using tailwind v4, add mention of the new docs and clarify that v3 config does not work. A lot of Q/A sites / online resources still only talk about v3 config without mentioning it is for v3 only and v4 docs aren't highly ranked, and attempting to use v3 config does not cause any error. I updated a few questions on stackoverflow as well after spending several hours trying various tooling, path patterns and options to build my packages.