### PR TITLE
Fix example syntax error

### DIFF
--- a/src/docs/styling-with-utility-classes.mdx
+++ b/src/docs/styling-with-utility-classes.mdx
@@ -422,8 +422,8 @@ It's also useful when you need to use CSS features like `calc()`, even if you ar
 
 ```html
 <!-- [!code filename:HTML] -->
-<!-- [!code classes:max-h-[calc(100dvh-(--spacing(6))]] -->
-<div class="max-h-[calc(100dvh-(--spacing(6))]">
+<!-- [!code classes:max-h-[calc(100dvh-(--spacing(6)))]] -->
+<div class="max-h-[calc(100dvh-(--spacing(6)))]">
   <!-- ... -->
 </div>
 ```


### PR DESCRIPTION
Fix unbalanced parentheses in an example, as spotted by tailwindlabs/tailwindcss#17857.