### PR TITLE
Drop `visibility` from `transition` utility

### DIFF
--- a/src/docs/transition-property.mdx
+++ b/src/docs/transition-property.mdx
@@ -12,7 +12,7 @@ export const description = "Utilities for controlling which CSS properties trans
     [
       "transition",
       dedent`
-        transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
+        transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
         transition-timing-function: var(--default-transition-timing-function); /* cubic-bezier(0.4, 0, 0.2, 1) */
         transition-duration: var(--default-transition-duration); /* 150ms */
       `,


### PR DESCRIPTION
See https://github.com/tailwindlabs/tailwindcss/pull/18795

This should be merged since 4.1.13 is out.