### PR TITLE
Update “standalone executable” link

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/tailwind-cli/page.tsx
@@ -93,7 +93,8 @@ export default function Page() {
         </h3>
         <p>
           The simplest and fastest way to get up and running with Tailwind CSS from scratch is with the Tailwind CLI
-          tool. The CLI is also available as a <Link href="/blog/standalone-cli">standalone executable</Link> if you
+          tool. The CLI is also available as a{" "}
+          <Link href="https://github.com/tailwindlabs/tailwindcss/releases/latest">standalone executable</Link> if you
           want to use it without installing Node.js.
         </p>
       </div>


### PR DESCRIPTION
Closes #2275

Instead of linking to the old blog post we'll just link to the place you can download them. The instructions for using it are the same as the normal CLI you just invoke the CLI directory instead of node / bun / npx / etc…
