### PR TITLE
Mention that `node_modules` is ignored by default

### DIFF
--- a/src/blog/tailwindcss-v4/index.mdx
+++ b/src/blog/tailwindcss-v4/index.mdx
@@ -199,8 +199,6 @@ For example, we automatically ignore anything in your `.gitignore` file to avoid
 /build
 ```
 
-Additionally, the `node_modules` folder is ignored by default, even if it’s not listed in your `.gitignore`.
-
 We also automatically ignore all binary extensions like images, videos, .zip files, and more.
 
 And if you ever need to explicitly add a source that's excluded by default, you can always add it with the `@source` directive, right in your CSS file:


### PR DESCRIPTION
As of v4.1.0, Tailwind ignores the `node_modules` directory by default, regardless of your `.gitignore` settings.

* https://github.com/tailwindlabs/tailwindcss/blob/main/CHANGELOG.md#410---2025-04-01

> Ignore `node_modules` by default (can be overridden by `@source` … rules) (https://github.com/tailwindlabs/tailwindcss/pull/17255)

This is worth mentioning in the relevant sections of the documentation:

* [Which files are scanned](https://tailwindcss-com-git-fork-rozsazoltan-update-604522-tailwindlabs.vercel.app/docs/detecting-classes-in-source-files#which-files-are-scanned) - Preview