### PR TITLE
Fix hash link in table of contents

### DIFF
--- a/src/blog/tailwindcss-v4-1/index.mdx
+++ b/src/blog/tailwindcss-v4-1/index.mdx
@@ -39,7 +39,7 @@ Here's all the best stuff we got into this release:
 - [Improved compatibility with older browsers](#improved-compatibility-with-older-browsers) — we've made things degrade way more gracefully for older browsers, while still taking advantage of modern features in browsers that support them.
 - [Fine-grained text wrapping with `overflow-wrap`](#fine-grained-text-wrapping-with-overflow-wrap) — defend the integrity of your layouts from even the longest German words your users will throw at you.
 - [Colored `drop-shadow` support](#colored-drop-shadow-support) — can't really remember why we didn't have these before but we do now.
-- [Target input devices with `pointer-*` and `any-pointer-*`](#target-input-devices-with-pointer-and-any-pointer) — tweak your design for touch devices explicitly instead of relying on viewport size.
+- [Target input devices with `pointer-*` and `any-pointer-*`](#target-input-devices-with-pointer-and-any-pointer-) — tweak your design for touch devices explicitly instead of relying on viewport size.
 - [Align items to the last baseline](#align-items-to-the-last-baseline) — align flex or grid items to the baseline of the last line of text using the new `items-baseline-last` and `self-baseline-last` utilities.
 - [Keep content visible with `safe` alignment](#keep-content-visible-with-safe-alignment) — center content in flex and grid layouts without it disappearing when there's not enough space.
 - [Ignore specific paths with `@source not`](#ignore-specific-paths-with-source-not) — explicitly ignore irrelevant large directories and speed up your builds even more.


### PR DESCRIPTION
Fixed a link in a blog post that wasn't correctly pointing to the corresponding section.