### PR TITLE
Improve `place-content` wording by referencing the correct axis

### DIFF
--- a/src/docs/place-content.mdx
+++ b/src/docs/place-content.mdx
@@ -154,7 +154,7 @@ Use `place-content-between` to distribute grid items along the inline and block 
 
 ### Space around
 
-Use `place-content-around` to distribute grid items such that there is an equal amount of space around each row on the inline axis and each column on the block axis:
+Use `place-content-around` to distribute grid items along the inline and block axes so that there is an equal amount of space around each row and column on each axis respectively:
 
 <Figure>
 


### PR DESCRIPTION
This PR fixes an issue where we were only using `block axis` in the `place-content` property docs, but the `place-content` property works on both the inline axis and the block axis.

This PR now references both the inline axis and block axis. This now also talks about the difference between rows and columns because we only talked about rows before.

Fixes: https://github.com/tailwindlabs/tailwindcss.com/issues/2357
