### PR TITLE
Fix `text-pretty` description

### DIFF
--- a/src/docs/text-wrap.mdx
+++ b/src/docs/text-wrap.mdx
@@ -111,7 +111,7 @@ For performance reasons browsers limit text balancing to blocks that are ~6 line
 
 ### Pretty text wrapping
 
-Use the `text-pretty` utility to prevent orphans (a single word on its own line) at the end of a text block:
+Use the `text-pretty` utility to optimimise for wrapping prettiness rather than browser speed. Behaviour varies by browser but often involves more complicated text wrapping approaches such as preventing orphans (a single word on its own line) at the end of a text block:
 
 <Figure>
 
@@ -138,6 +138,8 @@ Use the `text-pretty` utility to prevent orphans (a single word on its own line)
 ```
 
 </Figure>
+
+Browsers vary in their interpretation of prettiness but may include advanced typographic concepts such as: reducing the variation in length between lines; avoiding typographic rivers; prioritizing different classes of soft wrap opportunities, hyphenation opportunities, or justification opportunities; avoiding hyphenation on too many consecutive lines.
 
 ### Responsive design
 

--- a/src/docs/text-wrap.mdx
+++ b/src/docs/text-wrap.mdx
@@ -139,7 +139,9 @@ Use the `text-pretty` utility to optimimise for wrapping prettiness rather than 
 
 </Figure>
 
-Browsers vary in their interpretation of prettiness but may include advanced typographic concepts such as: reducing the variation in length between lines; avoiding typographic rivers; prioritizing different classes of soft wrap opportunities, hyphenation opportunities, or justification opportunities; avoiding hyphenation on too many consecutive lines.
+Browsers vary in their interpretation of prettiness but may include advanced typographic concepts such as:
+
+> reducing the variation in length between lines; avoiding typographic rivers; prioritizing different classes of soft wrap opportunities, hyphenation opportunities, or justification opportunities; avoiding hyphenation on too many consecutive lines - [CSS Text Level 4 specification](https://drafts.csswg.org/css-text-4/#text-wrap-style)
 
 ### Responsive design
 


### PR DESCRIPTION
Current `text-pretty` description says,

> Use the `text-pretty` utility to prevent orphans (a single word on its own line) at the end of a text block:

See [this recent blog post from Webkit about `text-wrap: pretty;`](https://webkit.org/blog/16547/better-typography-with-text-wrap-pretty/) and in particular, 

> Because of the way Chrome’s implementation of pretty has been taught, a lot of web developers expect this value is only supposed to prevent short last lines. But that was never the intention. In fact, the CSS Working Group defined a different value for such a purpose. It was [just renamed](https://github.com/w3c/csswg-drafts/issues/11283) last week to text-wrap: avoid-short-last-lines.

So it seems an updated description is needed and this PR has a first attempt.