### PR TITLE
Add safe area utilities docs

### DIFF
--- a/src/app/(docs)/docs/index.tsx
+++ b/src/app/(docs)/docs/index.tsx
@@ -35,6 +35,7 @@ export default {
     ["overscroll-behavior", "/docs/overscroll-behavior"],
     ["position", "/docs/position"],
     ["top / right / bottom / left", "/docs/top-right-bottom-left"],
+    ["safe area", "/docs/safe-area"],
     ["visibility", "/docs/visibility"],
     ["z-index", "/docs/z-index"],
   ] as const,

--- a/src/docs/safe-area.mdx
+++ b/src/docs/safe-area.mdx
@@ -1,0 +1,87 @@
+import { ApiTable } from "@/components/api-table.tsx";
+import { ResponsiveDesign } from "@/components/content.tsx";
+import { safeAreaRows } from "@/docs/utils/safe-area.ts";
+
+export const title = "safe area";
+export const description = "Utilities for accounting for viewport safe areas.";
+
+<ApiTable rows={safeAreaRows} />
+
+## Examples
+
+### Adding safe-area padding
+
+Use utilities like `p-safe`, `pt-safe`, and `pb-safe` to add padding that matches the browser's safe-area inset:
+
+```html
+<!-- [!code classes:pt-safe,pb-safe] -->
+<main class="pt-safe pb-safe">
+  <!-- ... -->
+</main>
+```
+
+Add a spacing value to reserve both the safe area and a normal spacing token:
+
+```html
+<!-- [!code classes:pt-safe-4,pb-safe-6] -->
+<main class="pt-safe-4 pb-safe-6">
+  <!-- ... -->
+</main>
+```
+
+### Positioning around safe areas
+
+Use utilities like `bottom-safe`, `top-safe-4`, and `-left-safe-px` to position elements relative to viewport safe areas:
+
+```html
+<!-- [!code classes:bottom-safe-4,right-safe-4] -->
+<button class="right-safe-4 bottom-safe-4 fixed ...">
+  <!-- ... -->
+</button>
+```
+
+### Resetting safe areas
+
+Safe-area spacing utilities use `env(safe-area-inset-*)` by default, but also read the `--tw-safe-area-*` variables when they are defined.
+Use utilities like `safe`, `safe-none`, and `safe-b-none` to scope or reset those variables for part of the page:
+
+```html
+<!-- [!code classes:safe,pb-safe,safe-b-none] -->
+<div class="safe">
+  <main class="pb-safe">
+    <!-- ... -->
+  </main>
+
+  <footer class="safe-b-none pb-safe">
+    <!-- ... -->
+  </footer>
+</div>
+```
+
+### Viewport height minus safe areas
+
+Use utilities like `h-dvh-safe`, `min-h-screen-safe`, and `max-h-lvh-safe` to set viewport-based heights with the top and bottom safe areas subtracted:
+
+```html
+<!-- [!code classes:min-h-dvh-safe] -->
+<main class="min-h-dvh-safe">
+  <!-- ... -->
+</main>
+```
+
+### Scroll offsets
+
+Use `scroll-m-safe` and `scroll-p-safe` utilities to account for safe areas when scrolling to snap points or anchored content:
+
+```html
+<!-- [!code classes:scroll-pt-safe,scroll-mt-safe-4] -->
+<div class="scroll-pt-safe">
+  <section class="scroll-mt-safe-4">
+    <!-- ... -->
+  </section>
+</div>
+```
+
+### Responsive design
+
+<ResponsiveDesign property="safe area padding" defaultClass="pt-safe" featuredClass="md:pt-safe-8" />

