### PR TITLE
Add reduced motion section to `transition-duration` and `transition-delay` docs

### DIFF
--- a/src/docs/transition-delay.mdx
+++ b/src/docs/transition-delay.mdx
@@ -56,6 +56,17 @@ Use utilities like `delay-150` and `delay-700` to set the transition delay of an
 
 </Figure>
 
+### Supporting reduced motion
+
+For situations where the user has specified that they prefer reduced motion, you can conditionally apply animations and transitions using the `motion-safe` and `motion-reduce` variants:
+
+```html
+<!-- [!code classes:motion-reduce:delay-0] -->
+<button type="button" class="delay-300 motion-reduce:delay-0 ...">
+  <!-- ... -->
+</button>
+```
+
 ### Using a custom value
 
 <UsingACustomValue element="button" utility="delay" value="1s,250ms" name="transition delay" />
@@ -63,15 +74,3 @@ Use utilities like `delay-150` and `delay-700` to set the transition delay of an
 ### Responsive design
 
 <ResponsiveDesign element="button" property="transition-delay" defaultClass="delay-150" featuredClass="delay-300" />
-
-### Supporting reduced motion
-
-For situations where the user has specified that they prefer reduced motion, you can conditionally apply transition-delay using the `motion-safe` and `motion-reduce` variants:
-
-```html
-<!-- [!code classes:motion-reduce:delay-0] -->
-<!-- prettier-ignore -->
-<button class="delay-300 motion-reduce:delay-0 ...">
-  <!-- ... -->
-</button>
-```

--- a/src/docs/transition-duration.mdx
+++ b/src/docs/transition-duration.mdx
@@ -57,6 +57,17 @@ Use utilities like `duration-150` and `duration-700` to set the transition durat
 
 </Figure>
 
+### Supporting reduced motion
+
+For situations where the user has specified that they prefer reduced motion, you can conditionally apply animations and transitions using the `motion-safe` and `motion-reduce` variants:
+
+```html
+<!-- [!code classes:motion-reduce:duration-0] -->
+<button type="button" class="duration-300 motion-reduce:duration-0 ...">
+  <!-- ... -->
+</button>
+```
+
 ### Using a custom value
 
 <UsingACustomValue element="button" utility="duration" value="1s,15s" name="transition duration" />
@@ -69,15 +80,3 @@ Use utilities like `duration-150` and `duration-700` to set the transition durat
   defaultClass="duration-0"
   featuredClass="duration-150"
 />
-
-### Supporting reduced motion
-
-For situations where the user has specified that they prefer reduced motion, you can conditionally apply transition-duration using the `motion-safe` and `motion-reduce` variants:
-
-```html
-<!-- [!code classes:motion-reduce:duration-0] -->
-<!-- prettier-ignore -->
-<button class="duration-300 motion-reduce:duration-0 ...">
-  <!-- ... -->
-</button>
-```


### PR DESCRIPTION
Currently, both the [transition-duration](https://tailwindcss.com/docs/transition-duration) and the [transition-delay](https://tailwindcss.com/docs/transition-delay) have a very good structure and clear content.

However, while they have additional information about responsive design, they lack an accessibility sections. The two docs should include a11y best practice, with code examples.
