### PR TITLE
Fix incorrect CSS config path example in Nuxt 4 framework guide

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
@@ -105,7 +105,7 @@ export let steps: Step[] = [
           compatibilityDate: "2025-07-15",
           devtools: { enabled: true },
           // [!code highlight:2]
-          css: ['~/assets/css/main.css'],
+          css: ['./app/assets/css/main.css'],
           vite: {
             plugins: [
               tailwindcss(),


### PR DESCRIPTION
In #2309, the Nuxt framework guide was updated to be compatible with Nuxt 4. The `css` config path was updated in the instructions on this page, but not also in the code example. This change updates the code example to also use the new path compatible with Nuxt 4 ("./app/assets/css/main.css" instead of "~/assets/css/main.css").

### Before

https://tailwindcss.com/docs/installation/framework-guides/nuxt

<img width="1146" height="654" alt="Screenshot-Install Tailwind CSS with Nuxt - Tailwind CSS-2025-10-25-09-46-36" src="https://github.com/user-attachments/assets/045d43fd-6cca-4ac9-892f-3694da138fa4" />

### After

<img width="1160" height="674" alt="Screenshot-Install Tailwind CSS with Nuxt - Tailwind CSS-2025-10-25-09-46-29" src="https://github.com/user-attachments/assets/608f1fb0-d1fa-4b8e-806d-67f284871091" />