### PR TITLE
Update path in Next.js installation guide

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nextjs.tsx
@@ -74,7 +74,7 @@ export let steps: Step[] = [
     title: "Import Tailwind CSS",
     body: (
       <p>
-        Add an <code>@import</code> to <code>./src/app/globals.css</code> that imports Tailwind CSS.
+        Add an <code>@import</code> to <code>./app/globals.css</code> that imports Tailwind CSS.
       </p>
     ),
     code: {


### PR DESCRIPTION
Hi, as always thanks for Tailwind CSS and the ecosystem! 🙌

I noticed that the docs mentioned a file path starting with `src/app/`, which is inconsistent with the default of `create-next-app`, which is to use the `app/` directory.

Given the simple `npx create-next-app@latest my-project --typescript --eslint --app` command mentioned in [step 1 on the same docs page](https://tailwindcss.com/docs/installation/framework-guides/nextjs), it would ask the following question, defaulting to `No`:

<img width="1080" height="52" alt="Screenshot 2025-08-18 at 18 47 04" src="https://github.com/user-attachments/assets/3a85e750-79b3-458b-b5c0-e3306b0c714b" />

```
Would you like your code inside a `src/` directory?  _No_ / Yes
```