### PR TITLE
Fixed typo in font-variant-numeric.mdx to properly show the slashed-zero

### DIFF
--- a/src/docs/font-variant-numeric.mdx
+++ b/src/docs/font-variant-numeric.mdx
@@ -187,8 +187,8 @@ The `font-variant-numeric` utilities are composable so you can enable multiple v
       <dd className="border-b border-gray-200 py-2 text-right slashed-zero tabular-nums dark:border-white/10">
         $14.50
       </dd>
-      <dt className="py-2">Total</dt>
-      <dd className="slashed-medium py-2 text-right tabular-nums">$114.50</dd>
+      <dt className="font-medium py-2">Total</dt>
+      <dd className="font-medium py-2 text-right slashed-zero tabular-nums">$114.50</dd>
     </dl>
   }
 </Example>


### PR DESCRIPTION
I think it was just a typo.

Before: 
![grafik](https://github.com/user-attachments/assets/96cc6540-b251-4f6c-bdd7-73dc272a2fc9)

After:
![grafik](https://github.com/user-attachments/assets/337eb366-8cfb-42f7-a9db-10353c6476aa)
