### PR TITLE
Fix RTL issue in Tables with direction agnostic examples for bidirectional layouts

### DIFF
--- a/src/components/api-table.tsx
+++ b/src/components/api-table.tsx
@@ -73,8 +73,8 @@ export function ApiTable({ rows }: { rows: [string, string][] }) {
         <table className="grid w-full grid-cols-[auto_auto] border-b border-gray-900/10 dark:border-white/10">
           <thead className="col-span-2 grid grid-cols-subgrid">
             <tr className="col-span-2 grid grid-cols-subgrid">
-              <th className="px-2 py-2.5 text-left text-sm/7 font-semibold text-gray-950 dark:text-white">Class</th>
-              <th className="px-2 py-2.5 text-left text-sm/7 font-semibold text-gray-950 dark:text-white">Styles</th>
+              <th className="px-2 py-2.5 text-start text-sm/7 font-semibold text-gray-950 dark:text-white">Class</th>
+              <th className="px-2 py-2.5 text-start text-sm/7 font-semibold text-gray-950 dark:text-white">Styles</th>
             </tr>
           </thead>
           <tbody className="col-span-2 grid grid-cols-subgrid border-t border-gray-900/10 dark:border-white/10">

--- a/src/docs/border-collapse.mdx
+++ b/src/docs/border-collapse.mdx
@@ -27,10 +27,10 @@ Use the `border-collapse` utility to combine adjacent cell borders into a single
       <table className="w-full border-collapse border border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               State
             </th>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               City
             </th>
           </tr>
@@ -106,10 +106,10 @@ Use the `border-separate` utility to force each cell to display its own separate
       <table className="w-full border-separate border border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               State
             </th>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               City
             </th>
           </tr>

--- a/src/docs/border-spacing.mdx
+++ b/src/docs/border-spacing.mdx
@@ -34,10 +34,10 @@ Use `border-spacing-<number>` utilities like `border-spacing-2` and `border-spac
       <table className="w-full border-separate border-spacing-2 border border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               State
             </th>
-            <th className="w-1/2 border border-gray-300 p-4 text-left font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
+            <th className="w-1/2 border border-gray-300 p-4 text-start font-semibold text-gray-900 dark:border-gray-600 dark:text-gray-200">
               City
             </th>
           </tr>

--- a/src/docs/caption-side.mdx
+++ b/src/docs/caption-side.mdx
@@ -30,36 +30,36 @@ Use the `caption-top` utility to position a caption element at the top of a tabl
         </caption>
         <thead>
           <tr>
-            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pl-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+            <th className="border border-gray-200 bg-gray-50 p-4 py-3 ps-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
               Wrestler
             </th>
-            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pr-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pe-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
               Signature Move(s)
             </th>
           </tr>
         </thead>
         <tbody className="bg-white dark:bg-gray-800">
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               "Stone Cold" Steve Austin
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Stone Cold Stunner, Lou Thesz Press
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Bret "The Hitman" Hart
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               The Sharpshooter
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Razor Ramon
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Razor's Edge, Fallaway Slam
             </td>
           </tr>
@@ -115,36 +115,36 @@ Use the `caption-bottom` utility to position a caption element at the bottom of 
         </caption>
         <thead>
           <tr>
-            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pl-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+            <th className="border border-gray-200 bg-gray-50 p-4 py-3 ps-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
               Wrestler
             </th>
-            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pr-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+            <th className="border border-gray-200 bg-gray-50 p-4 py-3 pe-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
               Signature Move(s)
             </th>
           </tr>
         </thead>
         <tbody className="bg-white dark:bg-gray-800">
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               "Stone Cold" Steve Austin
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Stone Cold Stunner, Lou Thesz Press
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Bret "The Hitman" Hart
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               The Sharpshooter
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Razor Ramon
             </td>
-            <td className="border border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Razor's Edge, Fallaway Slam
             </td>
           </tr>

--- a/src/docs/display.mdx
+++ b/src/docs/display.mdx
@@ -379,48 +379,48 @@ Use the `table`, `table-row`, `table-cell`, `table-caption`, `table-column`, `ta
       <div className="table w-full table-auto border-collapse text-sm">
         <div className="table-header-group">
           <div className="table-row">
-            <div className="table-cell border-b border-gray-200 p-4 pt-0 pb-3 pl-8 text-left font-medium text-gray-400 dark:border-white/20 dark:text-white">
+            <div className="table-cell border-b border-gray-200 p-4 pt-0 pb-3 ps-8 text-start font-medium text-gray-400 dark:border-white/20 dark:text-white">
               Song
             </div>
-            <div className="table-cell border-b border-gray-200 p-4 pt-0 pb-3 text-left font-medium text-gray-400 dark:border-white/20 dark:text-white">
+            <div className="table-cell border-b border-gray-200 p-4 pt-0 pb-3 text-start font-medium text-gray-400 dark:border-white/20 dark:text-white">
               Artist
             </div>
-            <div className="table-cell border-b border-gray-200 p-4 pt-0 pr-8 pb-3 text-left font-medium text-gray-400 dark:border-white/20 dark:text-white">
+            <div className="table-cell border-b border-gray-200 p-4 pt-0 pe-8 pb-3 text-start font-medium text-gray-400 dark:border-white/20 dark:text-white">
               Year
             </div>
           </div>
         </div>
         <div className="table-row-group dark:bg-black/5">
           <div className="table-row">
-            <div className="table-cell border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
               The Sliding Mr. Bones (Next Stop, Pottersville)
             </div>
             <div className="table-cell border-b border-gray-100 p-4 text-gray-500 dark:border-white/10 dark:text-gray-300">
               Malcolm Lockyer
             </div>
-            <div className="table-cell border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
               1961
             </div>
           </div>
           <div className="table-row">
-            <div className="table-cell border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
               Witchy Woman
             </div>
             <div className="table-cell border-b border-gray-100 p-4 text-gray-500 dark:border-white/10 dark:text-gray-300">
               The Eagles
             </div>
-            <div className="table-cell border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-white/10 dark:text-gray-300">
               1972
             </div>
           </div>
           <div className="table-row">
-            <div className="table-cell border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-white/20 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-white/20 dark:text-gray-300">
               Shining Star
             </div>
             <div className="table-cell border-b border-gray-100 p-4 text-gray-500 dark:border-white/20 dark:text-gray-300">
               Earth, Wind, and Fire
             </div>
-            <div className="table-cell border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-white/20 dark:text-gray-300">
+            <div className="table-cell border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-white/20 dark:text-gray-300">
               1975
             </div>
           </div>
@@ -435,9 +435,9 @@ Use the `table`, `table-row`, `table-cell`, `table-caption`, `table-column`, `ta
 <div class="table w-full ...">
   <div class="table-header-group ...">
     <div class="table-row">
-      <div class="table-cell text-left ...">Song</div>
-      <div class="table-cell text-left ...">Artist</div>
-      <div class="table-cell text-left ...">Year</div>
+      <div class="table-cell text-start ...">Song</div>
+      <div class="table-cell text-start ...">Artist</div>
+      <div class="table-cell text-start ...">Year</div>
     </div>
   </div>
   <div class="table-row-group">

--- a/src/docs/hover-focus-and-other-states.mdx
+++ b/src/docs/hover-focus-and-other-states.mdx
@@ -213,13 +213,13 @@ You can also style an element when it's an odd or even child using the `odd` and
               <table className="min-w-full">
                 <thead className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-950">
                   <tr>
-                    <th scope="col" className="px-6 py-3 text-left text-sm font-medium text-gray-900 dark:text-white">
+                    <th scope="col" className="px-6 py-3 text-start text-sm font-medium text-gray-900 dark:text-white">
                       Name
                     </th>
-                    <th scope="col" className="px-6 py-3 text-left text-sm font-medium text-gray-900 dark:text-white">
+                    <th scope="col" className="px-6 py-3 text-start text-sm font-medium text-gray-900 dark:text-white">
                       Title
                     </th>
-                    <th scope="col" className="px-6 py-3 text-left text-sm font-medium text-gray-900 dark:text-white">
+                    <th scope="col" className="px-6 py-3 text-start text-sm font-medium text-gray-900 dark:text-white">
                       Email
                     </th>
                   </tr>
@@ -2248,7 +2248,7 @@ If you need to use a one-off `aria` variant that doesn’t make sense to include
         <thead className="bg-gray-50 dark:bg-white/5">
           <tr>
             <th
-              className="group border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200"
+              className="group border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200"
               aria-sort="ascending"
             >
               <span className="flex w-full items-center justify-between gap-2">
@@ -2265,10 +2265,10 @@ If you need to use a one-off `aria` variant that doesn’t make sense to include
                 </svg>
               </span>
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200">
               Client
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-right font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-end font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-200">
               Amount
             </th>
           </tr>
@@ -2281,7 +2281,7 @@ If you need to use a one-off `aria` variant that doesn’t make sense to include
             <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               Pendant Publishing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               $2,000.00
             </td>
           </tr>
@@ -2292,7 +2292,7 @@ If you need to use a one-off `aria` variant that doesn’t make sense to include
             <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               Kruger Industrial Smoothing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               $545.00
             </td>
           </tr>
@@ -2303,7 +2303,7 @@ If you need to use a one-off `aria` variant that doesn’t make sense to include
             <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               J. Peterman
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-white/10 dark:text-gray-400">
               $10,000.25
             </td>
           </tr>

--- a/src/docs/table-layout.mdx
+++ b/src/docs/table-layout.mdx
@@ -27,48 +27,48 @@ Use the `table-auto` utility to automatically size table columns to fit the cont
       <table className="w-full table-auto border-collapse text-sm">
         <thead>
           <tr>
-            <th className="border-b border-gray-200 p-4 pt-0 pb-3 pl-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 ps-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Song
             </th>
-            <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Artist
             </th>
-            <th className="border-b border-gray-200 p-4 pt-0 pr-8 pb-3 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 pe-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Year
             </th>
           </tr>
         </thead>
         <tbody className="bg-white dark:bg-gray-800">
           <tr>
-            <td className="border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               The Sliding Mr. Bones (Next Stop, Pottersville)
             </td>
             <td className="border-b border-gray-100 p-4 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               Malcolm Lockyer
             </td>
-            <td className="border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               1961
             </td>
           </tr>
           <tr>
-            <td className="border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               Witchy Woman
             </td>
             <td className="border-b border-gray-100 p-4 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               The Eagles
             </td>
-            <td className="border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               1972
             </td>
           </tr>
           <tr>
-            <td className="border-b border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border-b border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Shining Star
             </td>
             <td className="border-b border-gray-200 p-4 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Earth, Wind, and Fire
             </td>
-            <td className="border-b border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border-b border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               1975
             </td>
           </tr>
@@ -122,48 +122,48 @@ Use the `table-fixed` utility to ignore the content of the table cells and use f
       <table className="w-full table-fixed border-collapse text-sm">
         <thead>
           <tr>
-            <th className="border-b border-gray-200 p-4 pt-0 pb-3 pl-8 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 ps-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Song
             </th>
-            <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Artist
             </th>
-            <th className="border-b border-gray-200 p-4 pt-0 pr-8 pb-3 text-left font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
+            <th className="border-b border-gray-200 p-4 pt-0 pb-3 pe-8 text-start font-medium text-gray-400 dark:border-gray-600 dark:text-gray-200">
               Year
             </th>
           </tr>
         </thead>
         <tbody className="bg-white dark:bg-gray-800">
           <tr>
-            <td className="border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               The Sliding Mr. Bones (Next Stop, Pottersville)
             </td>
             <td className="border-b border-gray-100 p-4 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               Malcolm Lockyer
             </td>
-            <td className="border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               1961
             </td>
           </tr>
           <tr>
-            <td className="border-b border-gray-100 p-4 pl-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 ps-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               Witchy Woman
             </td>
             <td className="border-b border-gray-100 p-4 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               The Eagles
             </td>
-            <td className="border-b border-gray-100 p-4 pr-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <td className="border-b border-gray-100 p-4 pe-8 text-gray-500 dark:border-gray-700 dark:text-gray-400">
               1972
             </td>
           </tr>
           <tr>
-            <td className="border-b border-gray-200 p-4 pl-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border-b border-gray-200 p-4 ps-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Shining Star
             </td>
             <td className="border-b border-gray-200 p-4 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               Earth, Wind, and Fire
             </td>
-            <td className="border-b border-gray-200 p-4 pr-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
+            <td className="border-b border-gray-200 p-4 pe-8 text-gray-500 dark:border-gray-600 dark:text-gray-400">
               1975
             </td>
           </tr>

--- a/src/docs/visibility.mdx
+++ b/src/docs/visibility.mdx
@@ -62,48 +62,48 @@ Use the `collapse` utility to hide table rows, row groups, columns, and column g
       <table className="w-full border-collapse border-y border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Invoice #
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Client
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-right font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-end font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Amount
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #100
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Pendant Publishing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $2,000.00
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #101
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Kruger Industrial Smoothing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $545.00
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #102
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               J. Peterman
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $10,000.25
             </td>
           </tr>
@@ -115,48 +115,48 @@ Use the `collapse` utility to hide table rows, row groups, columns, and column g
       <table className="w-full border-collapse border-y border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Invoice #
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Client
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-right font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-end font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Amount
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #100
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Pendant Publishing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $2,000.00
             </td>
           </tr>
           <tr className="collapse">
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #101
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Kruger Industrial Smoothing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $545.00
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #102
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               J. Peterman
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $10,000.25
             </td>
           </tr>
@@ -168,48 +168,48 @@ Use the `collapse` utility to hide table rows, row groups, columns, and column g
       <table className="w-full border-collapse border-y border-gray-400 bg-white text-sm dark:border-gray-500 dark:bg-gray-800">
         <thead className="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Invoice #
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-left font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-start font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Client
             </th>
-            <th className="border border-gray-300 px-4 py-3 text-right font-semibold text-gray-900 first:border-l-0 last:border-r-0 dark:border-gray-600 dark:text-gray-200">
+            <th className="border border-gray-300 px-4 py-3 text-end font-semibold text-gray-900 first:border-s-0 last:border-e-0 dark:border-gray-600 dark:text-gray-200">
               Amount
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #100
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Pendant Publishing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $2,000.00
             </td>
           </tr>
           <tr className="hidden">
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #101
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               Kruger Industrial Smoothing
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $545.00
             </td>
           </tr>
           <tr>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               #102
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-gray-500 first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               J. Peterman
             </td>
-            <td className="border border-gray-300 px-4 py-3 text-right text-gray-500 tabular-nums first:border-l-0 last:border-r-0 dark:border-gray-700 dark:text-gray-400">
+            <td className="border border-gray-300 px-4 py-3 text-end text-gray-500 tabular-nums first:border-s-0 last:border-e-0 dark:border-gray-700 dark:text-gray-400">
               $10,000.25
             </td>
           </tr>


### PR DESCRIPTION
To assist developers in creating multilingual projects that support bidirectional layouts, tailwind code samples should be direction agnostic, supporting both LTR and RTL designs.

The majority of the table-based examples seen in Tailwind docs don't support RTL. In LTR view, they appear excellent, but in RTL the text alignments are wrong, and so are the borders and paddings.

This PR resolves the RTL issues by adding direction awareness to all examples that show tables.

----

See the following doc: https://tailwindcss.com/docs/visibility#collapsing-elements

LTR view:

<img width="668" height="660" alt="ltr table" src="https://github.com/user-attachments/assets/2288501c-0366-47ed-a93f-12014dfee23f" />


RTL view:

<img width="667" height="660" alt="rtl table" src="https://github.com/user-attachments/assets/476f8947-25dc-40e3-9351-088fec6ad719" />
