### PR TITLE
Fix: replace UNPKG w/ jsDelivr

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/play-cdn/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/play-cdn/page.tsx
@@ -34,7 +34,7 @@ const steps: Step[] = [
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <!-- [!code highlight:2] -->
-            <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+            <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
           </head>
           <body>
             <!-- [!code highlight:4] -->
@@ -62,7 +62,7 @@ const steps: Step[] = [
           <head>
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+            <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
             <!-- [!code highlight:6] -->
             <style type="text/tailwindcss">
               @theme {


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.

The PR fixes https://github.com/tailwindlabs/tailwindcss/issues/17215 and https://github.com/tailwindlabs/tailwindcss/discussions/17216