### PR TITLE
fix(font): use `monospace` fallback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   --font-sans: var(--font-inter), system-ui;
   --font-source: var(--font-source-sans-pro), system-ui;
   --font-sans--font-feature-settings: "cv02", "cv03", "cv04", "cv11";
-  --font-mono: var(--font-plex-mono);
+  --font-mono: var(--font-plex-mono), monospace;
   --font-mono--font-feature-settings: "ss02", "zero";
   --font-ubuntu-mono: var(--font-ubuntu-mono);
 }


### PR DESCRIPTION
This helps with browsers/configs which blocks web fonts.

## Before
<img width="2880" height="1752" alt="image" src="https://github.com/user-attachments/assets/723ea5a8-4398-4b6f-9275-14cc7ecfc160" />

## After
<img width="2880" height="1752" alt="image" src="https://github.com/user-attachments/assets/7439d616-b49d-4598-9df4-a4b71d8d20b6" />
