### PR TITLE
Docs: clarify Tailwind CSS v4 PostCSS setup and upgrade notes for Lararvel

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
@@ -124,6 +124,33 @@ export let steps: Step[] = [
       `,
     },
   },
+  {
+      tabs: ["vite"],
+      title: "Remove legacy PostCSS configuration",
+      body: (
+          <p>
+              You can remove <code>tailwindcss</code>, <code>postcss-import</code>, and <code>autoprefixer</code> from your <code>postcss.config.js</code> — Tailwind CSS v4 handles them automatically via the Vite plugin.
+              This simplifies setup when upgrading from <a href="https://v3.tailwindcss.com/">v3</a>.
+              See the <a href="https://tailwindcss.com/docs/upgrade-guide">upgrade guide</a> for details.
+          </p>
+      ),
+      code: {
+          name: "postcss.config.js",
+          lang: "js",
+          code: js`
+      export default {
+          plugins: {
+              // [!code --:4]
+              "postcss-import": {},
+               tailwindcss: {},
+               autoprefixer: {},
+               // [!code ++:2]
+              "@tailwindcss/postcss": {},
+          },
+     };
+    `,
+      },
+  },
 
   {
     title: "Import Tailwind CSS",


### PR DESCRIPTION
Many developers — particularly those using Laravel — have faced confusion when upgrading to Tailwind CSS v4, as seen in [issue #15735](https://github.com/tailwindlabs/tailwindcss/issues/15735).

The main issue comes from legacy configuration in `postcss.config.js` that still includes `tailwindcss` as a plugin. This now causes an error in v4:
> "It looks like you're trying to use tailwindcss directly as a PostCSS plugin."

Laravel’s default scaffolding has not yet been updated to reflect the Tailwind CSS v4 setup, which increases the likelihood of this issue occurring during fresh installs or upgrades.

This PR updates the installation section to clarify:
- `tailwindcss`, `postcss-import`, and `autoprefixer` should be removed from `postcss.config.js`
- The Vite plugin now handles these automatically
- References to both [Tailwind v3 docs](https://v3.tailwindcss.com/) and the [official v4 upgrade guide](https://tailwindcss.com/docs/upgrade-guide) are included for clarity

This clarification should help prevent common setup errors and make the upgrade path smoother for developers working with Laravel or following older guides.
