### PR TITLE
Update Laravel doc link to always point to latest version

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
@@ -30,7 +30,7 @@ export let steps: Step[] = [
     body: (
       <p>
         Start by creating a new Laravel project if you don’t have one set up already. The most common approach is to use{" "}
-        <a href="https://laravel.com/docs/11.x#creating-an-application">the Laravel installer</a>.
+        <a href="https://laravel.com/docs#creating-an-application">the Laravel installer</a>.
       </p>
     ),
     code: {


### PR DESCRIPTION
The current link points to the Laravel 11.x docs, which are now outdated, Laravel is currently at 12.x.

This PR updates the URL to use the version-agnostic link so it always points to the latest docs.