### PR TITLE
fix: improve color contrast on homepage utility class indicators for …

### DIFF
--- a/src/components/home/build-anything-section.tsx
+++ b/src/components/home/build-anything-section.tsx
@@ -24,7 +24,7 @@ export default function BuildAnythingSection() {
     <div className="relative max-w-full">
       <div
         aria-hidden="true"
-        className="h-6 max-w-screen items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 2xl:flex dark:text-white/25"
+        className="h-6 max-w-screen items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 2xl:flex dark:text-white/50"
       >
         text-4xl <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> tracking-tighter
@@ -40,7 +40,7 @@ export default function BuildAnythingSection() {
         </h2>
       </GridContainer>
 
-      <div className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25">
+      <div className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50">
         text-base <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span>
       </div>

--- a/src/components/home/explainer-section.tsx
+++ b/src/components/home/explainer-section.tsx
@@ -104,7 +104,7 @@ export default function ExplainerSection() {
     <div className="relative max-w-full">
       <div
         aria-hidden="true"
-        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/25"
+        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/50"
       >
         text-4xl <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> tracking-tighter text-balance
@@ -120,7 +120,7 @@ export default function ExplainerSection() {
         </h2>
       </GridContainer>
 
-      <div className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25">
+      <div className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50">
         text-base <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span>
       </div>

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -51,7 +51,7 @@ const Hero: React.FC = () => {
     <div>
       <div
         aria-hidden="true"
-        className="flex h-16 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-24 dark:text-white/25"
+        className="flex h-16 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-24 dark:text-white/50"
       >
         <span className="hidden max-sm:inline">text-4xl </span>
         <span className="hidden sm:max-md:inline">text-5xl </span>
@@ -68,7 +68,7 @@ const Hero: React.FC = () => {
       </GridContainer>
       <div
         aria-hidden="true"
-        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25"
+        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50"
       >
         text-lg <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> font-medium

--- a/src/components/home/partners-section.tsx
+++ b/src/components/home/partners-section.tsx
@@ -28,7 +28,7 @@ export default function WhyTailwindCssSection() {
     <div className="relative max-w-full">
       <div
         aria-hidden="true"
-        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/25"
+        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/50"
       >
         text-4xl <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> tracking-tighter text-balance
@@ -46,7 +46,7 @@ export default function WhyTailwindCssSection() {
 
       <div
         aria-hidden="true"
-        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25"
+        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50"
       >
         text-base <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span>

--- a/src/components/home/tailwind-ui-section.tsx
+++ b/src/components/home/tailwind-ui-section.tsx
@@ -62,7 +62,7 @@ export default function TailwindUiSection() {
     <div className="relative max-w-full">
       <div
         aria-hidden="true"
-        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/25"
+        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/50"
       >
         text-4xl <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> tracking-tighter text-balance
@@ -80,7 +80,7 @@ export default function TailwindUiSection() {
 
       <div
         aria-hidden="true"
-        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25"
+        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50"
       >
         text-base <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span>

--- a/src/components/home/why-tailwind-css-section.tsx
+++ b/src/components/home/why-tailwind-css-section.tsx
@@ -49,7 +49,7 @@ export default function WhyTailwindCssSection() {
     <div className="relative max-w-full">
       <div
         aria-hidden="true"
-        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/25"
+        className="hidden h-4 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 2xl:visible 2xl:flex dark:text-white/50"
       >
         text-4xl <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span> tracking-tighter text-balance
@@ -67,7 +67,7 @@ export default function WhyTailwindCssSection() {
 
       <div
         aria-hidden="true"
-        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-10 dark:text-white/25"
+        className="flex h-6 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/55 max-sm:px-4 sm:h-10 dark:text-white/50"
       >
         text-base <span className="inline dark:hidden">text-gray-950</span>
         <span className="hidden dark:inline">text-white</span>


### PR DESCRIPTION
Fixes #2347 

# Fix color contrast issues on homepage utility class indicators

## Description
This PR improves the color contrast of utility class indicators throughout the homepage to meet WCAG accessibility standards. By increasing the opacity of text, we achieve AA-compliant contrast ratios in both light and dark modes, making the site more accessible for users with visual impairments.

## Changes made
- Increased text opacity from 20% to 55% in light mode (achieving 4.75:1 contrast ratio)
- Increased text opacity from 25% to 50% in dark mode (achieving 5.3:1 contrast ratio)
- Updated all utility class indicators across homepage components:
  - Hero
  - PartnersSection
  - WhyTailwindCssSection
  - ExplainerSection
  - BuildAnythingSection
  - TailwindUiSection

## Why this matters
While these elements have `aria-hidden="true"` (correctly hiding them from screen readers), they're still visible to users with visual impairments who don't use screen readers. Meeting WCAG contrast requirements ensures these users can still perceive the content.

## Testing completed
- Verified using Axe DevTools that the contrast issues are resolved
- Tested in both light and dark modes
- Ensured the subtle design aesthetic is maintained while improving accessibility

