### PR TITLE
fix: indicate which template to use when installing on vite

### DIFF
--- a/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/using-vite/page.tsx
@@ -22,7 +22,7 @@ const steps: Step[] = [
     body: (
       <p>
         Start by creating a new Vite project if you don’t have one set up already. The most common approach is to use{" "}
-        <a href="https://vite.dev/guide/#scaffolding-your-first-vite-project">Create Vite</a>.
+        <a href="https://vite.dev/guide/#scaffolding-your-first-vite-project">Create Vite</a>. Be sure to select the <strong>Vanilla</strong> template when asked. 
       </p>
     ),
     code: {


### PR DESCRIPTION
This change tells the user to use the **Vanilla** vite template to install Tailwind. The installation steps in this section will not work with other Vite examples.