### PR TITLE
fix: properly setup rtl truncation to truncate from the end

### DIFF
--- a/src/components/home/why-tailwind-css-section.tsx
+++ b/src/components/home/why-tailwind-css-section.tsx
@@ -634,7 +634,7 @@ export default function WhyTailwindCssSection() {
                       <div key={idx} className="flex items-center justify-start gap-4 p-6">
                         <div className="shrink-0">
                           <img
-                            alt=""
+                            alt={`${user.name} profile picture`}
                             src={user.src}
                             className="size-12 shrink-0 rounded-full bg-gray-950/5 outline -outline-offset-1 outline-gray-950/10 dark:outline-white/10"
                           />
@@ -654,18 +654,19 @@ export default function WhyTailwindCssSection() {
                     { src: avatar3.src, name: "خالد عمر", role: "مصمم واجهات المستخدم" },
                   ].map((user, idx) => {
                     return (
-                      <div key={idx} className="flex items-center justify-end gap-4 p-6">
-                        <div className="flex flex-col truncate text-right">
-                          <span className="text-sm/6 font-medium text-gray-950 dark:text-white">{user.name}</span>
-                          <span className="truncate text-sm/6 text-gray-500 dark:text-gray-400">{user.role}</span>
-                        </div>
-                        <div className="shrink-0">
+                      <div key={idx} className="flex items-center justify-start gap-4 p-6" dir="rtl">
+                         <div className="shrink-0">
                           <img
-                            alt=""
+                            alt={`صورة شخصية لـ ${user.name}`}
                             src={user.src}
                             className="size-12 shrink-0 rounded-full bg-gray-950/5 outline -outline-offset-1 outline-gray-950/10 dark:outline-white/10"
                           />
                         </div>
+                        <div className="flex flex-col truncate">
+                          <span className="text-sm/6 font-medium text-gray-950 dark:text-white">{user.name}</span>
+                          <span className="truncate text-sm/6 text-gray-500 dark:text-gray-400">{user.role}</span>
+                        </div>
+                       
                       </div>
                     );
                   })}

--- a/src/components/home/why-tailwind-css-section.tsx
+++ b/src/components/home/why-tailwind-css-section.tsx
@@ -634,7 +634,7 @@ export default function WhyTailwindCssSection() {
                       <div key={idx} className="flex items-center justify-start gap-4 p-6">
                         <div className="shrink-0">
                           <img
-                            alt={`${user.name} profile picture`}
+                            alt=""
                             src={user.src}
                             className="size-12 shrink-0 rounded-full bg-gray-950/5 outline -outline-offset-1 outline-gray-950/10 dark:outline-white/10"
                           />
@@ -657,7 +657,7 @@ export default function WhyTailwindCssSection() {
                       <div key={idx} className="flex items-center justify-start gap-4 p-6" dir="rtl">
                          <div className="shrink-0">
                           <img
-                            alt={`صورة شخصية لـ ${user.name}`}
+                            alt=""
                             src={user.src}
                             className="size-12 shrink-0 rounded-full bg-gray-950/5 outline -outline-offset-1 outline-gray-950/10 dark:outline-white/10"
                           />


### PR DESCRIPTION
The current behavior of the RTL part in the `WhyTailwindCssSection` is wrong, and I'll describe the problem in the following points.
- The RTL part does not have `dir="rtl"`
The DOM elements are ordered manually instead of leaving the order the same, and depending on the browser to order them according to their direction. So, in the RTL version, the image is the second element, but in the LTR, it's the first.
The `text-right` is used explicitly on the RTL version, although it should have been prefixed with `rtl:` or omitted entirely if the `dir` is set up correctly.
- The missing `dir` causes another issue with the truncation, as the direction of the container is `ltr`, so the truncation happened from the start of the text, not the end. 
How it looks: ![image](https://github.com/user-attachments/assets/69c09f3c-8c4c-4796-b1c8-b91889936550)
How it should look: ![image](https://github.com/user-attachments/assets/9ac2335c-f4af-4dd6-9d30-98340f0423cd)

These issues are in the RTL version on the homepage, and I didn't check any other pages, but the landing page is important to have an accurate representation to appeal to the developers who need RTL support. If a developer opens the dev tools currently and checks the implementation, they might move away from this solution, although it's capable, just because they saw a wrong implementation.
