### PR TITLE
docs: update v3 theme docs to use proper branch in URLs

### DIFF
--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -46,7 +46,7 @@ module.exports = {
 }
 ```
 
-We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js) with a very generous set of values to get you started, but don't be afraid to change it or extend it; you're encouraged to customize it as much as you need to fit the goals of your design.
+We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcss/blob/v3.3/stubs/config.full.js) with a very generous set of values to get you started, but don't be afraid to change it or extend it; you're encouraged to customize it as much as you need to fit the goals of your design.
 
 ---
 
@@ -54,7 +54,7 @@ We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcs
 
 The `theme` object contains keys for `screens`, `colors`, and `spacing`, as well as a key for each customizable [core plugin](/docs/configuration#core-plugins).
 
-See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js#L7) for a complete list of theme options.
+See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindlabs/tailwindcss/blob/v3.3/stubs/config.full.js#L7) for a complete list of theme options.
 
 ### Screens
 
@@ -191,13 +191,13 @@ You'll notice that using a key of `DEFAULT` in the theme configuration created t
 
 To learn more about customizing a specific core plugin, visit the documentation for that plugin.
 
-For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js).
+For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/v3.3/stubs/config.full.js).
 
 ---
 
 ## Customizing the default theme
 
-Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js). If you would like to customize the default theme, you have a few different options depending on your goals.
+Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/v3.3/stubs/config.full.js). If you would like to customize the default theme, you have a few different options depending on your goals.
 
 ### Extending the default theme
 

--- a/src/pages/docs/top-right-bottom-left.mdx
+++ b/src/pages/docs/top-right-bottom-left.mdx
@@ -143,13 +143,13 @@ Use the `start-*` and `end-*` utilities to set the `inset-inline-start` and `ins
   <div class="relative h-32 w-32 ...">
     <div class="absolute h-14 w-14 top-0 **start-0** ..."></div>
   </div>
-<div>
+</div>
 
 <div dir="**rtl**">
   <div class="relative h-32 w-32 ...">
     <div class="absolute h-14 w-14 top-0 **start-0** ..."></div>
   </div>
-<div>
+</div>
 ```
 
 For more control, you can also use the [LTR and RTL modifiers](/docs/hover-focus-and-other-states#rtl-support) to conditionally apply specific styles depending on the current text direction.


### PR DESCRIPTION
this should hopefully fix issues in [original PR](https://github.com/tailwindlabs/tailwindcss.com/pull/2168)

I didn't see any other v3.* branches, so hopefully `v3.3` is the correct branch to address this (and point to for public documentation.)

This fixes an issue in the `version < 4.x` docs where links to the default theme break/result in a 404 (presumably because master contains v4 changes.)

---

### Reproducing

1. Visit [tailwindcss.com/docs](https://tailwindcss.com/docs)
2. Select `v3.4.17` in the top-left version dropdown
3. Click `Get started`
4. Click the `Customization > Theme` link in left-hand nav
5. Search for `the default theme configuration` and click one of the resulting links
6. Observe redirect to [a (no longer existing) blob in Github](https://github.com/tailwindlabs/tailwindcss/blob/main/stubs/config.full.js)