### PR TITLE
Fix CSS variable syntax in adding-custom-styles docs to use `--spacing`

### DIFF
--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -265,7 +265,7 @@ Traditionally these would be classes like `card`, `btn`, `badge` — that kind o
   .card {
     background-color: var(--color-white);
     border-radius: var(--rounded-lg);
-    padding: var(--spacing-6);
+    padding: --spacing(6);
     box-shadow: var(--shadow-xl);
   }
   /* [!code highlight:2] */

--- a/src/docs/adding-custom-styles.mdx
+++ b/src/docs/adding-custom-styles.mdx
@@ -264,7 +264,7 @@ Traditionally these would be classes like `card`, `btn`, `badge` — that kind o
 @layer components {
   .card {
     background-color: var(--color-white);
-    border-radius: var(--rounded-lg);
+    border-radius: var(--radius-lg);
     padding: --spacing(6);
     box-shadow: var(--shadow-xl);
   }


### PR DESCRIPTION
## Summary
• Fix CSS variable syntax from `var(--spacing-6)` to `--spacing(6)` in custom styles documentation
• Update to align with Tailwind CSS v4 variable syntax conventions

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm the CSS variable syntax matches Tailwind v4 conventions