### PR TITLE
docs: add `h-lh`, `min-h-lh`, `max-h-lh` utilities to height, min-height, and max-height docs

### DIFF
--- a/src/docs/height.mdx
+++ b/src/docs/height.mdx
@@ -25,6 +25,7 @@ export const description = "Utilities for setting the height of an element.";
     ["h-min", "height: min-content;"],
     ["h-max", "height: max-content;"],
     ["h-fit", "height: fit-content;"],
+    ["h-lh", "height: 1lh;"],
     ["h-(<custom-property>)", "height: var(<custom-property>);"],
     ["h-[<value>]", "height: <value>;"],
     ["size-<number>", "width: calc(var(--spacing) * <number>);\nheight: calc(var(--spacing) * <number>);"],

--- a/src/docs/max-height.mdx
+++ b/src/docs/max-height.mdx
@@ -24,6 +24,7 @@ export const description = "Utilities for setting the maximum height of an eleme
     ["max-h-min", "max-height: min-content;"],
     ["max-h-max", "max-height: max-content;"],
     ["max-h-fit", "max-height: fit-content;"],
+    ["max-h-lh", "max-height: 1lh;"],
     ["max-h-(<custom-property>)", "max-height: var(<custom-property>);"],
     ["max-h-[<value>]", "max-height: <value>;"],
   ]}

--- a/src/docs/min-height.mdx
+++ b/src/docs/min-height.mdx
@@ -24,6 +24,7 @@ export const description = "Utilities for setting the minimum height of an eleme
     ["min-h-min", "min-height: min-content;"],
     ["min-h-max", "min-height: max-content;"],
     ["min-h-fit", "min-height: fit-content;"],
+    ["min-h-lh", "min-height: 1lh;"],
     ["min-h-(<custom-property>)", "min-height: var(<custom-property>);"],
     ["min-h-[<value>]", "min-height: <value>;"],
   ]}


### PR DESCRIPTION
These line-height-based sizing utilities were added in [tailwindcss#17790](https://github.com/tailwindlabs/tailwindcss/pull/17790) and released in **v4.1.5**.

This PR adds the following utilities to their respective documentation pages:

- `h-lh` → `height` page
- `min-h-lh` → `min-height` page
- `max-h-lh` → `max-height` page