### PR TITLE
docs: fix upgrade guide cursor selector

### DIFF
--- a/src/docs/upgrade-guide.mdx
+++ b/src/docs/upgrade-guide.mdx
@@ -562,7 +562,7 @@ If you'd like to continue using `cursor: pointer` by default, add these base sty
 /* [!code filename:CSS] */
 @layer base {
   button:not(:disabled),
-  [role="button"]:not(:disabled) {
+  [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
Fixes #2460

Updates the upgrade guide CSS snippet to use aria-disabled for non-form elements with role=button.