### PR TITLE
fix: sponsors part incorrect href trigger

### DIFF
--- a/src/app/sponsor/page.tsx
+++ b/src/app/sponsor/page.tsx
@@ -149,16 +149,17 @@ function FeaturedPartners() {
           <div className="border-l border-gray-950/5 max-xl:hidden dark:border-white/10"></div>
         </div>
         <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-3 xl:grid-cols-4">
-          {partners.map((partner, index) => (
-            <a
-              key={index}
-              href={partner.url}
-              target="_blank"
-              rel="noopener sponsored"
-              className="grid place-content-center transition-colors hover:bg-gray-950/2.5 max-lg:nth-[2n+1]:line-y sm:px-2 sm:py-4 lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y dark:hover:bg-white/2.5"
-            >
-              <partner.logo className="w-full max-w-80" aria-label={`${partner.name} logo`} />
-            </a>
+          {partners.map((company, index) => (
+            <li key={index} className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y">
+              <a
+                href={company.url}
+                target="_blank"
+                rel="noopener sponsored"
+                className="grid place-content-center transition-colors hover:bg-gray-950/2.5 sm:px-2 sm:py-4 dark:hover:bg-white/2.5"
+              >
+                <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
+              </a>
+            </li>
           ))}
         </ul>
       </div>
@@ -769,15 +770,16 @@ function Sponsors() {
         </div>
         <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-3 xl:grid-cols-4">
           {partners.map((company, index) => (
-            <a
-              key={index}
-              href={company.url}
-              target="_blank"
-              rel="noopener sponsored"
-              className="grid place-content-center transition-colors hover:bg-gray-950/2.5 max-lg:nth-[2n+1]:line-y sm:px-2 sm:py-4 lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y dark:hover:bg-white/2.5"
-            >
-              <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
-            </a>
+            <li key={index} className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y">
+              <a
+                href={company.url}
+                target="_blank"
+                rel="noopener sponsored"
+                className="grid place-content-center transition-colors hover:bg-gray-950/2.5 sm:px-2 sm:py-4 dark:hover:bg-white/2.5"
+              >
+                <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
+              </a>
+            </li>
           ))}
         </ul>
       </div>
@@ -793,15 +795,16 @@ function Sponsors() {
         </div>
         <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-4 xl:grid-cols-6">
           {ambassadors.map((company, index) => (
-            <a
-              key={index}
-              href={company.url}
-              target="_blank"
-              rel="noopener sponsored"
-              className="grid place-content-center transition-colors hover:bg-gray-950/2.5 max-lg:nth-[2n+1]:line-y sm:px-2 sm:py-4 lg:max-xl:nth-[4n+1]:line-y xl:nth-[6n+1]:line-y dark:hover:bg-white/2.5"
-            >
-              <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
-            </a>
+            <li key={index} className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[4n+1]:line-y xl:nth-[6n+1]:line-y">
+              <a
+                href={company.url}
+                target="_blank"
+                rel="noopener sponsored"
+                className="grid place-content-center transition-colors hover:bg-gray-950/2.5 sm:px-2 sm:py-4 dark:hover:bg-white/2.5"
+              >
+                <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
+              </a>
+            </li>
           ))}
         </ul>
       </div>
@@ -819,15 +822,16 @@ function Sponsors() {
         </div>
         <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-6 xl:grid-cols-8">
           {supporters.map((company, index) => (
-            <a
-              key={index}
-              href={company.url}
-              target="_blank"
-              rel="noopener sponsored"
-              className="grid place-content-center transition-colors hover:bg-gray-950/2.5 max-lg:nth-[2n+1]:line-y sm:px-2 sm:py-4 lg:max-xl:nth-[6n+1]:line-y xl:nth-[8n+1]:line-y dark:hover:bg-white/2.5"
-            >
-              <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
-            </a>
+            <li key={index} className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[6n+1]:line-y xl:nth-[8n+1]:line-y">
+              <a
+                href={company.url}
+                target="_blank"
+                rel="noopener sponsored"
+                className="grid place-content-center transition-colors hover:bg-gray-950/2.5 sm:px-2 sm:py-4 dark:hover:bg-white/2.5"
+              >
+                <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
+              </a>
+            </li>
           ))}
         </ul>
       </div>

--- a/src/components/home/partners-section.tsx
+++ b/src/components/home/partners-section.tsx
@@ -83,15 +83,16 @@ export default function WhyTailwindCssSection() {
           </div>
           <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-3 xl:grid-cols-4">
             {displayedSponsors.map((company, index) => (
-              <a
-                key={index}
-                href={company.url}
-                target="_blank"
-                rel="noopener sponsored"
-                className="grid place-content-center transition-colors hover:bg-gray-950/2.5 max-lg:nth-[2n+1]:line-y sm:px-2 sm:py-4 lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y dark:hover:bg-white/2.5"
-              >
-                <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
-              </a>
+              <li key={index} className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y">
+                <a
+                  href={company.url}
+                  target="_blank"
+                  rel="noopener sponsored"
+                  className="grid place-content-center transition-colors hover:bg-gray-950/2.5 sm:px-2 sm:py-4 dark:hover:bg-white/2.5"
+                >
+                  <company.logo className="w-full max-w-80" aria-label={`${company.name} logo`} />
+                </a>
+              </li>
             ))}
           </ul>
         </div>


### PR DESCRIPTION
This pull request refactors the sponsor and partner grid layouts to fix the incorrect href trigger. 

**Problem Description:**

* When your cursor hovers over the top or bottom border lines of the sponsors company box, the cursor changes to a pointer and jumps to the first company link after you click. This happens because the `line-y` classname is contained by the `<a>` tag.

<img width="2365" height="1009" alt="image" src="https://github.com/user-attachments/assets/804d3979-9ea7-486e-a49e-2507e333132a" />

**Variable Naming Consistency:**

* In `FeaturedPartners`, the variable name in the map callback was changed from `partner` to `company` for consistency with other sections.