### PR TITLE
Added copy button

### DIFF
--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -8,6 +8,7 @@ import { clsx } from "clsx";
 import dedent from "dedent";
 import { createHighlighter } from "shiki";
 import theme from "./syntax-highlighter/theme.json";
+import { CopyButton } from "./copy-button";
 
 import { highlightClasses } from "./highlight-classes";
 import atApplyInjection from "./syntax-highlighter/at-apply.json";
@@ -97,8 +98,12 @@ export async function CodeExample({
   className?: string;
 }) {
   return (
-    <CodeExampleWrapper className={className}>
+    <CodeExampleWrapper className={clsx('relative', className)}>
       {filename ? <CodeExampleFilename filename={filename} /> : null}
+      <CopyButton
+        className="absolute right-4 top-2 z-10 text-stone-400"
+        value={example.code}
+      />
       <HighlightedCode example={example} />
     </CodeExampleWrapper>
   );

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -38,6 +38,55 @@ export function css(strings: TemplateStringsArray, ...args: any[]) {
   return { lang: "css", code: dedent(strings, ...args) };
 }
 
+export function unshiki(code: string): string {
+  const lines = code.split("\n");
+  const result: string[] = [];
+  let skip = 0;
+
+  const commentRegex = /\/\*.*?\*\/|\/\/.*|<!--.*?-->|#.*/g;
+  const codeTagRegex = /\[!code\s+([^\]]+)\]/;
+
+  for (let i = 0; i < lines.length; i++) {
+    // skip lines if a remove directive is active
+    if (skip > 0) {
+      skip--;
+      continue;
+    }
+
+    let line = lines[i];
+    const comments = [...line.matchAll(commentRegex)];
+
+    let removed = false;
+
+    // process comments to detect [!code ...] directives
+    for (const c of comments) {
+      const match = c[0].match(codeTagRegex);
+      if (match) {
+        // check if directive to remove next N lines
+        const spec = match[1];
+        const removeMatch = spec.match(/^--:(\d+)$/);
+        if (removeMatch) {
+          // set lines to skip
+          skip = parseInt(removeMatch[1], 10) - 1;
+          // current line removed (important if the line is not just a comment but also valid code)
+          removed = true;
+          break;
+        }
+
+        // remove comment if it's not a remove directive
+        line = line.slice(0, c.index) + line.slice(c.index! + c[0].length);
+      }
+    }
+
+    // add line if not removed and line is not empty or has no comments
+    if (!removed && (comments.length === 0 || line.trim() !== "")) {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n').trim();
+}
+
 export async function CodeExample({
   example,
   filename,

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+import { unshiki } from "./code-example";
+
+export function CopyButton({
+  value,
+  className = "",
+}: {
+  value: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (copied) return;
+
+    try {
+      await navigator.clipboard.writeText(unshiki(value));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={clsx("flex items-center rounded-lg transition-colors hover:text-white cursor-pointer", className)}
+      title="Copy to clipboard"
+    >
+      <span className="relative inset-0">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="absolute inset-0 size-4 text-green-400"
+          style={{
+            opacity: copied ? 1 : 0,
+            transition: "opacity 0.3s ease-in-out",
+          }}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="size-4"
+          style={{
+            opacity: copied ? 0 : 1,
+            transition: "opacity 0.3s ease-in-out",
+          }}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+          />
+        </svg>
+      </span>
+    </button>
+  )
+}


### PR DESCRIPTION
Closes #2271

I know there are already a few active PRs (#2222, #2278), but each of them got stuck at some point for various reasons and tries to filter out Shiki comments using different logic.

There are several issues to address:
- we need to be compatible with different comment syntaxes across various languages  
- shiki comments can appear not only on new lines but also inline  
- in the case of inline comments, we don’t want to remove the entire line  
- for diff code, deleted lines aren't needed - after all, that's the point of diff examples  
- it needs to handle the removal of all Shiki comments in a general way, without listing every possible Shiki comment syntax explicitly

For my part, I'm currently using the code shared in this PR - it seems to be working so far:
- the copy button appears even without a code example header  
- it handles diffs correctly  
- it processes `highlight`, `word`, and other expressions properly  
- it works with any kind of code example (bash, css, html, js, ...)

I'm not convinced that this is the best solution to the problem - that's why I hesitated to share it earlier.