### PR TITLE
Fix typo in field-sizing documentation

### DIFF
--- a/src/docs/field-sizing.mdx
+++ b/src/docs/field-sizing.mdx
@@ -17,7 +17,7 @@ export const description = "Utilities for controlling the sizing of form control
 
 ### Sizing based on content
 
-Use the `field-sizing-content` utility to allow a form control to adjust it's size based on the content:
+Use the `field-sizing-content` utility to allow a form control to adjust its size based on the content:
 
 <Figure hint="Type in the input below to see the size change">
 


### PR DESCRIPTION
it's => its

(it's = it is, its = possessive)

cheers :)