### PR TITLE
Add logical properties examples to `text-align` doc

### DIFF
--- a/src/docs/text-align.mdx
+++ b/src/docs/text-align.mdx
@@ -133,14 +133,14 @@ Use the `text-justify` utility to justify the text of an element:
 
 ### Using logical properties
 
-Use the `rtl` variant to conditionally add styles in right-to-left and left-to-right when building multi-directional layouts:
+Use the `rtl` variant to conditionally add styles for both right-to-left and left-to-right, when building multi-directional layouts:
 
 ```html
 <!-- [!code classes:rtl:text-right] -->
 <p class="text-left rtl:text-right">So I started to walk into the water...</p>
 ```
 
-Alternatively, you can use the `text-start` and `text-end` logical utilities, to align the text either the left or right side based on the writing direction:
+Alternatively, you can use the `text-start` and `text-end` logical utilities, to let the browser align the text either the left or right side based on the writing direction:
 
 <Figure>
 


### PR DESCRIPTION
Currently, the `text-align` [doc](https://tailwindcss.com/docs/text-align) has only utilities for physical properties (`text-left` and `text-right`). It should also provide examples for bi-directional layouts.

This PR adds example of `rtl` variant, and the text align logical utilities (`text-start` and `text-end`).