### PR TITLE
Fix broken links to Default theme

### DIFF
--- a/src/pages/docs/theme.mdx
+++ b/src/pages/docs/theme.mdx
@@ -47,7 +47,7 @@ module.exports = {
 }
 ```
 
-We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js) with a very generous set of values to get you started, but don't be afraid to change it or extend it; you're encouraged to customize it as much as you need to fit the goals of your design.
+We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcss/blob/v3/stubs/config.full.js) with a very generous set of values to get you started, but don't be afraid to change it or extend it; you're encouraged to customize it as much as you need to fit the goals of your design.
 
 ---
 
@@ -55,7 +55,7 @@ We provide a sensible [default theme](https://github.com/tailwindlabs/tailwindcs
 
 The `theme` object contains keys for `screens`, `colors`, and `spacing`, as well as a key for each customizable [core plugin](/docs/configuration#core-plugins).
 
-See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js#L7) for a complete list of theme options.
+See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindlabs/tailwindcss/blob/v3/stubs/config.full.js) for a complete list of theme options.
 
 ### Screens
 
@@ -195,13 +195,13 @@ You'll notice that using a key of `DEFAULT` in the theme configuration created t
 
 To learn more about customizing a specific core plugin, visit the documentation for that plugin.
 
-For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js).
+For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/v3/stubs/config.full.js).
 
 ---
 
 ## Customizing the default theme
 
-Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js). If you would like to customize the default theme, you have a few different options depending on your goals.
+Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindlabs/tailwindcss/blob/v3/stubs/config.full.js). If you would like to customize the default theme, you have a few different options depending on your goals.
 
 ### Extending the default theme
 


### PR DESCRIPTION
**Links changed from**:
- https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js

**To**:
- https://github.com/tailwindlabs/tailwindcss/blob/v3/stubs/config.full.js

**As advised by**:
- https://github.com/tailwindlabs/tailwindcss/discussions/17374