### PR TITLE
Fix: background-image.mdx

### DIFF
--- a/src/docs/background-image.mdx
+++ b/src/docs/background-image.mdx
@@ -21,7 +21,7 @@ export const description = "Utilities for controlling an element's background im
 <ApiTable
   rows={[
     ["bg-[<value>]", "background-image: <value>;"],
-    ["bg-(image:<custom-property>)", "background-image: var(<custom-property>);"],
+    ["bg-[image:<custom-property>]", "background-image: var(<custom-property>);"],
     ["bg-none", "background-image: none;"],
     ["bg-linear-to-t", "background-image: linear-gradient(to top, var(--tw-gradient-stops));"],
     ["bg-linear-to-tr", "background-image: linear-gradient(to top right, var(--tw-gradient-stops));"],


### PR DESCRIPTION
Custom properties should be wrapped in square brackets rather than parentheses.