### PR TITLE
fix: missing stone-950 on default theme variables

### DIFF
--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -922,6 +922,7 @@ For reference, here's a complete list of the theme variables included by default
   --color-stone-700: oklch(37.4% 0.01 67.558);
   --color-stone-800: oklch(26.8% 0.007 34.298);
   --color-stone-900: oklch(21.6% 0.006 56.043);
+  --color-stone-950: oklch(14.7% 0.004 49.25);
 
   --color-black: #000;
   --color-white: #fff;


### PR DESCRIPTION
There were no `stone-950` on the default theme token
<img width="1635" height="1033" alt="image" src="https://github.com/user-attachments/assets/49044228-32c6-4f53-a93e-f037f2268cf0" />
