### PR TITLE
Fix incorrect text-shadow color name in API table

### DIFF
--- a/src/docs/text-shadow.mdx
+++ b/src/docs/text-shadow.mdx
@@ -37,7 +37,7 @@ export const description = "Utilities for controlling the shadow of a text eleme
     ["text-shadow-transparent", "--tw-shadow-color transparent;"],
     ...Object.entries(colors).map(([name, value]) => [
       `text-shadow-${name}`,
-      `--tw-shadow-color var(--color-${name}); /* ${value} */`,
+      `--tw-text-shadow-color var(--color-${name}); /* ${value} */`,
     ]),
   ]}
 />

--- a/src/docs/text-shadow.mdx
+++ b/src/docs/text-shadow.mdx
@@ -36,7 +36,7 @@ export const description = "Utilities for controlling the shadow of a text eleme
     ["text-shadow-current", "--tw-shadow-color currentColor;"],
     ["text-shadow-transparent", "--tw-shadow-color transparent;"],
     ...Object.entries(colors).map(([name, value]) => [
-      `shadow-${name}`,
+      `text-shadow-${name}`,
       `--tw-shadow-color var(--color-${name}); /* ${value} */`,
     ]),
   ]}


### PR DESCRIPTION
`shadow-<color>` is used for box-shadow, the right name is `text-shadow-<color>` according to https://github.com/tailwindlabs/tailwindcss/pull/17389.