### PR TITLE
Fix `order-first` and `order-last` in the docs

### DIFF
--- a/src/docs/order.mdx
+++ b/src/docs/order.mdx
@@ -10,8 +10,8 @@ export const description = "Utilities for controlling the order of flex and grid
   rows={[
     ["order-<number>", "order: <number>;"],
     ["-order-<number>", "order: calc(<number> * -1);"],
-    ["order-first", "order: calc(-9999);"],
-    ["order-last", "order: calc(9999);"],
+    ["order-first", "order: -9999;"],
+    ["order-last", "order: 9999;"],
     ["order-none", "order: 0;"],
     ["order-(<custom-property>)", "order: var(<custom-property>);"],
     ["order-[<value>]", "order: <value>;"],


### PR DESCRIPTION
The order-first/last utilities were changed to use `9999` instead of infinity because of FF: https://github.com/tailwindlabs/tailwindcss/pull/16266

Closes #2338