### PR TITLE
Update Tailwind CSS integration example for Laravel

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/laravel.tsx
@@ -130,15 +130,19 @@ export let steps: Step[] = [
     body: (
       <p>
         Add an <code>@import</code> to <code>./resources/css/app.css</code> that imports Tailwind CSS. Additionally,
-        tell Tailwind CSS to scan your <code>resources/views</code> directory for utilities.
+        tell Tailwind CSS to scan some directories for utilities.
       </p>
     ),
     code: {
       name: "app.css",
       lang: "css",
       code: css`
-        @import "tailwindcss";
-        @source "../views";
+        @import 'tailwindcss';
+
+        @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
+        @source '../../storage/framework/views/*.php';
+        @source '../**/*.blade.php';
+        @source '../**/*.js';
       `,
     },
   },


### PR DESCRIPTION
Description
---
This PR updates the documentation to reflect the actual default integration of Tailwind CSS in Laravel as shown in the official [Laravel repository](https://github.com/laravel/laravel/blob/12.x/resources/css/app.css).

Reason
--
The current Tailwind documentation for Laravel does not accurately reflect how Tailwind is integrated by default in the latest Laravel releases. This update ensures that new users following the guide get a setup experience that matches the actual Laravel boilerplate.