### PR TITLE
Remove Discord redirect from next.config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -458,8 +458,6 @@ const nextConfig = {
         permanent: false,
       },
 
-      // External Links
-      { source: "/discord", destination: "https://discord.gg/7NF8GNe", permanent: false },
     ];
   },
   async rewrites() {


### PR DESCRIPTION
## Summary
Removed the Discord server redirect rule from the Next.js configuration redirects.

## Changes
- Deleted the `/discord` redirect that pointed to `https://discord.gg/7NF8GNe`
- Removed associated comment for external links section

## Details
This change removes a redirect rule that was previously routing requests to `/discord` to an external Discord server invite link. The redirect is no longer needed in the application's routing configuration.

https://claude.ai/code/session_01LVzhj3ZvUjeZu458sJQP8G