### PR TITLE
Fix list-style-type documentation playground/code mismatch

### DIFF
--- a/src/docs/list-style-type.mdx
+++ b/src/docs/list-style-type.mdx
@@ -56,20 +56,20 @@ Use utilities like `list-disc` and `list-decimal` to control the style of the ma
 </Example>
 
 ```html
-<!-- [!code classes:list-disc] -->
-<ul class="list-disc">
+<!-- [!code classes:list-disc,list-inside] -->
+<ul class="list-inside list-disc">
   <li>Now this is a story all about how, my life got flipped-turned upside down</li>
   <!-- ... -->
 </ul>
 
-<!-- [!code classes:list-decimal] -->
-<ol class="list-decimal">
+<!-- [!code classes:list-decimal,list-inside] -->
+<ul class="list-inside list-decimal">
   <li>Now this is a story all about how, my life got flipped-turned upside down</li>
   <!-- ... -->
-</ol>
+</ul>
 
-<!-- [!code classes:list-none] -->
-<ul class="list-none">
+<!-- [!code classes:list-none,list-inside] -->
+<ul class="list-inside list-none">
   <li>Now this is a story all about how, my life got flipped-turned upside down</li>
   <!-- ... -->
 </ul>


### PR DESCRIPTION
## Summary
Fixes inconsistency between the interactive playground examples and the HTML code snippets in the list-style-type documentation.

## Changes
- Added missing `list-inside` class to all three HTML code snippets (list-disc, list-decimal, list-none)
- Changed `<ol>` to `<ul>` for the list-decimal example to match the playground implementation
- Updated code highlighting comments to include `list-inside` class

## Issue
Closes #2255

## Testing
✅ Verified locally on development server
✅ Confirmed playground examples and code snippets now match exactly
✅ All three examples now correctly show `list-inside` class
✅ Documentation renders correctly

## Before
Code snippets showed:
- `<ul class="list-disc">`
- `<ol class="list-decimal">`
- `<ul class="list-none">`

But playground showed `list-inside` on all examples.

## After
Code snippets now correctly show:
- `<ul class="list-inside list-disc">`
- `<ul class="list-inside list-decimal">`
- `<ul class="list-inside list-none">`

Matching the interactive playground examples.