### PR TITLE
docs(nextjs): clarify globals.css placement for App Router

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
@@ -1,4 +1,4 @@
-import { css, js, shell, Page, Step, Tile, tsx } from "./utils";
+import { css, js, shell, Page, Step, Tile } from "./utils";
 import Logo from "@/docs/img/guides/nextjs.react.svg";
 import LogoDark from "@/docs/img/guides/nextjs-white.react.svg";
 
@@ -95,7 +95,7 @@ export let steps: Step[] = [
     code: {
       name: "layout.tsx",
       lang: "tsx",
-      code: tsx`
+      code: js`
         import "./globals.css";
       `,
     },

--- a/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
@@ -1,4 +1,4 @@
-import { css, js, shell, Page, Step, Tile } from "./utils";
+import { css, js, shell, Page, Step, Tile, tsx } from "./utils";
 import Logo from "@/docs/img/guides/nextjs.react.svg";
 import LogoDark from "@/docs/img/guides/nextjs-white.react.svg";
 
@@ -82,6 +82,21 @@ export let steps: Step[] = [
       lang: "css",
       code: css`
         @import "tailwindcss";
+      `,
+    },
+  },
+  {
+    title: "Import global.css",
+    body: (
+      <p>
+        Import the global.css file in the <code>./src/app/layout.tsx</code> file.
+      </p>
+    ),
+    code: {
+      name: "layout.tsx",
+      lang: "tsx",
+      code: tsx`
+        import "./globals.css";
       `,
     },
   },

--- a/src/app/(docs)/docs/installation/framework-guides/utils.ts
+++ b/src/app/(docs)/docs/installation/framework-guides/utils.ts
@@ -2,7 +2,6 @@ import dedent from "dedent";
 import type { ReactNode } from "react";
 
 export const js = dedent;
-export const tsx = dedent;
 export const css = dedent;
 export const shell = dedent;
 export const html = dedent;

--- a/src/app/(docs)/docs/installation/framework-guides/utils.ts
+++ b/src/app/(docs)/docs/installation/framework-guides/utils.ts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import type { ReactNode } from "react";
 
 export const js = dedent;
+export const tsx = dedent;
 export const css = dedent;
 export const shell = dedent;
 export const html = dedent;


### PR DESCRIPTION
Enhance Next.js guide by adding a step to import global.css and introduce a new tsx utility for code examples.