### PR TITLE
docs: update `bg-gradient-to-r` to `bg-linear-to-r`

### DIFF
--- a/src/docs/background-image.mdx
+++ b/src/docs/background-image.mdx
@@ -192,14 +192,14 @@ Use utilities like `from-indigo-500`, `via-purple-500`, and `to-pink-500` to set
           <div className="mt-2 h-2 w-0.5 bg-gray-900/30 dark:bg-white/30"></div>
         </div>
       </div>
-      <div className="h-10 rounded-lg bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500"></div>
+      <div className="h-10 rounded-lg bg-linear-to-r from-indigo-500 via-purple-500 to-pink-500"></div>
     </div>
   }
 </Example>
 
 ```html
 <!-- [!code classes:from-indigo-500,via-purple-500,to-pink-500] -->
-<div class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 ..."></div>
+<div class="bg-linear-to-r from-indigo-500 via-purple-500 to-pink-500 ..."></div>
 ```
 
 </Figure>
@@ -242,14 +242,14 @@ Use utilities like `from-10%`, `via-30%`, and `to-90%` to set more precise posit
           </div>
         </div>
       </div>
-      <div className="h-10 rounded-lg bg-gradient-to-r from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-90%"></div>
+      <div className="h-10 rounded-lg bg-linear-to-r from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-90%"></div>
     </div>
   }
 </Example>
 
 ```html
 <!-- [!code classes:from-10%,via-30%,to-90%] -->
-<div class="bg-gradient-to-r from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-90% ..."></div>
+<div class="bg-linear-to-r from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-90% ..."></div>
 ```
 
 </Figure>


### PR DESCRIPTION
I believe `bg-gradient-to-r` is the deprecated legacy way of the newer `bg-linear-to-r`.  this commit updates the actually used class and the class visible to the user as an example.