### PR TITLE
chore: replace literal copyright symbol with HTML entity for better compatibility

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -57,7 +57,7 @@ export function FooterMeta({ className }: { className?: string }) {
       >
         <ThemeToggle />
         <div className="flex flex-col gap-4 text-sm/6 text-gray-700 sm:flex-row sm:gap-2 sm:pr-4 dark:text-gray-400">
-          <span>Copyright ©&nbsp;{new Date().getFullYear()}&nbsp;Tailwind Labs Inc.</span>
+          <span>Copyright &copy;&nbsp;{new Date().getFullYear()}&nbsp;Tailwind Labs Inc.</span>
           <span className="max-sm:hidden">&middot;</span>
           <Link href="/brand" className="hover:underline">
             Trademark Policy


### PR DESCRIPTION
- use HTML entities for copyright