### PR TITLE
Fix link to Tailwind CLI tab on Framework Guides page

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/framework-guides/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/framework-guides/page.tsx
@@ -37,7 +37,7 @@ export default async function FrameworkGuides() {
       </ul>
       <div className="my-4 md:my-16">
         <Cta>
-          Don't see your framework of choice? Try using the <Link href="/docs/installation">Tailwind CLI</Link>, the{" "}
+          Don't see your framework of choice? Try using the <Link href="/docs/installation/tailwind-cli">Tailwind CLI</Link>, the{" "}
           <Link href="/docs/installation/using-vite">Vite plugin</Link>, or the{" "}
           <Link href="/docs/installation/using-postcss">PostCSS plugin</Link> instead.
         </Cta>


### PR DESCRIPTION
I noticed that the Tailwind CLI link at the bottom of the framework guides page does not work.

This PR fixes that by changing the link from `/docs/installation` to `/docs/installation/tailwind-cli`. 