### PR TITLE
claude/fix-accent-color-docs-mEG1G

### DIFF
--- a/src/docs/accent-color.mdx
+++ b/src/docs/accent-color.mdx
@@ -21,7 +21,7 @@ export const description = "Utilities for controlling the accented color of a fo
       `accent-${name}`,
       `accent-color: var(--color-${name}); /* ${value} */`,
     ]),
-    ["accent-<custom-property>", "accent-color: var(<custom-property>);"],
+    ["accent-(<custom-property>)", "accent-color: var(<custom-property>);"],
     ["accent-[<value>]", "accent-color: <value>;"],
   ]}
 />


### PR DESCRIPTION
The API table was missing parentheses for the custom property syntax. It should be `accent-(<custom-property>)` not `accent-<custom-property>`.