### PR TITLE
fix background-image api map error

### DIFF
--- a/src/docs/background-image.mdx
+++ b/src/docs/background-image.mdx
@@ -47,7 +47,7 @@ export const description = "Utilities for controlling an element's background im
     ["bg-conic-<angle>", "background-image: conic-gradient(from <angle> in oklab, var(--tw-gradient-stops));"],
     ["-bg-conic-<angle>", "background-image: conic-gradient(from -<angle> in oklab, var(--tw-gradient-stops));"],
     ["bg-conic-(<custom-property>)", "background-image: var(<custom-property>);"],
-    ["bg-conic-[<value>]", "background-image: <image>;"],
+    ["bg-conic-[<value>]", "background-image: <value>;"],
     ["from-<color>", "--tw-gradient-from: <color>;"],
     ["from-<percentage>", "--tw-gradient-from-position: <percentage>;"],
     ["from-(<custom-property>)", "--tw-gradient-from: var(<custom-property>);"],


### PR DESCRIPTION
According to the API map above, I thought this part should be `<value>` instead of `<image>`.