--- a/src/docs/utils/safe-area.ts
+++ b/src/docs/utils/safe-area.ts
@@ -1,0 +1,280 @@
+type ApiTableRow = [string, string];
+type SafeAreaInset = "top" | "right" | "bottom" | "left";
+type SafeAreaDeclaration = [property: string, inset: SafeAreaInset];
+type SafeAreaGroup = [prefix: string, properties: SafeAreaDeclaration[]];
+
+function safeArea(inset: SafeAreaInset) {
+  return `var(--tw-safe-area-${inset}, env(safe-area-inset-${inset}))`;
+}
+
+function safeAreaValue(inset: SafeAreaInset, value?: string, negative = false) {
+  const base = safeArea(inset);
+
+  if (value === undefined) {
+    return negative ? `calc(${base} * -1)` : base;
+  }
+
+  return negative ? `calc((${base} + ${value}) * -1)` : `calc(${base} + ${value})`;
+}
+
+function declarations(properties: SafeAreaDeclaration[], value?: string, negative = false) {
+  return properties.map(([property, inset]) => `${property}: ${safeAreaValue(inset, value, negative)};`).join("\n");
+}
+
+function variableRows(groups: [string, SafeAreaInset[]][], valueForInset: (inset: SafeAreaInset) => string) {
+  return groups.map(
+    ([prefix, insets]) =>
+      [prefix, insets.map((inset) => `--tw-safe-area-${inset}: ${valueForInset(inset)};`).join("\n")] as ApiTableRow,
+  );
+}
+
+function spacingRows(
+  groups: SafeAreaGroup[],
+  { supportsNegative = false, supportsFractions = false } = {},
+): ApiTableRow[] {
+  const rows: ApiTableRow[] = [];
+
+  for (const [prefix, properties] of groups) {
+    rows.push([`${prefix}`, declarations(properties)]);
+    rows.push([`${prefix}-<number>`, declarations(properties, "calc(var(--spacing) * <number>)")]);
+
+    if (supportsFractions) {
+      rows.push([`${prefix}-<fraction>`, declarations(properties, "calc(<fraction> * 100%)")]);
+    }
+
+    rows.push([`${prefix}-px`, declarations(properties, "1px")]);
+    rows.push([`${prefix}-(<custom-property>)`, declarations(properties, "var(<custom-property>)")]);
+    rows.push([`${prefix}-[<value>]`, declarations(properties, "<value>")]);
+
+    if (!supportsNegative) continue;
+
+    rows.push([`-${prefix}`, declarations(properties, undefined, true)]);
+    rows.push([`-${prefix}-<number>`, declarations(properties, "calc(var(--spacing) * <number>)", true)]);
+
+    if (supportsFractions) {
+      rows.push([`-${prefix}-<fraction>`, declarations(properties, "calc(<fraction> * 100%)", true)]);
+    }
+
+    rows.push([`-${prefix}-px`, declarations(properties, "1px", true)]);
+    rows.push([`-${prefix}-(<custom-property>)`, declarations(properties, "var(<custom-property>)", true)]);
+    rows.push([`-${prefix}-[<value>]`, declarations(properties, "<value>", true)]);
+  }
+
+  return rows;
+}
+
+const controlRows = variableRows(
+  [
+    ["safe", ["top", "right", "bottom", "left"]],
+    ["safe-x", ["right", "left"]],
+    ["safe-y", ["top", "bottom"]],
+    ["safe-t", ["top"]],
+    ["safe-r", ["right"]],
+    ["safe-b", ["bottom"]],
+    ["safe-l", ["left"]],
+  ],
+  (inset) => `env(safe-area-inset-${inset})`,
+);
+
+const resetRows = variableRows(
+  [
+    ["safe-none", ["top", "right", "bottom", "left"]],
+    ["safe-x-none", ["right", "left"]],
+    ["safe-y-none", ["top", "bottom"]],
+    ["safe-t-none", ["top"]],
+    ["safe-r-none", ["right"]],
+    ["safe-b-none", ["bottom"]],
+    ["safe-l-none", ["left"]],
+  ],
+  () => "0px",
+);
+
+const insetRows = spacingRows(
+  [
+    [
+      "inset-safe",
+      [
+        ["top", "top"],
+        ["right", "right"],
+        ["bottom", "bottom"],
+        ["left", "left"],
+      ],
+    ],
+    [
+      "inset-x-safe",
+      [
+        ["right", "right"],
+        ["left", "left"],
+      ],
+    ],
+    [
+      "inset-y-safe",
+      [
+        ["top", "top"],
+        ["bottom", "bottom"],
+      ],
+    ],
+    ["top-safe", [["top", "top"]]],
+    ["right-safe", [["right", "right"]]],
+    ["bottom-safe", [["bottom", "bottom"]]],
+    ["left-safe", [["left", "left"]]],
+  ],
+  { supportsNegative: true, supportsFractions: true },
+);
+
+const marginRows = spacingRows(
+  [
+    [
+      "m-safe",
+      [
+        ["margin-top", "top"],
+        ["margin-right", "right"],
+        ["margin-bottom", "bottom"],
+        ["margin-left", "left"],
+      ],
+    ],
+    [
+      "mx-safe",
+      [
+        ["margin-right", "right"],
+        ["margin-left", "left"],
+      ],
+    ],
+    [
+      "my-safe",
+      [
+        ["margin-top", "top"],
+        ["margin-bottom", "bottom"],
+      ],
+    ],
+    ["mt-safe", [["margin-top", "top"]]],
+    ["mr-safe", [["margin-right", "right"]]],
+    ["mb-safe", [["margin-bottom", "bottom"]]],
+    ["ml-safe", [["margin-left", "left"]]],
+  ],
+  { supportsNegative: true },
+);
+
+const paddingRows = spacingRows([
+  [
+    "p-safe",
+    [
+      ["padding-top", "top"],
+      ["padding-right", "right"],
+      ["padding-bottom", "bottom"],
+      ["padding-left", "left"],
+    ],
+  ],
+  [
+    "px-safe",
+    [
+      ["padding-right", "right"],
+      ["padding-left", "left"],
+    ],
+  ],
+  [
+    "py-safe",
+    [
+      ["padding-top", "top"],
+      ["padding-bottom", "bottom"],
+    ],
+  ],
+  ["pt-safe", [["padding-top", "top"]]],
+  ["pr-safe", [["padding-right", "right"]]],
+  ["pb-safe", [["padding-bottom", "bottom"]]],
+  ["pl-safe", [["padding-left", "left"]]],
+]);
+
+const scrollMarginRows = spacingRows(
+  [
+    [
+      "scroll-m-safe",
+      [
+        ["scroll-margin-top", "top"],
+        ["scroll-margin-right", "right"],
+        ["scroll-margin-bottom", "bottom"],
+        ["scroll-margin-left", "left"],
+      ],
+    ],
+    [
+      "scroll-mx-safe",
+      [
+        ["scroll-margin-right", "right"],
+        ["scroll-margin-left", "left"],
+      ],
+    ],
+    [
+      "scroll-my-safe",
+      [
+        ["scroll-margin-top", "top"],
+        ["scroll-margin-bottom", "bottom"],
+      ],
+    ],
+    ["scroll-mt-safe", [["scroll-margin-top", "top"]]],
+    ["scroll-mr-safe", [["scroll-margin-right", "right"]]],
+    ["scroll-mb-safe", [["scroll-margin-bottom", "bottom"]]],
+    ["scroll-ml-safe", [["scroll-margin-left", "left"]]],
+  ],
+  { supportsNegative: true },
+);
+
+const scrollPaddingRows = spacingRows([
+  [
+    "scroll-p-safe",
+    [
+      ["scroll-padding-top", "top"],
+      ["scroll-padding-right", "right"],
+      ["scroll-padding-bottom", "bottom"],
+      ["scroll-padding-left", "left"],
+    ],
+  ],
+  [
+    "scroll-px-safe",
+    [
+      ["scroll-padding-right", "right"],
+      ["scroll-padding-left", "left"],
+    ],
+  ],
+  [
+    "scroll-py-safe",
+    [
+      ["scroll-padding-top", "top"],
+      ["scroll-padding-bottom", "bottom"],
+    ],
+  ],
+  ["scroll-pt-safe", [["scroll-padding-top", "top"]]],
+  ["scroll-pr-safe", [["scroll-padding-right", "right"]]],
+  ["scroll-pb-safe", [["scroll-padding-bottom", "bottom"]]],
+  ["scroll-pl-safe", [["scroll-padding-left", "left"]]],
+]);
+
+const viewportHeightRows: ApiTableRow[] = [];
+
+for (const [prefix, property] of [
+  ["h", "height"],
+  ["min-h", "min-height"],
+  ["max-h", "max-height"],
+] satisfies ApiTableRow[]) {
+  for (const [viewport, value] of [
+    ["screen", "100vh"],
+    ["dvh", "100dvh"],
+    ["lvh", "100lvh"],
+    ["svh", "100svh"],
+  ] satisfies ApiTableRow[]) {
+    viewportHeightRows.push([
+      `${prefix}-${viewport}-safe`,
+      `${property}: calc(${value} - (${safeArea("top")} + ${safeArea("bottom")}));`,
+    ]);
+  }
+}
+
+export const safeAreaRows = [
+  ...controlRows,
+  ...resetRows,
+  ...insetRows,
+  ...marginRows,
+  ...paddingRows,
+  ...scrollMarginRows,
+  ...scrollPaddingRows,
+  ...viewportHeightRows,
+];


### PR DESCRIPTION
## Summary
- add a new safe area utilities docs page covering control/reset helpers, safe-area spacing variants, scroll offsets, and viewport-safe heights
- add generated quick-reference rows for the new utilities from tailwindlabs/tailwindcss#19921
- link the page from the Layout section of the docs sidebar

## Validation
- pnpm build
- pnpm exec eslint src/docs/utils/safe-area.ts src/app/(docs)/docs/index.tsx (passes with one existing anonymous default export warning in the sidebar index)
- opened http://127.0.0.1:3010/docs/safe-area locally in Playwright and verified title, sidebar link, quick reference rows, and examples

## Remote checks
- Vercel failed immediately with `Authorization required to deploy.` This appears to be a fork/Vercel authorization issue, so the PR is still draft.

Based on https://github.com/tailwindlabs/tailwindcss/pull/19921