### PR TITLE
Fix `justify-stretch` example

### DIFF
--- a/src/docs/justify-content.mdx
+++ b/src/docs/justify-content.mdx
@@ -293,7 +293,7 @@ Use the `justify-stretch` utility to allow auto-sized content items to fill the 
   {
     <div className="grid grid-cols-1">
       <Stripes border className="col-start-1 row-start-1 rounded-lg" />
-      <div className="col-start-1 row-start-1 grid grid-cols-[4rem_auto_4rem] gap-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
+      <div className="col-start-1 row-start-1 grid grid-cols-[4rem_auto_4rem] justify-stretch gap-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
         <div className="flex h-14 items-center justify-center rounded-lg bg-fuchsia-500">01</div>
         <div className="flex h-14 items-center justify-center rounded-lg bg-fuchsia-500">02</div>
         <div className="flex h-14 items-center justify-center rounded-lg bg-fuchsia-500">03</div>


### PR DESCRIPTION
Fixes #2327

The example code showed `flex` but `justify-stretch` only works on grid containers. In flex containers this is controlled with the `grow-*` class.