### PR TITLE
Don’t render Next `<Link>` for `/plus` urls

### DIFF
--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -72,6 +72,10 @@ const components = {
   h6: createHeading(6),
 
   a(props) {
+    if (props.href?.startsWith("/plus") || props.href?.startsWith("https://tailwindcss.com/plus")) {
+      return <a {...props} />;
+    }
+
     return <Link {...(props as React.ComponentProps<typeof Link>)} />;
   },
 


### PR DESCRIPTION
This should hopefully stop all the RSC prefetches from happening on page load.