### PR TITLE
Improve Negative Values example

### DIFF
--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -548,12 +548,14 @@ To support negative values, register separate positive and negative utilities in
 ```css
 /* [!code filename:CSS] */
 @utility inset-* {
-  inset: calc(var(--spacing) * --value([percentage], [length]));
+  inset: calc(var(--spacing) * --value(integer));
+  inset: --value([percentage], [length]);
 }
 
 /* [!code highlight:4] */
 @utility -inset-* {
-  inset: calc(var(--spacing) * --value([percentage], [length]) * -1);
+  inset: calc(var(--spacing) * --value(integer) * -1);
+  inset: calc(--value([percentage], [length]) * -1);
 }
 ```
 

--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -548,13 +548,13 @@ To support negative values, register separate positive and negative utilities in
 ```css
 /* [!code filename:CSS] */
 @utility inset-* {
-  inset: calc(var(--spacing) * --value(integer));
+  inset: --spacing(--value(integer));
   inset: --value([percentage], [length]);
 }
 
 /* [!code highlight:4] */
 @utility -inset-* {
-  inset: calc(var(--spacing) * --value(integer) * -1);
+  inset: --spacing(--value(integer) * -1);
   inset: calc(--value([percentage], [length]) * -1);
 }
 ```


### PR DESCRIPTION
`<length>` × `<percentage>` or `<length>` × `<length>` in `calc()` is invalid. This makes the example misleading. I've rewritten the example utility with valid examples.