### PR TITLE
Fixed the app not-found height to hide the scrollbar

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFoundPage() {
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">
-          <div className="flex h-[calc(100dvh-var(--spacing)*14.25-2px)] items-center justify-center">
+          <div className="flex h-full items-center justify-center">
             <div className="flex flex-auto flex-col items-center justify-center px-4 text-center sm:flex-row">
               <h1 className="text-2xl font-extrabold tracking-tight text-gray-900 sm:mr-6 sm:border-r sm:border-gray-900/10 sm:pr-6 sm:text-3xl dark:text-gray-200 sm:dark:border-gray-300/10">
                 404

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFoundPage() {
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">
-          <div className="flex h-[calc(100vh-3.5rem)] items-center justify-center">
+          <div className="flex h-[calc(100vh-var(--spacing)*14.25)] items-center justify-center">
             <div className="flex flex-auto flex-col items-center justify-center px-4 text-center sm:flex-row">
               <h1 className="text-2xl font-extrabold tracking-tight text-gray-900 sm:mr-6 sm:border-r sm:border-gray-900/10 sm:pr-6 sm:text-3xl dark:text-gray-200 sm:dark:border-gray-300/10">
                 404

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFoundPage() {
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">
-          <div className="flex h-[calc(100vh-var(--spacing)*14.25)] items-center justify-center">
+          <div className="flex h-[calc(100dvh-var(--spacing)*14.25-2px)] items-center justify-center">
             <div className="flex flex-auto flex-col items-center justify-center px-4 text-center sm:flex-row">
               <h1 className="text-2xl font-extrabold tracking-tight text-gray-900 sm:mr-6 sm:border-r sm:border-gray-900/10 sm:pr-6 sm:text-3xl dark:text-gray-200 sm:dark:border-gray-300/10">
                 404


### PR DESCRIPTION
The parent element has a `pt-14.25`, which needs to be subtracted from `100vh`. The parent also has a `1px` border on the top and bottom, which should also be subtracted. Additionally, I would use `dvh` instead of `vh`.

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/669e6f66-d291-4f4c-a9c9-b9330cef6e48)|![image](https://github.com/user-attachments/assets/6d6ea882-31fa-42b7-bf7f-4cea3064df71)|