### PR TITLE
Prevent infinite compilation loop in Symfony app

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/symfony.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/symfony.tsx
@@ -109,7 +109,8 @@ export let steps: Step[] = [
     title: "Import Tailwind CSS",
     body: (
       <p>
-        Add an <code>@import</code> to <code>./assets/styles/app.css</code> that imports Tailwind CSS, and <code>@source not "../../public";</code> to prevent compilation loops in watch mode.
+        Add an <code>@import</code> to <code>./assets/styles/app.css</code> that imports Tailwind CSS and an{" "}
+        <code>@source</code> that ignores the public dir to prevent recompile loops in watch mode.
       </p>
     ),
     code: {


### PR DESCRIPTION
Related to https://github.com/symfony/webpack-encore/issues/1374

Users in Symfony apps face issues when running Webpack Encore in watch/dev-server mode, because we generates files in `public/`, but Tailwind detects them as source files, and leads to infinite compilation loop.