### PR TITLE
feat: make footer copyright year dynamic

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -57,7 +57,7 @@ export function FooterMeta({ className }: { className?: string }) {
       >
         <ThemeToggle />
         <div className="flex flex-col gap-4 text-sm/6 text-gray-700 sm:flex-row sm:gap-2 sm:pr-4 dark:text-gray-400">
-          <span>Copyright ©&nbsp;2025&nbsp;Tailwind Labs Inc.</span>
+          <span>Copyright ©&nbsp;{new Date().getFullYear()}&nbsp;Tailwind Labs Inc.</span>
           <span className="max-sm:hidden">&middot;</span>
           <Link href="/brand" className="hover:underline">
             Trademark Policy


### PR DESCRIPTION
## 📅 Make Copyright Year Dynamic

Hey! 👋 

Someone had to do it, right? 😄
<img width="2976" height="184" alt="image" src="https://github.com/user-attachments/assets/2c7bee9f-fd3c-4d23-9e44-6ccaf15cf8df" />


This PR changes the hardcoded `2025` in the footer to dynamically use `new Date().getFullYear()`. 

**Why?** 🤔
- No more manual updates every January 1st 🎉
- The year will always be current ✨
- One less thing to worry about 🧘

**What changed?** 🔧
- `src/components/footer.tsx:60`
- From: `Copyright © 2025 Tailwind Labs Inc.`
- To: `Copyright © {new Date().getFullYear()} Tailwind Labs Inc.`

Small change, but hey, it's one less manual update to remember! 🚀
