### PR TITLE
Fix Accessibility Issues in Showcase Thumbnail Links

### DIFF
--- a/src/components/showcase-thumbnail.tsx
+++ b/src/components/showcase-thumbnail.tsx
@@ -82,7 +82,13 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
         hideVideo();
       }}
     >
-      <a href={showcase.url} target="_blank" rel="noopener noreferrer" className="absolute inset-0 z-10"></a>
+      <a
+        href={showcase.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="absolute inset-0 z-10"
+        aria-label={showcase.name}
+      ></a>
       <GridContainer className={clsx("p-2", BEFORE_AND_AFTER_ONLY_IN_FIRST_COLUMN_OF_CURRENT_GRID)}>
         <div className="relative aspect-[672/494] overflow-hidden rounded-xl outline outline-gray-950/5">
           <Image


### PR DESCRIPTION
### Issue Description

When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.9) on the [showcase page](https://tailwindcss.com/showcase), multiple (49) violations were detected indicating that links in the showcase thumbnail component lack accessible names. This creates barriers for screen reader users who cannot understand the purpose of these links. The checker identified multiple instances of **"Hyperlink has no link text, label or image with a text alternative"** violations.

Screenshot of Webpage:

<img width="2560" height="835" alt="image" src="https://github.com/user-attachments/assets/bb6379ec-ca90-4a6d-a6d0-7efd91edd2fb" />

Violation Report:

<img width="773" height="735" alt="image" src="https://github.com/user-attachments/assets/4fda91c2-6d1f-4bbe-8dab-1d289d0640d5" />



### Solution
Added aria-label attribute to the link element in the ShowcaseThumbnail component, using showcase.name as the accessible label text. This ensures:

- Screen reader users can clearly understand the destination of each link
- Compliance with WCAG accessibility standards
- Improved overall user experience for assistive technology users

Generated Patch of A11YRepair:
```
diff --git a/src/components/showcase-thumbnail.tsx b/src/components/showcase-thumbnail.tsx
index 1900ca29..854bfd90 100644
--- a/src/components/showcase-thumbnail.tsx
+++ b/src/components/showcase-thumbnail.tsx
@@ -82,7 +82,13 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
         hideVideo();
       }}
     >
-      <a href={showcase.url} target="_blank" rel="noopener noreferrer" className="absolute inset-0 z-10"></a>
+      <a
+        href={showcase.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="absolute inset-0 z-10"
+        aria-label={showcase.name}
+      ></a>
       <GridContainer className={clsx("p-2", BEFORE_AND_AFTER_ONLY_IN_FIRST_COLUMN_OF_CURRENT_GRID)}>
         <div className="relative aspect-[672/494] overflow-hidden rounded-xl outline outline-gray-950/5">
           <Image

```

Added `aria-label={showcase.name}` attribute to the absolutely positioned link element.

- Note: The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.

**Fix Before:**

<img width="2560" height="764" alt="image" src="https://github.com/user-attachments/assets/62466144-2e3b-477e-9304-89dca5bad5f0" />

There are 49 violations - "Hyperlink has no link text, label or image with a text alternative"

Violation Element Example:
```
<a href="https://cursor.com" target="_blank" rel="noopener noreferrer" class="absolute inset-0 z-10"></a>
```

**Fix After:**

<img width="2560" height="767" alt="image" src="https://github.com/user-attachments/assets/9169c97d-d73f-461d-a509-d6e5d1506535" />

All 49 violations have been resolved, use the `aria-label` attribute to point to text visible on the page that identifies the link purpose.

Fixed Violation Element Example:
```
<a href="https://cursor.com" target="_blank" rel="noopener noreferrer" class="absolute inset-0 z-10" aria-label="Cursor"></a>
```