### PR TITLE
docs: Add link to `Safelisting specific utilities` from upgrade guide

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -761,7 +761,7 @@ If you still need to use a JavaScript config file, you can load it explicitly us
 @config "../../tailwind.config.js";
 ```
 
-The `corePlugins`, `safelist`, and `separator` options from the JavaScript-based config are not supported in v4.0. To safelist utilities in v4.0 use [`@source inline()`](/docs/detecting-classes-in-source-files#safelisting-specific-utilities).
+The `corePlugins`, `safelist`, and `separator` options from the JavaScript-based config are not supported in v4.0. To safelist utilities in v4 use [`@source inline()`](/docs/detecting-classes-in-source-files#safelisting-specific-utilities).
 
 ### Theme values in JavaScript
 


### PR DESCRIPTION
Think it'd be helpful to have the `@source inline` feature mentioned in upgrade guide instead of it just saying `safelist` doesn't exist anymore (this might be a newer feature than when the docs were written).

Maybe could've been a little section or something, but wasn't sure how to do it best, and I think like this is better than not at all 🤓 