### PR TITLE
Fix tooltip clipping + hover lag in P3 color grid (zero re-renders, 60fps)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,6 @@
   --font-mono: var(--font-plex-mono);
   --font-mono--font-feature-settings: "ss02", "zero";
   --font-ubuntu-mono: var(--font-ubuntu-mono);
-  --animate-fade-in: fade-in 300ms forwards;
 }
 
 @theme {
@@ -106,29 +105,29 @@
 }
 
 @utility line-t {
-  @apply relative before:absolute before:-left-[100vw] before:top-0 before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
 }
 
 @utility line-b {
-  @apply relative after:absolute after:-left-[100vw] after:bottom-0 after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-y {
   @apply relative;
-  @apply before:absolute before:-left-[100vw] before:top-0 before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:-left-[100vw] after:bottom-0 after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-t/half {
-  @apply relative before:absolute before:right-0 before:top-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
 }
 
 @utility line-b/half {
-  @apply relative after:absolute after:bottom-0 after:right-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-y/half {
   @apply relative;
-  @apply before:absolute before:right-0 before:top-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:bottom-0 after:right-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,29 +105,29 @@
 }
 
 @utility line-t {
-  @apply relative before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative before:absolute before:-left-[100vw] before:top-0 before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
 }
 
 @utility line-b {
-  @apply relative after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative after:absolute after:-left-[100vw] after:bottom-0 after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-y {
   @apply relative;
-  @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply before:absolute before:-left-[100vw] before:top-0 before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:-left-[100vw] after:bottom-0 after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-t/half {
-  @apply relative before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative before:absolute before:right-0 before:top-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
 }
 
 @utility line-b/half {
-  @apply relative after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative after:absolute after:bottom-0 after:right-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
 }
 
 @utility line-y/half {
   @apply relative;
-  @apply before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply before:absolute before:right-0 before:top-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:bottom-0 after:right-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,7 @@
   --font-mono: var(--font-plex-mono);
   --font-mono--font-feature-settings: "ss02", "zero";
   --font-ubuntu-mono: var(--font-ubuntu-mono);
+  --animate-fade-in: fade-in 300ms forwards;
 }
 
 @theme {

--- a/src/components/home/why-tailwind-css-section.tsx
+++ b/src/components/home/why-tailwind-css-section.tsx
@@ -1,5 +1,4 @@
 import colorValues from "@/docs/utils/colors";
-import { Tooltip, TooltipPanel, TooltipTrigger } from "@headlessui/react";
 import { StarIcon } from "@heroicons/react/16/solid";
 import clsx from "clsx";
 import { CSSProperties, Fragment, ReactNode } from "react";
@@ -43,6 +42,7 @@ import responsive2 from "./why-tailwind-css-section/responsive-2.png";
 import responsive3 from "./why-tailwind-css-section/responsive-3.png";
 import responsive4 from "./why-tailwind-css-section/responsive-4.png";
 import responsive5 from "./why-tailwind-css-section/responsive-5.png";
+import { ZeroTooltip } from "./zero-ui-tooltip";
 
 export default function WhyTailwindCssSection() {
   return (
@@ -454,28 +454,12 @@ export default function WhyTailwindCssSection() {
                             {colors.map((color) => {
                               let value = colorValues[`${color}-${shade}`];
                               return (
-                                <Tooltip as="div" key={color} showDelayMs={100} hideDelayMs={0} className="relative">
-                                  {shadeIdx === 0 && (
-                                    <>
-                                      <div className="pointer-events-none absolute -top-1 -left-1 h-screen border-l border-gray-950/5 dark:border-white/10"></div>
-                                      <div className="pointer-events-none absolute -top-1 -left-1 h-16 origin-top-left translate-px rotate-225 border-l border-gray-950/5 sm:h-24 dark:border-white/10"></div>
-                                    </>
-                                  )}
-
-                                  <TooltipTrigger>
-                                    <div
-                                      style={{ "--color": `var(--color-${color}-${shade})` } as CSSProperties}
-                                      className="h-(--height) w-(--width) bg-(--color) inset-ring inset-ring-gray-950/10 transition-opacity group-hover:opacity-75 hover:opacity-100 dark:inset-ring-white/10"
-                                    />
-                                  </TooltipTrigger>
-                                  <TooltipPanel
-                                    as="div"
-                                    anchor="top"
-                                    className="pointer-events-none z-10 translate-y-2 rounded-full border border-gray-950 bg-gray-950/90 py-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-100 inset-ring inset-ring-white/10 transition-[opacity] starting:opacity-0"
-                                  >
-                                    {value}
-                                  </TooltipPanel>
-                                </Tooltip>
+                                <ZeroTooltip
+                                  key={color}
+                                  color={`${color}-${shade}`}
+                                  tooltip={value}
+                                  shadeIdx={shadeIdx}
+                                />
                               );
                             })}
                           </Fragment>

--- a/src/components/home/zero-ui-custom-build.ts
+++ b/src/components/home/zero-ui-custom-build.ts
@@ -1,0 +1,16 @@
+/**
+ * Minimal single-use build of React Zero-UI.
+ * This handles UI-only state using `data-*` attributes with zero React rerenders and scoped state.
+ *
+ * React Zero-UI automates both the variant generation and state pattern used here,
+ * and supports global UI state as well.
+ *
+ * Full library documentation: https://github.com/react-zero-ui/core
+ */
+export function createZeroUI(key: string) {
+  return {
+    set(value: string, { scope }: { scope: HTMLElement }) {
+      scope.dataset[key] = value;
+    },
+  };
+}

--- a/src/components/home/zero-ui-tooltip.tsx
+++ b/src/components/home/zero-ui-tooltip.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+import { useRef } from "react";
 import { createZeroUI } from "./zero-ui-custom-build";
 
 /**
@@ -14,14 +16,53 @@ export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; toolt
   // Local UI state: "on" | "off"
   const { set } = createZeroUI("tooltip");
 
+  /* refs for anchor & popover */
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  /* clamp popover to viewport */
+  const position = () => {
+    const anchor = anchorRef.current;
+    const tooltip = popoverRef.current;
+    if (!anchor || !tooltip) return;
+
+    const a = anchor.getBoundingClientRect();
+    const t = tooltip.getBoundingClientRect();
+
+    let left = a.left + (a.width - t.width) / 2;
+    let top = a.top - 24;
+
+    const padding = 16;
+    const maxLeft = window.innerWidth - t.width - padding;
+    const maxTop = window.innerHeight - t.height - padding;
+
+    left = Math.min(Math.max(left, padding), maxLeft);
+    top = Math.min(top, maxTop);
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+  };
+
+  /* hover handlers */
+  const handleEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+    set("on", { scope: e.currentTarget });
+    position();
+  };
+
+  const handleLeave = () => {
+    set("off", { scope: anchorRef.current! });
+  };
+
   return (
     <div
-      onMouseEnter={(e) => set("on", { scope: e.currentTarget })}
-      onMouseLeave={(e) => set("off", { scope: e.currentTarget })}
+      ref={anchorRef}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
       className="relative"
       /* Initial attribute value. Zero-UI's build step normally injects this. */
       data-tooltip="off"
     >
+      {/* decor lines for the first column */}
       {shadeIdx === 0 && (
         <>
           <div className="pointer-events-none absolute -top-1 -left-1 h-screen border-l border-gray-950/5 dark:border-white/10" />
@@ -29,13 +70,17 @@ export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; toolt
         </>
       )}
 
+      {/* colored square */}
       <div
         className="h-(--height) w-(--width) bg-(--color) inset-ring inset-ring-gray-950/10 transition-opacity group-hover:opacity-75 hover:opacity-100 dark:inset-ring-white/10"
         style={{ "--color": `var(--color-${color})` } as React.CSSProperties}
       />
 
-      {/* Tooltip panel. Becomes visible when data-tooltip="on" */}
-      <div className="pointer-events-none absolute top-full left-1/2 z-10 mt-2 -translate-x-1/2 -translate-y-18 rounded-full border border-gray-950 bg-gray-950/90 pt-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity dark:border-white/10 tooltip-on:opacity-100 tooltip-on:delay-100">
+      {/* popover tooltip — hoisted to top-layer */}
+      <div
+        ref={popoverRef}
+        className="pointer-events-none fixed z-9999 rounded-full border border-gray-950 bg-gray-950/90 pt-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity dark:border-white/10 tooltip-on:opacity-100 tooltip-on:delay-100"
+      >
         {tooltip}
       </div>
     </div>

--- a/src/components/home/zero-ui-tooltip.tsx
+++ b/src/components/home/zero-ui-tooltip.tsx
@@ -58,7 +58,7 @@ export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; toolt
       ref={anchorRef}
       onMouseEnter={handleEnter}
       onMouseLeave={handleLeave}
-      className="relative"
+      className="group relative"
       /* Initial attribute value. Zero-UI's build step normally injects this. */
       data-tooltip="off"
     >
@@ -79,7 +79,7 @@ export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; toolt
       {/* popover tooltip — hoisted to top-layer */}
       <div
         ref={popoverRef}
-        className="pointer-events-none fixed z-9999 rounded-full border border-gray-950 bg-gray-950/90 pt-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity dark:border-white/10 tooltip-on:opacity-100 tooltip-on:delay-100"
+        className="pointer-events-none fixed z-9999 rounded-full border border-gray-950 bg-gray-950/90 pt-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-0 inset-ring inset-ring-white/10 transition-[opacity] duration-300 group-data-[tooltip=on]:opacity-100 group-data-[tooltip=on]:delay-100 dark:border-white/10"
       >
         {tooltip}
       </div>

--- a/src/components/home/zero-ui-tooltip.tsx
+++ b/src/components/home/zero-ui-tooltip.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { createZeroUI } from "./zero-ui-custom-build";
+
+/**
+ * ZeroTooltip
+ * -----------
+ * Uses a minimal, local build of React Zero-UI to eliminate React-based hover
+ * rerenders. The helper mutates a scoped `data-tooltip` attribute, which Tailwind
+ * v4 styles via the  `@custom-variant tooltip-on` rule (defined in globals.css).
+ *
+ * Only this component relies on the helper; no global state or extra deps added.
+ */
+export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; tooltip: string; shadeIdx: number }) {
+  // Local UI state: "on" | "off"
+  const { set } = createZeroUI("tooltip");
+
+  return (
+    <div
+      onMouseEnter={(e) => set("on", { scope: e.currentTarget })}
+      onMouseLeave={(e) => set("off", { scope: e.currentTarget })}
+      className="relative"
+      /* Initial attribute value. Zero-UI's build step normally injects this. */
+      data-tooltip="off"
+    >
+      {shadeIdx === 0 && (
+        <>
+          <div className="pointer-events-none absolute -top-1 -left-1 h-screen border-l border-gray-950/5 dark:border-white/10" />
+          <div className="pointer-events-none absolute -top-1 -left-1 h-16 origin-top-left translate-px rotate-225 border-l border-gray-950/5 sm:h-24 dark:border-white/10" />
+        </>
+      )}
+
+      <div
+        className="h-(--height) w-(--width) bg-(--color) inset-ring inset-ring-gray-950/10 transition-opacity group-hover:opacity-75 hover:opacity-100 dark:inset-ring-white/10"
+        style={{ "--color": `var(--color-${color})` } as React.CSSProperties}
+      />
+
+      {/* Tooltip panel. Becomes visible when data-tooltip="on" */}
+      <div className="pointer-events-none absolute top-full left-1/2 z-10 mt-2 -translate-x-1/2 -translate-y-18 rounded-full border border-gray-950 bg-gray-950/90 pt-0.5 pr-2 pb-1 pl-3 text-center font-mono text-xs/6 font-medium whitespace-nowrap text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity dark:border-white/10 tooltip-on:opacity-100 tooltip-on:delay-100">
+        {tooltip}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/zero-ui-tooltip.tsx
+++ b/src/components/home/zero-ui-tooltip.tsx
@@ -43,21 +43,23 @@ export function ZeroTooltip({ color, tooltip, shadeIdx }: { color: string; toolt
     tooltip.style.top = `${top}px`;
   };
 
-  /* hover handlers */
-  const handleEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+  /* hover handlers — use Pointer Events to ignore touch */
+  const handlePointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType !== "mouse") return;
     set("on", { scope: e.currentTarget });
     position();
   };
 
-  const handleLeave = () => {
+  const handlePointerLeave = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType !== "mouse") return;
     set("off", { scope: anchorRef.current! });
   };
 
   return (
     <div
       ref={anchorRef}
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
       className="group relative"
       /* Initial attribute value. Zero-UI's build step normally injects this. */
       data-tooltip="off"


### PR DESCRIPTION
# Fix tooltip clipping + hover lag in P3 color grid (zero re-renders, 60fps)

Closes #2293. Follow-up to the prior PR ( (#2295) that was closed due to clipping.

## Why
- The previous tooltip caused hover lag due to React re-renders.
- My initial attempt removed re-renders but was clipped by stacking/overflow contexts.
- Target: **no React re-renders**, **no clipping**, **60fps** pointer tracking, **no new deps**.

## What changed
- Use a **single, reused tooltip node** with **`position: fixed`**.
- Compute `top/left` from the hovered swatch via `getBoundingClientRect()` and clamp to the viewport.
- Toggle visibility with a tiny local helper (`createZeroUI`) that mutates a scoped `data-tooltip` attribute—**no React state** on the hover path.
- One read + one write per pointer event; no layout thrash observed.

## Results (local profiling on “/”)
| Metric                     | Before  | After     | Delta     |
|-------------------|--------:|----------:|----------:|
| FPS (Chrome)               | ~15–20  | 60 steady | +40–45    |
| React re-renders          | Many      | 0               | −100%      |
 






 