### PR TITLE
Replace misleading "aspect-ratio-video" var with correct "aspect-video"

### DIFF
--- a/src/docs/aspect-ratio.mdx
+++ b/src/docs/aspect-ratio.mdx
@@ -10,7 +10,7 @@ export const description = "Utilities for controlling the aspect ratio of an ele
   rows={[
     ["aspect-<ratio>", "aspect-ratio: <ratio>;"],
     ["aspect-square", "aspect-ratio: 1 / 1;"],
-    ["aspect-video", "aspect-ratio: var(--aspect-ratio-video); /* 16 / 9 */"],
+    ["aspect-video", "aspect-ratio: var(--aspect-video); /* 16 / 9 */"],
     ["aspect-auto", "aspect-ratio: auto;"],
     ["aspect-(<custom-property>)", "aspect-ratio: var(<custom-property>);"],
     ["aspect-[<value>]", "aspect-ratio: <value>;"],


### PR DESCRIPTION
As seen on https://github.com/tailwindlabs/tailwindcss/blob/496a1e93622789b121aeb608e0c6a07e35abeb0c/packages/tailwindcss/theme.css#L442, the aspect-video utility uses the aspect-video variable.