### PR TITLE
fix: Docs sidebar auto-scroll not working on page navigation

### DIFF
--- a/src/components/docs-sidebar-autoscroll.tsx
+++ b/src/components/docs-sidebar-autoscroll.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useLayoutEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 
 export function DocsSidebarAutoscroll({ children }: { children: React.ReactNode }) {
   let ref = useRef<HTMLDivElement>(null);
+  let pathname = usePathname();
 
   useLayoutEffect(() => {
     let element = ref.current;
@@ -17,7 +19,7 @@ export function DocsSidebarAutoscroll({ children }: { children: React.ReactNode 
     } else {
       activeLink.scrollIntoView();
     }
-  }, []);
+  }, [pathname]);
 
   return <div ref={ref}>{children}</div>;
 }


### PR DESCRIPTION
Previously, when navigating between documentation pages using the `command palette (⌘K)`, the sidebar would not automatically scroll to highlight the current page location. This made it difficult to maintain context of where you were in the documentation structure.

This PR enhances the `DocsSidebarAutoscroll` component to respond to navigation changes by:
- Adding pathname dependency to useLayoutEffect
- Making the sidebar auto-scroll to the active page whenever navigation occurs
- Maintaining the same smooth scrolling behavior as the initial page load

Now the sidebar will properly scroll to the current documentation page regardless of how you navigate to it - whether through direct clicks or command palette navigation.