### PR TITLE
fix: make footer copyright year dynamic

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -57,7 +57,7 @@ export function FooterMeta({ className }: { className?: string }) {
       >
         <ThemeToggle />
         <div className="flex flex-col gap-4 text-sm/6 text-gray-700 sm:flex-row sm:gap-2 sm:pr-4 dark:text-gray-400">
-          <span>Copyright ©&nbsp;2025&nbsp;Tailwind Labs Inc.</span>
+          <span>Copyright ©&nbsp;{new Date().getFullYear()}&nbsp;Tailwind Labs Inc.</span>
           <span className="max-sm:hidden">&middot;</span>
           <Link href="/brand" className="hover:underline">
             Trademark Policy


### PR DESCRIPTION
Description:
The copyright year was static, made it dynamic.

Before:
<img width="538" height="119" alt="Screenshot 2026-01-09 at 2 26 47 PM" src="https://github.com/user-attachments/assets/073ed951-cd5f-43fc-aef8-74eb3c3d6a64" />

After: 
<img width="602" height="161" alt="Screenshot 2026-01-09 at 2 27 23 PM" src="https://github.com/user-attachments/assets/5853cc4e-3d85-490b-9827-508c59d0e6f4" />


