### PR TITLE
fix: replace wrong link with right one for discord

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -173,7 +173,7 @@ function Community() {
           </Link>
         </li>
         <li>
-          <Link href="/sponsor#insiders" className="hover:underline">
+          <Link href="https://discord.gg/7NF8GNe" className="hover:underline">
             Discord
           </Link>
         </li>


### PR DESCRIPTION
I noticed that there is no way to open discord group from website footer, so I just updated the link