### PR TITLE
fix: upgrade guide typo on transition-colors property

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -760,7 +760,7 @@ Generally though we recommend treating hover functionality as an enhancement, an
 
 ### Transitioning outline-color
 
-The `transition` and `transition-color` utilities now include the `outline-color` property.
+The `transition` and `transition-colors` utilities now include the `outline-color` property.
 
 This means if you were adding an outline with a custom color on focus, you will see the color transition from the default color. To avoid this, make sure you set the outline color unconditionally, or explicitly set it for both states:
 


### PR DESCRIPTION
Going through the upgrade, I found a typo on the `transition-color` > `transition-colors` property.
See doc: https://tailwindcss.com/docs/transition-property