### PR TITLE
Document 4.3.2 changes

### DIFF
--- a/src/docs/grid-auto-columns.mdx
+++ b/src/docs/grid-auto-columns.mdx
@@ -10,6 +10,7 @@ export const description = "Utilities for controlling the size of implicitly-cre
     ["auto-cols-min", "grid-auto-columns: min-content;"],
     ["auto-cols-max", "grid-auto-columns: max-content;"],
     ["auto-cols-fr", "grid-auto-columns: minmax(0, 1fr);"],
+    ["auto-cols-<number>", "grid-auto-columns: calc(var(--spacing) * <number>);"],
     ["auto-cols-(<custom-property>)", "grid-auto-columns: var(<custom-property>);"],
     ["auto-cols-[<value>]", "grid-auto-columns: <value>;"],
   ]}

--- a/src/docs/grid-auto-rows.mdx
+++ b/src/docs/grid-auto-rows.mdx
@@ -10,6 +10,7 @@ export const description = "Utilities for controlling the size of implicitly-cre
     ["auto-rows-min", "grid-auto-rows: min-content;"],
     ["auto-rows-max", "grid-auto-rows: max-content;"],
     ["auto-rows-fr", "grid-auto-rows: minmax(0, 1fr);"],
+    ["auto-rows-<number>", "grid-auto-rows: calc(var(--spacing) * <number>);"],
     ["auto-rows-(<custom-property>)", "grid-auto-rows: var(<custom-property>);"],
     ["auto-rows-[<value>]", "grid-auto-rows: <value>;"],
   ]}


### PR DESCRIPTION
This PR adds some documentation changes for the 4.3.2 release

- Document `auto-rows-*` using the spacing scale (e.g. `auto-rows-12` → `grid-auto-rows: calc(var(--spacing) * 12)`)
- Document `auto-cols-*` using the spacing scale (e.g. `auto-cols-12` → `grid-auto-columns: calc(var(--spacing) * 12)`)

