### PR TITLE
fix: fix inconsistent min-width fraction example

### DIFF
--- a/src/docs/min-width.mdx
+++ b/src/docs/min-width.mdx
@@ -88,7 +88,7 @@ Use `min-w-full` or `min-w-<fraction>` utilities like `min-w-1/2` and `min-w-2/5
   {
     <div className="relative mx-auto my-6 flex w-full justify-items-start gap-3 text-center font-mono text-xs font-bold text-white">
       <Stripes border className="absolute inset-x-0 -inset-y-3 rounded-lg" />
-      <div className="relative min-w-2/3 rounded-lg bg-indigo-500 px-4 py-2">min-w-1/3</div>
+      <div className="relative min-w-2/3 rounded-lg bg-indigo-500 px-4 py-2">min-w-3/4</div>
       <div className="relative w-full rounded-lg bg-indigo-300 px-4 py-2 dark:bg-indigo-800 dark:text-indigo-400">
         w-full
       </div>


### PR DESCRIPTION
The example in min-width.mdx shows min-w-1/3 in the UI but uses min-w-3/4 in the HTML example.  
This commit updates the UI example to correctly display min-w-3/4 to match the HTML code. 