### PR TITLE
docs(responsive-design): note CSS variables aren't supported in arbitrary breakpoints

### DIFF
--- a/src/docs/responsive-design.mdx
+++ b/src/docs/responsive-design.mdx
@@ -375,6 +375,8 @@ If you need to use a one-off breakpoint that doesn’t make sense to include in 
 
 Learn more about arbitrary value support in the [arbitrary values](/docs/adding-custom-styles#using-arbitrary-values) documentation.
 
+Note that CSS variables aren't supported as arbitrary breakpoint values because CSS `@media` queries don't support the `var()` function.
+
 ## Container queries
 
 ### What are container queries?


### PR DESCRIPTION
## Summary
Adds a short note to the *Using arbitrary values* section of the Responsive Design page clarifying that CSS variables cannot be used as arbitrary breakpoint values, because CSS `@media` queries do not support the `var()` function.

## Issue
Fixes #2453

## Changes
- `src/docs/responsive-design.mdx`: appended a one-line note after the existing arbitrary-values paragraph.

## Testing
- Docs-only change; renders as a single paragraph between the existing section text and the following `## Container queries` heading.