### PR TITLE
docs: update sr-only utility to use clip-path inset(50%)

### DIFF
--- a/src/docs/display.mdx
+++ b/src/docs/display.mdx
@@ -40,7 +40,7 @@ export const description = "Utilities for controlling the display box type of an
         padding: 0;
         margin: -1px;
         overflow: hidden;
-        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
         white-space: nowrap;
         border-width: 0;
       `,


### PR DESCRIPTION
This updates the sr-only documentation to match the current implementation in Tailwind CSS, replacing the legacy clip property with clip-path: inset(50%).