### PR TITLE
Improve the `@custom-variant` docs

### DIFF
--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -1,3 +1,5 @@
+import { CodeExampleStack } from "@/components/code-example";
+
 export const title = "Adding custom styles";
 export const description = "Best practices for adding your own custom styles in Tailwind projects.";
 
@@ -294,6 +296,74 @@ The `components` layer is also a good place to put custom styles for any third-p
 }
 ```
 
+### Using variants
+
+Use the `@variant` directive to apply a Tailwind variant within custom CSS:
+
+<CodeExampleStack>
+
+```css
+/* [!code filename:app.css] */
+.my-element {
+  background: white;
+
+  /* [!code highlight:4] */
+  @variant dark {
+    background: black;
+  }
+}
+```
+
+```css
+/* [!code filename:Compiled CSS] */
+.my-element {
+  background: white;
+
+  /* [!code highlight:4] */
+  @media (prefers-color-scheme: dark) {
+    background: black;
+  }
+}
+```
+
+</CodeExampleStack>
+
+If you need to apply multiple variants at the same time, use nesting:
+
+<CodeExampleStack>
+
+```css
+/* [!code filename:app.css] */
+.my-element {
+  background: white;
+
+  /* [!code highlight:6] */
+  @variant dark {
+    @variant hover {
+      background: black;
+    }
+  }
+}
+```
+
+```css
+/* [!code filename:Compiled CSS] */
+.my-element {
+  background: white;
+
+  /* [!code highlight:7] */
+  @media (prefers-color-scheme: dark) {
+    &:hover {
+      @media (hover: hover) {
+        background: black;
+      }
+    }
+  }
+}
+```
+
+</CodeExampleStack>
+
 ## Adding custom utilities
 
 ### Simple utilities
@@ -508,31 +578,38 @@ This will match utilities like `aspect-square`, `aspect-3/4`, and `aspect-[7/9]`
 
 ## Adding custom variants
 
-Use the `@variant` directive to apply a Tailwind variant within custom CSS:
+In addition to using the variants that ship with Tailwind, you can also add your own custom variants using the `@custom-variant` directive:
 
 ```css
-/* [!code filename:CSS] */
-.my-element {
-  background: white;
-
-  /* [!code highlight:4] */
-  @variant dark {
-    background: black;
+@custom-variant theme-midnight {
+  &:where([data-theme="midnight"] *) {
+    @slot;
   }
 }
 ```
 
-If you need to apply multiple variants at the same time, use nesting:
+Now you can use the `theme-midnight:<utility>` variant in your HTML:
+
+```html
+<!-- [!code classes:theme-midnight:bg-black] -->
+<html data-theme="midnight">
+  <button class="theme-midnight:bg-black ..."></button>
+</html>
+```
+
+You can create variants using the shorthand syntax when nesting isn't required:
 
 ```css
-/* [!code filename:CSS] */
-.my-element {
-  background: white;
+@custom-variant theme-midnight (&:where([data-theme="midnight"] *));
+```
 
-  /* [!code highlight:6] */
-  @variant dark {
-    @variant hover {
-      background: black;
+When a custom variant has multiple rules, they can be nested within each other:
+
+```css
+@custom-variant any-hover {
+  @media (any-hover: hover) {
+    &:hover {
+      @slot;
     }
   }
 }

--- a/src/docs/functions-and-directives.mdx
+++ b/src/docs/functions-and-directives.mdx
@@ -83,23 +83,7 @@ Use the `@variant` directive to apply a Tailwind variant to styles in your CSS:
 }
 ```
 
-If you need to apply multiple variants at the same time, use nesting:
-
-```css
-/* [!code filename:CSS] */
-.my-element {
-  background: white;
-
-  /* [!code highlight:6] */
-  @variant dark {
-    @variant hover {
-      background: black;
-    }
-  }
-}
-```
-
-Learn more about variants in the [hover, focus, and other states documentation](/docs/hover-focus-and-other-states).
+Learn more using variants in the [using variants documentation](/docs/adding-custom-styles#using-variants).
 
 <h3 id="custom-variant-directive">@custom-variant</h3>
 
@@ -107,13 +91,12 @@ Use the `@custom-variant` directive to add a custom variant in your project:
 
 ```css
 /* [!code filename:CSS] */
-@custom-variant pointer-coarse (@media (pointer: coarse));
 @custom-variant theme-midnight (&:where([data-theme="midnight"] *));
 ```
 
-This lets you write utilities like `pointer-coarse:size-48` and `theme-midnight:bg-slate-900`.
+This lets you write utilities `theme-midnight:bg-black` and `theme-midnight:text-white`.
 
-Learn more about adding custom variants in the [registering a custom variant documentation](/docs/hover-focus-and-other-states#registering-a-custom-variant).
+Learn more about adding custom variants in the [adding custom variants documentation](/docs/adding-custom-styles#adding-custom-variants).
 
 <h3 id="apply-directive">@apply</h3>
 

--- a/src/docs/hover-focus-and-other-states.mdx
+++ b/src/docs/hover-focus-and-other-states.mdx
@@ -2881,40 +2881,22 @@ With at-rule custom variants the `&` placeholder isn't necessary, just like when
 
 ### Registering a custom variant
 
-If you find yourself using the same arbitrary variant multiple times in your project, it might be worth creating a custom variant:
+If you find yourself using the same arbitrary variant multiple times in your project, it might be worth creating a custom variant using the `@custom-variant` directive:
 
 ```css
-@custom-variant pointer-coarse {
-  @media (pointer: coarse) {
-    @slot;
-  }
-}
+@custom-variant theme-midnight (&:where([data-theme="midnight"] *));
 ```
 
-Now you can use the `pointer-coarse:<utility>` variant in your HTML:
+Now you can use the `theme-midnight:<utility>` variant in your HTML:
 
 ```html
-<!-- [!code classes:pointer-coarse:size-12] -->
-<button class="pointer-coarse:size-12 ..."></button>
+<!-- [!code classes:theme-midnight:bg-black] -->
+<html data-theme="midnight">
+  <button class="theme-midnight:bg-black ..."></button>
+</html>
 ```
 
-You can create variants using the shorthand syntax when nesting isn't required:
-
-```css
-@custom-variant pointer-coarse (@media (pointer: coarse));
-```
-
-When a custom variant has multiple rules, they can be nested within each other:
-
-```css
-@custom-variant any-hover {
-  @media (any-hover: hover) {
-    &:hover {
-      @slot;
-    }
-  }
-}
-```
+Learn more about adding custom variants in the [adding custom variants documentation](/docs/adding-custom-styles#adding-custom-variants).
 
 ## Appendix
 


### PR DESCRIPTION
This PR improves the `@custom-variant` docs, including:

1. Updating the "Adding custom variants" section on the "Adding custom styles" page to actually explain the `@custom-variant` directive, instead of the `@variant` directive.
2. Creating a new "Using variants" section on the "Adding custom styles" page to explain the `@variant` directive.
3. Updating the "@custom-variant" section of the "Functions and directives" page to remove the "pointer-coarse" example (in preparation for v4.1), and also link to the new "Adding custom variants" section on the "Adding custom styles" page, instead of the "Registering a custom variant" on the "Hover, focus, and other states" page. The "Adding custom styles" page is now considered the canonical location for this information.
4. Simplifying the "Registering a custom variant" section on the "Hover, focus, and other states" page, and adding a link to the "Adding custom variants" section on the "Adding custom styles" page for more information.