### PR TITLE
Add logical properties section to `text-align` docs

### DIFF
--- a/src/docs/text-align.mdx
+++ b/src/docs/text-align.mdx
@@ -148,8 +148,11 @@ Use the `text-start` and `text-end` utilities, which use [logical properties](ht
 </Example>
 
 ```html
+<!-- [!code word:dir="rtl"] -->
 <!-- [!code classes:text-end] -->
-<p class="text-end">فبدأت بالسير نحو الماء...</p>
+<div dir="rtl" lang="ar">
+  <p class="text-end">فبدأت بالسير نحو الماء...</p>
+</div>
 ```
 
 </Figure>


### PR DESCRIPTION
Added examples for text alignment utilities in LTR and RTL contexts for `text-start` and `text-end` classes