### PR TITLE
Document `@container-size` utility

### DIFF
--- a/src/docs/responsive-design.mdx
+++ b/src/docs/responsive-design.mdx
@@ -383,7 +383,7 @@ Learn more about arbitrary value support in the [arbitrary values](/docs/adding-
 
 ### Basic example
 
-Use the `@container` class to mark an element as a container, then use variants like `@sm` and `@md` to style child elements based on the size of the container:
+Use the `@container` class to mark an element as an inline-size container, then use variants like `@sm` and `@md` to style child elements based on the size of the container:
 
 ```html
 <!-- [!code filename:HTML] -->
@@ -508,7 +508,7 @@ Use variants like `@min-[475px]` and `@max-[960px]` for one-off container query 
 
 ### Using container query units
 
-Use [container query length units](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries#container_query_length_units) like `cqw` as arbitrary values in other utility classes to reference the container size:
+Use [container query length units](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries#container_query_length_units) like `cqw` and `cqi` as arbitrary values in other utility classes to reference the container size:
 
 ```html
 <!-- [!code filename:HTML] -->
@@ -519,6 +519,8 @@ Use [container query length units](https://developer.mozilla.org/en-US/docs/Web/
   </div>
 </div>
 ```
+
+For units that need more than the inline size, like `cqb` and `cqh`, use `@container-size` to make the full size of the container available.
 
 ### Container size reference
 

--- a/src/docs/responsive-design.mdx
+++ b/src/docs/responsive-design.mdx
@@ -512,7 +512,7 @@ Use [container query length units](https://developer.mozilla.org/en-US/docs/Web/
 
 ```html
 <!-- [!code filename:HTML] -->
-<!-- [!code word:w-\[50cqw\] -->
+<!-- [!code word:w-\[50cqw\]] -->
 <div class="@container">
   <div class="w-[50cqw]">
     <!-- ... -->

--- a/src/docs/responsive-design.mdx
+++ b/src/docs/responsive-design.mdx
@@ -444,6 +444,23 @@ For complex designs that use multiple nested containers, you can name containers
 
 This makes it possible to style something based on the size of a distant container, rather than just the nearest container.
 
+### Using size containers
+
+Use `@container-size` to mark an element as a size container instead of an inline-size container when you need to use container query length units that depend on the block size, like `cqb`:
+
+```html
+<!-- [!code filename:HTML] -->
+<!-- [!code word:@container-size] -->
+<!-- [!code word:h-\[50cqb\]] -->
+<div class="@container-size">
+  <div class="h-[50cqb]">
+    <!-- ... -->
+  </div>
+</div>
+```
+
+You can also name size containers using `@container-size/{name}`.
+
 ### Using custom container sizes
 
 Use the `--container-*` theme variables to customize your container sizes:


### PR DESCRIPTION
Direct link: https://tailwindcss-com-git-feat-document-at-contai-a275fb-tailwindlabs.vercel.app/docs/responsive-design#using-size-containers

This PR documents the `@container-size` that was introduced by https://github.com/tailwindlabs/tailwindcss/pull/18901
