### PR TITLE
Bump Tailwind CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@next/mdx": "16.2.6",
     "@next/third-parties": "16.2.6",
     "@shikijs/transformers": "^1.29.2",
-    "@tailwindcss/postcss": "^4.3.0",
+    "@tailwindcss/postcss": "^4.3.3",
     "clsx": "^2.1.1",
     "dedent": "^1.6.0",
     "feed": "^5.1.0",
@@ -28,11 +28,11 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "shiki": "^1.29.2",
-    "tailwindcss": "^4.3.2"
+    "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
-    "@tailwindcss/node": "^4.3.0",
+    "@tailwindcss/node": "^4.3.3",
     "@types/hast": "^3.0.4",
     "@types/mdx": "^2.0.13",
     "@types/node": "^22.15.33",
@@ -42,7 +42,7 @@
     "eslint-config-next": "16.2.6",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "prettier-plugin-svelte": "^3.4.0",
-    "prettier-plugin-tailwindcss": "0.7.2",
+    "prettier-plugin-tailwindcss": "0.8.1",
     "typescript": "^5.8.3"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "16.2.6",
     "hast-util-to-jsx-runtime": "^2.3.6",
-    "prettier-plugin-svelte": "^3.4.0",
+    "prettier": "^3.9.5",
+    "prettier-plugin-svelte": "^4.1.1",
     "prettier-plugin-tailwindcss": "0.8.1",
     "typescript": "^5.8.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^1.29.2
         version: 1.29.2
       '@tailwindcss/postcss':
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.3
+        version: 4.3.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -67,15 +67,15 @@ importers:
         specifier: ^1.29.2
         version: 1.29.2
       tailwindcss:
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^4.3.3
+        version: 4.3.3
     devDependencies:
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.3)
       '@tailwindcss/node':
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.3
+        version: 4.3.3
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -93,10 +93,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+        version: 16.2.6(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
@@ -104,8 +104,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0(prettier@3.4.2)(svelte@5.17.3)
       prettier-plugin-tailwindcss:
-        specifier: 0.7.2
-        version: 0.7.2(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2)
+        specifier: 0.8.1
+        version: 0.8.1(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1256,65 +1256,65 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@tailwindcss/node@4.3.0':
-    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
-  '@tailwindcss/oxide-android-arm64@4.3.0':
-    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.0':
-    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.3.0':
-    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.0':
-    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
-    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
-    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
-    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
-    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
-    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
-    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1325,24 +1325,24 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
-    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
-    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.3.0':
-    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/postcss@4.3.0':
-    resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+  '@tailwindcss/postcss@4.3.3':
+    resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
   '@tanstack/react-virtual@3.13.12':
     resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
@@ -1936,8 +1936,8 @@ packages:
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
-  enhanced-resolve@5.21.2:
-    resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
+  enhanced-resolve@5.24.2:
+    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -2486,8 +2486,8 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -2823,6 +2823,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2970,8 +2975,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2984,8 +2989,8 @@ packages:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
+  prettier-plugin-tailwindcss@0.8.1:
+    resolution: {integrity: sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -3326,11 +3331,8 @@ packages:
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
-  tailwindcss@4.3.0:
-    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
-
-  tailwindcss@4.3.2:
-    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -4392,9 +4394,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4898,74 +4900,74 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/node@4.3.0':
+  '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.2
-      jiti: 2.6.1
+      enhanced-resolve: 5.24.2
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.3
 
-  '@tailwindcss/oxide-android-arm64@4.3.0':
+  '@tailwindcss/oxide-android-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.3.0':
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide@4.3.0':
+  '@tailwindcss/oxide@4.3.3':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.0
-      '@tailwindcss/oxide-darwin-arm64': 4.3.0
-      '@tailwindcss/oxide-darwin-x64': 4.3.0
-      '@tailwindcss/oxide-freebsd-x64': 4.3.0
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/postcss@4.3.0':
+  '@tailwindcss/postcss@4.3.3':
     dependencies:
       '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.3.0
-      '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
-      tailwindcss: 4.3.0
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      postcss: 8.5.19
+      tailwindcss: 4.3.3
 
   '@tanstack/react-virtual@3.13.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -5026,15 +5028,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.8.3)
@@ -5042,14 +5044,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5072,13 +5074,13 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.4.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -5101,13 +5103,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5588,7 +5590,7 @@ snapshots:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
 
-  enhanced-resolve@5.21.2:
+  enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -5720,18 +5722,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.6(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      typescript-eslint: 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -5748,33 +5750,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5783,9 +5785,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5797,13 +5799,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -5813,7 +5815,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -5822,18 +5824,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.27.7
       '@babel/parser': 7.27.7
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.3.5
       zod-validation-error: 4.0.2(zod@4.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -5841,7 +5843,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -5864,9 +5866,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -5901,7 +5903,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6354,7 +6356,7 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6833,6 +6835,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.16: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -7005,9 +7009,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.14:
+  postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7018,7 +7022,7 @@ snapshots:
       prettier: 3.4.2
       svelte: 5.17.3
 
-  prettier-plugin-tailwindcss@0.7.2(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2):
+  prettier-plugin-tailwindcss@0.8.1(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2):
     dependencies:
       prettier: 3.4.2
     optionalDependencies:
@@ -7441,9 +7445,7 @@ snapshots:
 
   tabbable@6.2.0: {}
 
-  tailwindcss@4.3.0: {}
-
-  tailwindcss@4.3.2: {}
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
 
@@ -7512,13 +7514,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
+  typescript-eslint@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,12 +100,15 @@ importers:
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
+      prettier:
+        specifier: ^3.9.5
+        version: 3.9.5
       prettier-plugin-svelte:
-        specifier: ^3.4.0
-        version: 3.4.0(prettier@3.4.2)(svelte@5.17.3)
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.9.5)(svelte@5.17.3)
       prettier-plugin-tailwindcss:
         specifier: 0.8.1
-        version: 0.8.1(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2)
+        version: 0.8.1(prettier-plugin-svelte@4.1.1(prettier@3.9.5)(svelte@5.17.3))(prettier@3.9.5)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2983,11 +2986,12 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.4.0:
-    resolution: {integrity: sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==}
+  prettier-plugin-svelte@4.1.1:
+    resolution: {integrity: sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==}
+    engines: {node: '>=20'}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+      svelte: ^5.0.0
 
   prettier-plugin-tailwindcss@0.8.1:
     resolution: {integrity: sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==}
@@ -3044,8 +3048,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+  prettier@3.9.5:
+    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7017,18 +7021,18 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3):
+  prettier-plugin-svelte@4.1.1(prettier@3.9.5)(svelte@5.17.3):
     dependencies:
-      prettier: 3.4.2
+      prettier: 3.9.5
       svelte: 5.17.3
 
-  prettier-plugin-tailwindcss@0.8.1(prettier-plugin-svelte@3.4.0(prettier@3.4.2)(svelte@5.17.3))(prettier@3.4.2):
+  prettier-plugin-tailwindcss@0.8.1(prettier-plugin-svelte@4.1.1(prettier@3.9.5)(svelte@5.17.3))(prettier@3.9.5):
     dependencies:
-      prettier: 3.4.2
+      prettier: 3.9.5
     optionalDependencies:
-      prettier-plugin-svelte: 3.4.0(prettier@3.4.2)(svelte@5.17.3)
+      prettier-plugin-svelte: 4.1.1(prettier@3.9.5)(svelte@5.17.3)
 
-  prettier@3.4.2: {}
+  prettier@3.9.5: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/app/(docs)/docs/installation/(tabs)/framework-guides/page.tsx
+++ b/src/app/(docs)/docs/installation/(tabs)/framework-guides/page.tsx
@@ -52,7 +52,7 @@ function GuideTile({ guide }: { guide: Guide }) {
 
   return (
     <li className="relative flex flex-row-reverse">
-      <div className="peer group ml-6 flex-auto">
+      <div className="group peer ml-6 flex-auto">
         <h4 className="mb-2 leading-6 font-semibold text-slate-900 dark:text-slate-200">
           <Link
             href={
@@ -78,9 +78,9 @@ function GuideTile({ guide }: { guide: Guide }) {
             </svg>
           </Link>
         </h4>
-        <p className="text-sm leading-6 text-slate-700 dark:text-slate-400">{guide.tile.description}</p>
+        <p className="text-sm/6 text-slate-700 dark:text-slate-400">{guide.tile.description}</p>
       </div>
-      <div className="dark:highlight-white/5 flex h-14 w-14 flex-none items-center justify-center overflow-hidden rounded-full bg-white shadow ring-1 ring-slate-900/5 dark:bg-slate-800">
+      <div className="dark:highlight-white/5 flex size-14 flex-none items-center justify-center overflow-hidden rounded-full bg-white shadow ring-1 ring-slate-900/5 dark:bg-slate-800">
         {LogoDark ? (
           <>
             <Logo className="block dark:hidden" />

--- a/src/app/(docs)/docs/installation/framework-guides/[...slug]/page.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/[...slug]/page.tsx
@@ -90,7 +90,7 @@ export default async function Page({ params }: Props) {
 
           {page.notice ? (
             <div className="relative my-4 overflow-hidden rounded-lg bg-gray-200 p-1">
-              <div className="absolute inset-0 bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 dark:[--pattern-fg:var(--color-white)]/10"></div>
+              <div className="absolute inset-0 bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 dark:[--pattern-fg:var(--color-white)]/10"></div>
 
               <div className="relative z-10 rounded-md bg-white/75 px-4 py-3 text-sm font-medium text-gray-600 inset-ring-2 inset-ring-gray-700/25">
                 {page.notice}

--- a/src/app/(docs)/docs/installation/framework-guides/ruby-on-rails.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/ruby-on-rails.tsx
@@ -15,7 +15,7 @@ export let page: Page = {
 
   // NOTE: This intro is not used currently but is here for reference as we'll want to bring it back once the rails gem is updated for a stable v4 release.
   intro: (
-    <div className="prose prose-slate dark:prose-dark relative z-10 mb-16 max-w-3xl">
+    <div className="dark:prose-dark prose prose-slate relative z-10 mb-16 max-w-3xl">
       <p>
         The quickest way to start using Tailwind CSS in your Rails project is to use{" "}
         <a href="https://github.com/rails/tailwindcss-rails">Tailwind CSS for Rails</a> by running{" "}

--- a/src/app/(docs)/layout.tsx
+++ b/src/app/(docs)/layout.tsx
@@ -31,13 +31,13 @@ export default async function Layout({
         </div>
 
         {/* Candy cane */}
-        <div className="col-start-2 row-span-5 row-start-1 border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 max-lg:hidden dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-2 row-span-5 row-start-1 border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 max-lg:hidden dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="relative row-start-1 grid grid-cols-subgrid lg:col-start-3">{children}</div>
 
         {/* Candy cane */}
-        <div className="col-start-4 row-span-5 row-start-1 border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 max-lg:hidden dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-4 row-span-5 row-start-1 border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 max-lg:hidden dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         <div className="col-span-full col-start-2 row-start-2 h-px bg-gray-950/5 dark:bg-white/10" />
         <div className="row-start-3 lg:col-start-3">

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -60,53 +60,51 @@ export async function GET(req: NextRequest) {
   ]);
 
   return new ImageResponse(
-    (
-      <div
-        style={{
-          fontSize: 40,
-          background: `url("${HOST}/og-background.jpg")`,
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          fontFamily: "Inter",
-        }}
-      >
-        <div tw="absolute flex h-full w-full flex-col justify-between p-[32px] pt-[394px] pr-[40px]">
-          <div tw="flex flex-col h-full border-1 border-t border-gray-800 p-8">
-            {section && (
-              <div
-                tw="flex text-[20px] leading-[20px] font-medium tracking-[2px] text-gray-400"
-                style={{
-                  fontFamily: "Geist Mono",
-                }}
-              >
-                {section}
-              </div>
-            )}
+    <div
+      style={{
+        fontSize: 40,
+        background: `url("${HOST}/og-background.jpg")`,
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        fontFamily: "Inter",
+      }}
+    >
+      <div tw="absolute flex h-full w-full flex-col justify-between p-[32px] pt-[394px] pr-[40px]">
+        <div tw="flex flex-col h-full border-1 border-t border-gray-800 p-8">
+          {section && (
             <div
-              tw="mt-4 text-[60px] leading-[60px] font-medium text-white"
+              tw="flex text-[20px] leading-[20px] font-medium tracking-[2px] text-gray-400"
+              style={{
+                fontFamily: "Geist Mono",
+              }}
+            >
+              {section}
+            </div>
+          )}
+          <div
+            tw="mt-4 text-[60px] leading-[60px] font-medium text-white"
+            style={{
+              display: "block",
+              lineClamp: 1,
+            }}
+          >
+            {title}
+          </div>
+          {description && (
+            <div
+              tw="mt-4 text-[24px] leading-[40px] font-medium text-gray-400"
               style={{
                 display: "block",
                 lineClamp: 1,
               }}
             >
-              {title}
+              {description}
             </div>
-            {description && (
-              <div
-                tw="mt-4 text-[24px] leading-[40px] font-medium text-gray-400"
-                style={{
-                  display: "block",
-                  lineClamp: 1,
-                }}
-              >
-                {description}
-              </div>
-            )}
-          </div>
+          )}
         </div>
       </div>
-    ),
+    </div>,
     {
       width: WIDTH,
       height: HEIGHT,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function DocPage(props: Props) {
       <div hidden />
 
       <div className="grid grid-cols-1 xl:grid-cols-[22rem_2.5rem_auto] xl:grid-rows-[1fr_auto]">
-        <div className="col-start-2 row-span-2 border-r border-l border-gray-950/5 max-xl:hidden dark:border-white/10"></div>
+        <div className="col-start-2 row-span-2 border-x border-gray-950/5 max-xl:hidden dark:border-white/10"></div>
 
         <div className="max-xl:mx-auto max-xl:w-full max-xl:max-w-(--breakpoint-md)">
           <div className="mt-16 px-4 font-mono text-sm/7 font-medium tracking-widest text-gray-500 uppercase lg:px-2">
@@ -90,7 +90,7 @@ export default async function DocPage(props: Props) {
               <GridContainer
                 direction="to-left"
                 key={author.twitter}
-                className="flex items-center px-4 py-2 font-medium whitespace-nowrap max-xl:before:-left-[100vw]! max-xl:after:-left-[100vw]! xl:px-2 xl:before:hidden"
+                className="flex items-center px-4 py-2 font-medium whitespace-nowrap max-xl:before:left-[-100vw]! max-xl:after:left-[-100vw]! xl:px-2 xl:before:hidden"
               >
                 <Author author={author} />
               </GridContainer>
@@ -105,7 +105,7 @@ export default async function DocPage(props: Props) {
             </article>
           </GridContainer>
 
-          <GridContainer className="mt-16 px-4 py-4 sm:py-2 lg:px-2">
+          <GridContainer className="mt-16 p-4 sm:py-2 lg:px-2">
             <section>
               <h2 className="text-3xl font-medium tracking-tight text-slate-900 dark:text-white">
                 Get all of our updates directly to your&nbsp;inbox.

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -9,13 +9,13 @@ export default async function Layout({ children }: React.PropsWithChildren) {
       </div>
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center pt-14.25 [--gutter-width:2.5rem] lg:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-2xl))_var(--gutter-width)]">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">{children}</div>
 
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
       </div>
     </div>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -53,7 +53,7 @@ export default async function Blog() {
               </div>
               <div className="max-lg:hidden" />
               <div className="text-md px-2">
-                <div className="max-w-(--container-2xl)">
+                <div className="max-w-2xl">
                   <div className="mb-4 font-mono text-sm/6 font-medium tracking-widest text-gray-500 uppercase lg:hidden">
                     {formatDate(meta.date)}
                   </div>

--- a/src/app/build-uis-that-dont-suck/layout.tsx
+++ b/src/app/build-uis-that-dont-suck/layout.tsx
@@ -5,13 +5,13 @@ export default async function Layout({ children }: React.PropsWithChildren) {
     <div className="max-w-screen overflow-x-hidden [html:has(&)]:bg-gray-950">
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center [--gutter-width:--spacing(6)] sm:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-xl))_var(--gutter-width)] lg:[--gutter-width:--spacing(10)]">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-white)]/10 sm:block"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-white)]/10 sm:block"></div>
 
         {/* Main content area */}
         <div className="text-white">{children}</div>
 
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-white)]/10 sm:col-start-3 sm:block"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-white)]/10 sm:col-start-3 sm:block"></div>
       </div>
     </div>
   );

--- a/src/app/course/confirmed/page.tsx
+++ b/src/app/course/confirmed/page.tsx
@@ -8,13 +8,8 @@ export default async function Subscribed() {
     <div className="relative grid min-h-dvh grid-cols-1 place-items-center py-8 sm:px-0">
       <GridContainer className="grid gap-6 sm:grid-cols-[auto_1fr] md:gap-10">
         <div className="relative grid border-black/5 p-2 max-sm:justify-center max-sm:px-4 sm:border-r md:border-x dark:border-white/10">
-          <DotGridImage
-            darkMode={true}
-            width={472}
-            height={667}
-            className="aspect-[472/667] h-[320px] not-dark:hidden"
-          />
-          <DotGridImage darkMode={false} width={472} height={667} className="aspect-[472/667] h-[320px] dark:hidden" />
+          <DotGridImage darkMode={true} width={472} height={667} className="aspect-472/667 h-[320px] not-dark:hidden" />
+          <DotGridImage darkMode={false} width={472} height={667} className="aspect-472/667 h-[320px] dark:hidden" />
           <Signature className="pointer-events-none absolute inset-x-0 -bottom-8 mx-auto fill-gray-900 lg:-translate-x-1/5 dark:fill-gray-200" />
         </div>
         <div className="grid content-center border-l border-black/5 md:border-x dark:border-white/10">

--- a/src/app/course/layout.tsx
+++ b/src/app/course/layout.tsx
@@ -9,13 +9,13 @@ export default async function Layout({ children }: React.PropsWithChildren) {
       </div>
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center [--gutter-width:--spacing(6)] sm:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-xl))_var(--gutter-width)] lg:[--gutter-width:--spacing(10)]">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="text-gray-900 dark:text-white">{children}</div>
 
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:col-start-3 sm:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:col-start-3 sm:block dark:[--pattern-fg:var(--color-white)]/10"></div>
       </div>
     </div>
   );

--- a/src/app/course/page.tsx
+++ b/src/app/course/page.tsx
@@ -56,25 +56,25 @@ export default async function Course() {
     <div className="grid md:grid-cols-[1fr_--spacing(6)_1fr_--spacing(6)_1fr] lg:grid-cols-[1fr_--spacing(12)_1fr_--spacing(12)_1fr]">
       <div className="col-start-2 row-span-full row-start-1 grid border-x border-black/5 max-md:hidden dark:border-white/10"></div>
       <GridContainer className="col-span-full col-start-1 row-start-1 mt-12 mb-16 grid md:my-36 md:grid-cols-3 md:gap-x-6 lg:gap-x-12">
-        <div className="grid-span-1 relative grid grid-cols-1 items-center justify-center justify-self-center after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-black/5 max-sm:px-4 sm:grid-cols-[1fr_1fr] sm:pl-16 md:grid-cols-1 md:p-2 md:pl-0 dark:after:bg-white/10">
+        <div className="grid-span-1 relative grid grid-cols-1 items-center justify-center justify-self-center after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-black/5 max-sm:px-4 sm:grid-cols-[1fr_1fr] sm:pl-16 md:grid-cols-1 md:p-2 md:pl-0 dark:after:bg-white/10">
           <DotGridImage
             darkMode={true}
             width={472}
             height={667}
-            className="aspect-[472/667] w-full max-w-[226px] not-dark:hidden"
+            className="aspect-472/667 w-full max-w-[226px] not-dark:hidden"
           />
           <DotGridImage
             darkMode={false}
             width={472}
             height={667}
-            className="aspect-[472/667] w-full max-w-[226px] dark:hidden"
+            className="aspect-472/667 w-full max-w-[226px] dark:hidden"
           />
           <div className="relative font-mono text-xs font-medium text-gray-700 uppercase sm:translate-y-1/2 sm:py-5 md:hidden dark:text-gray-400">
             <p className="max-sm:hidden">
               Adam Wathan, <br />
               Creator of Tailwind CSS
             </p>
-            <Signature className="pointer-events-none absolute -translate-y-3/4 fill-gray-900 max-sm:inset-x-0 max-sm:mx-auto sm:-translate-x-1/4 sm:-translate-y-[110%] dark:fill-gray-200" />
+            <Signature className="pointer-events-none absolute -translate-y-3/4 fill-gray-900 max-sm:inset-x-0 max-sm:mx-auto sm:-translate-x-1/4 sm:translate-y-[-110%] dark:fill-gray-200" />
           </div>
         </div>
         <div className="relative grid content-between border-black/5 max-md:mt-10 max-md:border-t md:col-span-2 dark:border-white/10">
@@ -95,12 +95,12 @@ export default async function Course() {
             </div>
           </div>
         </div>
-        <div className="relative py-5 pl-16 font-mono text-xs font-medium text-gray-700 uppercase after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 max-md:hidden md:col-span-3 dark:text-gray-400 dark:after:bg-white/10">
+        <div className="relative py-5 pl-16 font-mono text-xs font-medium text-gray-700 uppercase after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 max-md:hidden md:col-span-3 dark:text-gray-400 dark:after:bg-white/10">
           <p>
             Adam Wathan, <br />
             Creator of Tailwind CSS
           </p>
-          <Signature className="pointer-events-none absolute mx-auto -translate-x-1/4 -translate-y-[110%] fill-gray-900 dark:fill-gray-200" />
+          <Signature className="pointer-events-none absolute mx-auto -translate-x-1/4 translate-y-[-110%] fill-gray-900 dark:fill-gray-200" />
         </div>
         <div className="prose grid max-w-2xl border-black/5 p-2 max-md:mt-10 max-md:border-t max-md:px-4 md:col-span-2 md:col-start-2 dark:border-white/10">
           <p className="text-lg/7">

--- a/src/app/course/subscribed/page.tsx
+++ b/src/app/course/subscribed/page.tsx
@@ -8,13 +8,8 @@ export default async function Subscribed() {
     <div className="relative grid min-h-dvh grid-cols-1 place-items-center py-8 sm:px-0">
       <GridContainer className="grid gap-6 sm:grid-cols-[auto_1fr] md:gap-10">
         <div className="relative grid border-black/5 p-2 max-sm:justify-center max-sm:px-4 sm:border-r md:border-x dark:border-white/10">
-          <DotGridImage
-            darkMode={true}
-            width={472}
-            height={667}
-            className="aspect-[472/667] h-[320px] not-dark:hidden"
-          />
-          <DotGridImage darkMode={false} width={472} height={667} className="aspect-[472/667] h-[320px] dark:hidden" />
+          <DotGridImage darkMode={true} width={472} height={667} className="aspect-472/667 h-[320px] not-dark:hidden" />
+          <DotGridImage darkMode={false} width={472} height={667} className="aspect-472/667 h-[320px] dark:hidden" />
           <Signature className="pointer-events-none absolute inset-x-0 -bottom-8 mx-auto fill-gray-900 lg:-translate-x-1/5 dark:fill-gray-200" />
         </div>
         <div className="grid content-center border-l border-black/5 md:border-x dark:border-white/10">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,31 +51,43 @@
 }
 
 @utility line-t {
-  @apply relative before:absolute before:top-0 before:left-[-100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative;
+  @variant before {
+    @apply absolute top-0 left-[-100vw] h-px w-[200vw] bg-gray-950/5;
+  }
+  @apply dark:before:bg-white/10;
 }
 
 @utility line-b {
-  @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative;
+  @variant after {
+    @apply absolute bottom-0 left-[-100vw] h-px w-[200vw] bg-gray-950/5;
+  }
+  @apply dark:after:bg-white/10;
 }
 
 @utility line-y {
-  @apply relative;
-  @apply before:absolute before:top-0 before:left-[-100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply line-t line-b relative;
 }
 
 @utility line-t/half {
-  @apply relative before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply relative;
+  @variant before {
+    @apply absolute top-0 right-0 h-px w-screen bg-gray-950/5;
+  }
+  @apply dark:before:bg-white/10;
 }
 
 @utility line-b/half {
-  @apply relative after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply relative;
+  @variant after {
+    @apply absolute right-0 bottom-0 h-px w-screen bg-gray-950/5;
+  }
+  @apply dark:after:bg-white/10;
 }
 
 @utility line-y/half {
-  @apply relative;
-  @apply before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+  @apply line-t/half line-b/half relative;
 }
 
 :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,17 +26,7 @@
   }
 }
 
-:root {
-  color-scheme: light dark;
-}
-.dark {
-  color-scheme: dark;
-}
-.light {
-  color-scheme: light;
-}
-
-@variant dark {
+@custom-variant dark {
   &:where(.dark, .dark *) {
     @slot;
   }
@@ -48,7 +38,7 @@
   }
 }
 
-@variant not-dark {
+@custom-variant not-dark {
   &:not(:where(.dark, .dark *)) {
     @media not (prefers-color-scheme: dark) {
       @slot;
@@ -58,6 +48,44 @@
       @slot;
     }
   }
+}
+
+@utility line-t {
+  @apply relative before:absolute before:top-0 before:left-[-100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+}
+
+@utility line-b {
+  @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+}
+
+@utility line-y {
+  @apply relative;
+  @apply before:absolute before:top-0 before:left-[-100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:bottom-0 after:left-[-100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
+}
+
+@utility line-t/half {
+  @apply relative before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+}
+
+@utility line-b/half {
+  @apply relative after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+}
+
+@utility line-y/half {
+  @apply relative;
+  @apply before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
+  @apply after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
+}
+
+:root {
+  color-scheme: light dark;
+}
+.dark {
+  color-scheme: dark;
+}
+.light {
+  color-scheme: light;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -102,32 +130,4 @@
       }
     }
   }
-}
-
-@utility line-t {
-  @apply relative before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
-}
-
-@utility line-b {
-  @apply relative after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
-}
-
-@utility line-y {
-  @apply relative;
-  @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-gray-950/5 dark:after:bg-white/10;
-}
-
-@utility line-t/half {
-  @apply relative before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
-}
-
-@utility line-b/half {
-  @apply relative after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
-}
-
-@utility line-y/half {
-  @apply relative;
-  @apply before:absolute before:top-0 before:right-0 before:h-px before:w-screen before:bg-gray-950/5 dark:before:bg-white/10;
-  @apply after:absolute after:right-0 after:bottom-0 after:h-px after:w-screen after:bg-gray-950/5 dark:after:bg-white/10;
 }

--- a/src/app/insiders/page.tsx
+++ b/src/app/insiders/page.tsx
@@ -155,7 +155,7 @@ function InsiderPerks() {
 function InsiderPerkScreenshots() {
   return (
     <div className="line-y mt-10 grid grid-rows-1 gap-2 p-2 md:h-130 md:grid-rows-2 lg:grid-cols-3">
-      <div className="relative overflow-hidden rounded-xl bg-gray-200 pt-9 pl-9 outline -outline-offset-1 outline-gray-950/5 max-md:aspect-[4/3] md:col-start-1 md:row-start-1 md:max-lg:col-span-2 md:max-lg:pt-5 md:max-lg:pl-5 lg:row-span-2 dark:bg-gray-900 dark:outline-white/5">
+      <div className="relative overflow-hidden rounded-xl bg-gray-200 pt-9 pl-9 outline -outline-offset-1 outline-gray-950/5 max-md:aspect-4/3 md:col-start-1 md:row-start-1 md:max-lg:col-span-2 md:max-lg:pt-5 md:max-lg:pl-5 lg:row-span-2 dark:bg-gray-900 dark:outline-white/5">
         <p className="absolute right-4 bottom-4 flex items-center gap-2 rounded-full border border-white/20 bg-black/80 pr-4 pl-2 font-mono text-xs/7 font-medium text-white outline outline-black backdrop-blur-sm lg:right-6 lg:bottom-6">
           <svg fill="#D97757" viewBox="0 0 16 16" className="size-4">
             <path d="m3.137 10.637 3.145-1.765.052-.154-.052-.085h-.154l-.526-.032-1.797-.048-1.559-.065-1.51-.081-.38-.081L0 7.856l.036-.234.32-.215.458.04 1.011.07 1.518.105 1.101.064 1.631.17h.26l.036-.105-.09-.065-.068-.064-1.57-1.065-1.7-1.125-.89-.648-.483-.328-.242-.307-.106-.672.438-.482.586.04.15.041.595.458 1.271.983 1.66 1.222.242.203.098-.07.012-.048-.11-.182-.902-1.63-.964-1.66-.429-.689-.113-.412a1.982 1.982 0 0 1-.069-.486l.498-.676L4.46 0l.664.09.28.242.412.943.668 1.485L7.52 4.78l.304.6.162.554.06.17h.106v-.097l.085-1.138.158-1.396.153-1.797.053-.506.251-.607.498-.328.388.186.32.457-.044.296-.19 1.234-.373 1.935-.243 1.295h.142l.162-.162.655-.87 1.101-1.376.486-.546.567-.604.364-.287h.688l.506.753-.226.777-.709.899-.587.76-.842 1.134-.526.907.049.072.125-.012 1.902-.405 1.029-.186 1.226-.21.555.259.06.263-.218.538-1.312.324-1.538.308-2.29.542-.03.02.033.04 1.033.098.44.024h1.081l2.012.15.526.348.316.425-.053.324-.81.413-1.092-.26-2.55-.606-.874-.219h-.122v.073l.729.712 1.336 1.206 1.671 1.555.085.384-.214.304-.227-.033-1.47-1.105-.566-.498-1.283-1.08h-.085v.113l.295.433 1.563 2.348.08.72-.113.235-.404.142-.446-.081-.914-1.283-.943-1.445-.761-1.296-.093.053-.45 4.837-.21.247L7.58 16l-.405-.308-.214-.498.214-.983.26-1.283.21-1.02.19-1.267.113-.42-.008-.03-.093.013-.955 1.311-1.453 1.963-1.15 1.23-.275.11-.477-.247.044-.441.267-.393 1.59-2.023.96-1.255.62-.725-.005-.105h-.036l-4.226 2.744-.753.098-.323-.304.04-.498.154-.162 1.27-.874-.003.004Z" />
@@ -179,7 +179,7 @@ function InsiderPerkScreenshots() {
           className="hidden w-212 max-w-none rounded-tl-xl bg-[#0F1116] outline outline-gray-950/10 dark:block dark:outline dark:outline-white/10"
         />
       </div>
-      <div className="relative overflow-hidden rounded-xl bg-[#F66969] pt-9 pl-9 inset-ring inset-ring-gray-950/10 max-md:aspect-[4/3] md:row-start-1 md:max-lg:col-start-3 md:max-lg:pt-5 md:max-lg:pl-5 lg:col-start-2">
+      <div className="relative overflow-hidden rounded-xl bg-[#F66969] pt-9 pl-9 inset-ring inset-ring-gray-950/10 max-md:aspect-4/3 md:row-start-1 md:max-lg:col-start-3 md:max-lg:pt-5 md:max-lg:pl-5 lg:col-start-2">
         <p className="absolute right-4 bottom-4 flex items-center gap-2 rounded-full border border-white/20 bg-black/80 pr-4 pl-2 font-mono text-xs/7 font-medium text-white outline outline-black backdrop-blur-sm lg:right-6 lg:bottom-6">
           <svg fill="#FF6363" viewBox="0 0 16 16" className="size-4">
             <path
@@ -196,7 +196,7 @@ function InsiderPerkScreenshots() {
           className="w-180 max-w-none rounded-tl-xl border border-black bg-[#1B1B1C] outline -outline-offset-2 outline-white/30 sm:w-200 md:w-150"
         />
       </div>
-      <div className="relative flex items-center justify-center rounded-xl bg-[#5865F2] inset-ring inset-ring-gray-950/10 max-md:aspect-[4/3] md:row-start-2 md:max-lg:col-start-1 lg:col-start-2">
+      <div className="relative flex items-center justify-center rounded-xl bg-[#5865F2] inset-ring inset-ring-gray-950/10 max-md:aspect-4/3 md:row-start-2 md:max-lg:col-start-1 lg:col-start-2">
         <p className="absolute right-4 bottom-4 flex items-center gap-2 rounded-full border border-white/20 bg-black/80 pr-4 pl-2 font-mono text-xs/7 font-medium text-white outline outline-black backdrop-blur-sm lg:right-6 lg:bottom-6">
           <LockClosedIcon className="size-4 fill-white/75" />
           Private community
@@ -205,7 +205,7 @@ function InsiderPerkScreenshots() {
           <path d="M81.15 0a73.745 73.745 0 0 0-3.36 6.794 97.867 97.867 0 0 0-28.994 0A67.876 67.876 0 0 0 45.437 0a105.544 105.544 0 0 0-26.14 8.057C2.779 32.53-1.691 56.373.53 79.887a105.038 105.038 0 0 0 32.05 16.088 76.912 76.912 0 0 0 6.87-11.063c-3.737-1.389-7.35-3.131-10.81-5.152.91-.657 1.794-1.339 2.653-1.995a75.255 75.255 0 0 0 64.075 0c.86.707 1.743 1.389 2.652 1.995a68.772 68.772 0 0 1-10.835 5.178A76.903 76.903 0 0 0 94.056 96a104.99 104.99 0 0 0 32.051-16.063c2.626-27.277-4.496-50.917-18.817-71.855A103.922 103.922 0 0 0 81.175.051L81.15 0ZM42.28 65.414c-6.238 0-11.416-5.657-11.416-12.653s4.976-12.679 11.391-12.679 11.517 5.708 11.416 12.679c-.101 6.97-5.026 12.653-11.39 12.653Zm42.078 0c-6.264 0-11.391-5.657-11.391-12.653s4.975-12.679 11.39-12.679c6.416 0 11.492 5.708 11.391 12.679-.1 6.97-5.026 12.653-11.39 12.653Z" />
         </svg>
       </div>
-      <div className="relative overflow-hidden rounded-xl bg-gray-200 pt-9 pl-9 outline -outline-offset-1 outline-gray-950/5 max-md:aspect-[4/3] md:max-lg:col-span-2 md:max-lg:col-start-2 md:max-lg:row-start-2 md:max-lg:pt-5 md:max-lg:pl-5 lg:col-start-3 lg:row-span-2 lg:row-start-1 dark:bg-gray-900 dark:outline-white/5">
+      <div className="relative overflow-hidden rounded-xl bg-gray-200 pt-9 pl-9 outline -outline-offset-1 outline-gray-950/5 max-md:aspect-4/3 md:max-lg:col-span-2 md:max-lg:col-start-2 md:max-lg:row-start-2 md:max-lg:pt-5 md:max-lg:pl-5 lg:col-start-3 lg:row-span-2 lg:row-start-1 dark:bg-gray-900 dark:outline-white/5">
         <p className="absolute right-4 bottom-4 flex items-center gap-2 rounded-full border border-white/20 bg-black/80 pr-4 pl-2 font-mono text-xs/7 font-medium text-white outline outline-black backdrop-blur-sm lg:right-6 lg:bottom-6">
           <svg fill="none" viewBox="0 0 16 16" className="size-4">
             <path

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFoundPage() {
       </div>
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center pt-14.25 [--gutter-width:2.5rem] lg:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-2xl))_var(--gutter-width)]">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">
@@ -26,7 +26,7 @@ export default function NotFoundPage() {
           </div>
         </div>
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default async function Home() {
       </div>
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center pt-14.25 [--gutter-width:2.5rem] md:-mx-4 md:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-2xl))_var(--gutter-width)] lg:mx-0">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="grid gap-24 pb-24 text-gray-950 sm:gap-40 md:pb-40 dark:text-white">
@@ -34,7 +34,7 @@ export default async function Home() {
         </div>
 
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:col-start-3 md:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:col-start-3 md:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         <GridContainer className="col-start-1 row-start-3 md:col-start-2">
           <FooterSitemap className="*:first:border-l-0 *:last:border-r-0" />

--- a/src/app/partners/[slug]/page.tsx
+++ b/src/app/partners/[slug]/page.tsx
@@ -100,7 +100,7 @@ function SponsorDetailBody({ body }: { body: SponsorDetailBodyBlock[] }) {
         return (
           <ul
             key={index}
-            className="list-[square] space-y-3 pl-5 marker:[color:color-mix(in_oklab,var(--color-gray-700)_25%,transparent)] dark:marker:[color:color-mix(in_oklab,var(--color-gray-300)_35%,transparent)]"
+            className="list-[square] space-y-3 pl-5 marker:text-[color-mix(in_oklab,var(--color-gray-700)_25%,transparent)] dark:marker:text-[color-mix(in_oklab,var(--color-gray-300)_35%,transparent)]"
           >
             {block.items.map((item) => (
               <li key={item}>{item}</li>

--- a/src/app/partners/page.tsx
+++ b/src/app/partners/page.tsx
@@ -206,7 +206,7 @@ function WhyPartner() {
             <h2 className="inline-block rounded-md bg-gray-950/5 px-3 py-1 font-mono text-xs/5 tracking-widest text-gray-950 uppercase dark:bg-white/10 dark:text-white">
               <a href="#why">
                 <span aria-hidden="true">02 / </span>
-                  Partner with us
+                Partner with us
               </a>
             </h2>
             <p className="mt-8 text-lg/7 font-medium tracking-tight text-pretty">

--- a/src/app/search.css
+++ b/src/app/search.css
@@ -704,7 +704,8 @@
     width: calc(4.5rem + 1px);
     height: 1.5rem;
     margin-left: calc(-3rem - 1px);
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+    background-image:
+      url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%2394A3B8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
     background-repeat: no-repeat, repeat-y, no-repeat;
@@ -712,13 +713,15 @@
   }
 
   .dark &::after {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+    background-image:
+      url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' opacity='0.05' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   }
   @media (prefers-color-scheme: dark) {
     .system &::after {
-      background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+      background-image:
+        url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
         url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' opacity='0.05' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
         url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
     }
@@ -727,19 +730,22 @@
 
 .DocSearch-Hit-action [title="Remove this search from favorites"]:hover {
   &::after {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+    background-image:
+      url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   }
 
   .dark &::after {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+    background-image:
+      url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' opacity='0.05' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
       url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   }
   @media (prefers-color-scheme: dark) {
     .system &::after {
-      background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
+      background-image:
+        url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12 5 2 5h5l-4 4 2 5-5-3-5 3 2-5-4-4h5l2-5Z' fill='%230EA5E9' stroke='%230EA5E9' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"),
         url("data:image/svg+xml,%3Csvg width='1' height='1' fill='%23e2e8f0' opacity='0.05' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1' height='1'/%3E%3C/svg%3E"),
         url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17 7 7 17M7 7l10 10' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
     }

--- a/src/app/showcase/layout.tsx
+++ b/src/app/showcase/layout.tsx
@@ -9,13 +9,13 @@ export default async function Layout({ children }: React.PropsWithChildren) {
       </div>
       <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_1px_auto_1px_auto] justify-center pt-14.25 [--gutter-width:2.5rem] lg:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-2xl))_var(--gutter-width)]">
         {/* Candy cane */}
-        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
 
         {/* Main content area */}
         <div className="text-gray-950 dark:text-white">{children}</div>
 
         {/* Candy cane */}
-        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
+        <div className="row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 lg:col-start-3 lg:block dark:[--pattern-fg:var(--color-white)]/10"></div>
       </div>
     </div>
   );

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -27,7 +27,7 @@ export default async function Showcase() {
       </GridContainer>
 
       <GridContainer className="mt-10">
-        <p className="prose mx-2 max-w-(--breakpoint-md) text-lg leading-8 text-gray-600 dark:text-gray-400">
+        <p className="prose mx-2 max-w-(--breakpoint-md) text-lg/8 text-gray-600 dark:text-gray-400">
           Well not quite <em>anything</em>, like you can't build a spaceship with it. But you can definitely build the
           website for the spaceship —{" "}
           <a href="https://www.jpl.nasa.gov/?utm_source=tailwindcss" target="_blank" rel="noopener noreferrer">

--- a/src/app/typography.css
+++ b/src/app/typography.css
@@ -11,7 +11,7 @@
   --prose-hr-color: color-mix(in oklab, var(--color-gray-950) 5%, transparent);
   --prose-blockquote-border-color: var(--color-gray-300);
 
-  &:where(.dark, .dark *) {
+  @variant dark {
     --prose-color: var(--color-gray-300);
     --prose-heading-color: var(--color-white);
     --prose-strong-color: var(--color-white);
@@ -23,21 +23,6 @@
     --prose-td-borders: var(--color-gray-700);
     --prose-hr-color: color-mix(in oklab, var(--color-white) 10%, transparent);
     --prose-blockquote-border-color: var(--color-gray-600);
-  }
-  @media (prefers-color-scheme: dark) {
-    &:where(.system, .system *) {
-      --prose-color: var(--color-gray-300);
-      --prose-heading-color: var(--color-white);
-      --prose-strong-color: var(--color-white);
-      --prose-link-color: var(--color-white);
-      --prose-code-color: var(--color-white);
-      --prose-marker-color: color-mix(in oklab, var(--color-gray-300) 35%, transparent);
-      --prose-link-underline-color: var(--color-sky-400);
-      --prose-th-borders: var(--color-gray-600);
-      --prose-td-borders: var(--color-gray-700);
-      --prose-hr-color: color-mix(in oklab, var(--color-white) 10%, transparent);
-      --prose-blockquote-border-color: var(--color-gray-600);
-    }
   }
 
   color: var(--prose-color);

--- a/src/blog/2022-06-23-tailwind-templates-and-all-access/index.mdx
+++ b/src/blog/2022-06-23-tailwind-templates-and-all-access/index.mdx
@@ -37,9 +37,9 @@ So today we're releasing our first batch of official Tailwind CSS <Link href="ht
 
 We started designing these way back in March and I'm really excited to get these first five out the door so you can check them out and start playing with them:
 
-- <Link href="https://syntax.tailwindui.com/">Syntax</Link> — a documentation site template powered by Stripe's new <Link href="https://markdoc.io/">
-    Markdoc
-  </Link> library that's perfect for things like open-source projects or product documentation.
+- <Link href="https://syntax.tailwindui.com/">Syntax</Link> — a documentation site template powered by Stripe's new
+  <Link href="https://markdoc.io/">Markdoc</Link> library that's perfect for things like open-source projects or product
+  documentation.
 - <Link href="https://primer.tailwindui.com/">Primer</Link> — a landing page template for ebooks and courses that bakes
   in a lot of the best practices we've learned releasing our own info products.
 - <Link href="https://salient.tailwindui.com/">Salient</Link> — a stunning but simple SaaS marketing website you can

--- a/src/components/api-table.tsx
+++ b/src/components/api-table.tsx
@@ -126,10 +126,10 @@ function ApiTableRow({
         className,
       )}
     >
-      <td className="px-2 py-2 align-top font-mono text-xs/6 font-medium text-sky-500 dark:text-sky-400">
+      <td className="p-2 align-top font-mono text-xs/6 font-medium text-sky-500 dark:text-sky-400">
         {highlight(utility)}
       </td>
-      <td className="px-2 py-2 align-top font-mono text-xs/6 text-violet-600 dark:text-violet-400">
+      <td className="p-2 align-top font-mono text-xs/6 text-violet-600 dark:text-violet-400">
         {(Array.isArray(styles) ? styles : [styles]).map((style, i) => (
           <div key={i} className="*:whitespace-pre!">
             {highlight(style)}

--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -154,7 +154,7 @@ export function HighlightedCode({
       example={example}
       className={clsx(
         "*:flex *:*:shrink-0 *:*:grow *:overflow-auto *:rounded-lg *:bg-white/10! *:p-5 dark:*:bg-white/5!",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
         "*:inset-ring *:inset-ring-white/10 dark:*:inset-ring-white/5",
         example.lang === "txt" ? "*:*:max-w-full *:*:whitespace-normal" : "*:*:max-w-none",
         className,
@@ -192,11 +192,11 @@ export function RawHighlightedCode({
         }),
         transformerNotationWordHighlight({
           classActiveWord:
-            "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word_+_&]:before:rounded-l-none",
+            "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word+&]:before:rounded-l-none",
         }),
         highlightClasses({
           highlightedClassName:
-            "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word_+_&]:before:rounded-l-none",
+            "highlighted-word relative before:absolute before:-inset-x-0.5 before:-inset-y-0.25 before:-z-10 before:block before:rounded-sm before:bg-[lab(19.93_-1.66_-9.7)] [.highlighted-word+&]:before:rounded-l-none",
         }),
       ],
     })

--- a/src/components/color.tsx
+++ b/src/components/color.tsx
@@ -387,7 +387,7 @@ export function Color({ name, shade, value }: { name: string; shade: string; val
         onClick={copyHexToClipboard}
         style={{ backgroundColor: `var(${colorVariableName})` }}
         className={clsx(
-          "aspect-1/1 w-full rounded-sm outline -outline-offset-1 outline-black/10 sm:rounded-md dark:outline-white/10",
+          "aspect-square w-full rounded-sm outline -outline-offset-1 outline-black/10 sm:rounded-md dark:outline-white/10",
         )}
       />
     </TooltipTrigger>

--- a/src/components/dynamic-viewport-example.tsx
+++ b/src/components/dynamic-viewport-example.tsx
@@ -74,7 +74,7 @@ export function DynamicViewportExample({
                 viewBox="0 0 24 24"
                 strokeWidth="1.5"
                 stroke="currentColor"
-                className="h-5 w-5 text-slate-600 dark:text-slate-400"
+                className="size-5 text-slate-600 dark:text-slate-400"
               >
                 <path
                   strokeLinecap="round"
@@ -91,7 +91,7 @@ export function DynamicViewportExample({
                 viewBox="0 0 24 24"
                 strokeWidth="1.5"
                 stroke="currentColor"
-                className="h-5 w-5 text-slate-600 dark:text-slate-400"
+                className="size-5 text-slate-600 dark:text-slate-400"
               >
                 <path
                   strokeLinecap="round"
@@ -101,7 +101,7 @@ export function DynamicViewportExample({
               </svg>
             </div>
             <motion.div
-              className="pointer-events-none h-full w-full p-[7px]"
+              className="pointer-events-none size-full p-[7px]"
               transition={{
                 ...transition,
                 duration: 0.2,
@@ -121,7 +121,7 @@ export function DynamicViewportExample({
               <div
                 className={clsx(
                   colorStyles,
-                  "grid h-full w-full grid-rows-[1fr_auto_1fr] content-center items-center justify-items-center gap-5 self-center overflow-hidden rounded-md py-4 font-mono font-bold text-slate-50",
+                  "grid size-full grid-rows-[1fr_auto_1fr] content-center items-center justify-items-center gap-5 self-center overflow-hidden rounded-md py-4 font-mono font-bold text-slate-50",
                 )}
               >
                 <div className="grid h-full grid-rows-[1px_1fr] justify-items-center">
@@ -157,13 +157,13 @@ export function DynamicViewportExample({
             animate={hidden ? "hidden" : "visible"}
             // For some reason putting this in a tailwind class doesn't work
             style={{ width: `${viewport.width - 16}px` }}
-            className={clsx(colorStyles, "absolute right-0 left-0 mx-auto rounded-b-md opacity-20")}
+            className={clsx(colorStyles, "absolute inset-x-0 mx-auto rounded-b-md opacity-20")}
           ></motion.div>
         )}{" "}
       </div>
       <div
         style={{ backgroundPosition: "10px 10px" }}
-        className="bg-grid-slate-100 dark:bg-grid-slate-700/25 pointer-events-none absolute inset-0 z-[-1] [mask-image:linear-gradient(0deg,#fff,rgba(255,255,255,0.6))] dark:[mask-image:linear-gradient(0deg,rgba(255,255,255,0.1),rgba(255,255,255,0.5))]"
+        className="bg-grid-slate-100 dark:bg-grid-slate-700/25 pointer-events-none absolute inset-0 z-[-1] mask-[linear-gradient(0deg,#fff,rgba(255,255,255,0.6))] dark:mask-[linear-gradient(0deg,rgba(255,255,255,0.1),rgba(255,255,255,0.5))]"
       />
       <div className="pointer-events-none absolute inset-0 z-[-1] rounded-xl border border-black/5 dark:border-white/5" />
     </Example>

--- a/src/components/grid-container.tsx
+++ b/src/components/grid-container.tsx
@@ -13,8 +13,8 @@ export default function GridContainer({
   let bottomDirection = "";
   switch (direction) {
     case "full":
-      topDirection = "before:-left-[100vw]";
-      bottomDirection = "after:-left-[100vw]";
+      topDirection = "before:left-[-100vw]";
+      bottomDirection = "after:left-[-100vw]";
       break;
     case "to-left":
       topDirection = "before:right-0";

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -62,7 +62,7 @@ function VersionPicker() {
       </MenuButton>
       <MenuItems
         anchor="bottom start"
-        className="mt-2 w-28 rounded-xl bg-white p-1 py-1 text-xs/7 font-medium text-gray-950 tabular-nums shadow-sm ring ring-gray-950/5 [--anchor-offset:calc(var(--spacing)*-1)] dark:bg-gray-950 dark:text-white dark:ring-white/10"
+        className="mt-2 w-28 rounded-xl bg-white p-1 text-xs/7 font-medium text-gray-950 tabular-nums shadow-sm ring ring-gray-950/5 [--anchor-offset:--spacing(-1)] dark:bg-gray-950 dark:text-white dark:ring-white/10"
       >
         <MenuItem disabled>
           <div className="flex items-center justify-between gap-2 rounded-lg px-2.5 data-active:bg-gray-950/5 dark:data-active:bg-white/10">
@@ -142,7 +142,7 @@ export function Header(props: React.PropsWithChildren) {
               />
             </svg>
 
-            <kbd className="hidden font-sans text-xs/4 text-gray-500 dark:text-gray-400 [.os-macos_&]:block">⌘K</kbd>
+            <kbd className="hidden font-sans text-xs/4 text-gray-500 in-[.os-macos]:block dark:text-gray-400">⌘K</kbd>
             <kbd className="hidden font-sans text-xs/4 text-gray-500 not-[.os-macos_&]:block dark:text-gray-400">
               Ctrl&nbsp;K
             </kbd>
@@ -223,7 +223,7 @@ export function Header(props: React.PropsWithChildren) {
             className="fixed inset-0 bg-white focus:outline-none md:hidden dark:bg-gray-950"
           >
             <DialogPanel className="size-full overflow-y-auto">
-              <div className="flex h-14 items-center justify-between px-4 py-4 sm:px-6">
+              <div className="flex h-14 items-center justify-between p-4 sm:px-6">
                 <TailwindMark className="h-6" />
                 <IconButton aria-label="Navigation" onClick={() => setNavIsOpen(false)}>
                   <svg viewBox="0 0 16 16" fill="currentColor" className="size-4">

--- a/src/components/home/bento.tsx
+++ b/src/components/home/bento.tsx
@@ -54,9 +54,9 @@ export function BentoBody({
         className,
         padding && "p-4 sm:p-8",
         "relative overflow-hidden",
-        "rounded-lg bg-gray-950/[2.5%]",
+        "rounded-lg bg-gray-950/2.5",
         "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:inset-ring after:inset-ring-gray-950/5 dark:after:inset-ring-white/10",
-        "bg-[image:radial-gradient(var(--pattern-fg)_1px,_transparent_0)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 dark:[--pattern-fg:var(--color-white)]/10",
+        "bg-[radial-gradient(var(--pattern-fg)_1px,transparent_0)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 dark:[--pattern-fg:var(--color-white)]/10",
       )}
     >
       {children}

--- a/src/components/home/build-anything-section.tsx
+++ b/src/components/home/build-anything-section.tsx
@@ -209,7 +209,7 @@ export default function BuildAnythingSection() {
 
 function ExternalLinkLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="absolute top-1/2 left-1/2 z-10 hidden -translate-x-1/2 -translate-y-1/2 transform flex-row items-center gap-[calc(1rem/16*7)] rounded-full border border-gray-950 bg-gray-950/90 py-0.5 pr-2 pb-1 pl-3 text-center font-mono text-sm/6 font-medium text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity group-hover:flex group-hover:opacity-100">
+    <div className="absolute top-1/2 left-1/2 z-10 hidden -translate-1/2 transform flex-row items-center gap-[calc(1rem/16*7)] rounded-full border border-gray-950 bg-gray-950/90 py-0.5 pr-2 pb-1 pl-3 text-center font-mono text-sm/6 font-medium text-white opacity-0 inset-ring inset-ring-white/10 transition-opacity group-hover:flex group-hover:opacity-100">
       {children}
       <svg viewBox="0 0 16 16" fill="currentColor" className="size-4">
         <path

--- a/src/components/home/category-header.tsx
+++ b/src/components/home/category-header.tsx
@@ -5,7 +5,7 @@ export default function CategoryHeader({ children, className }: { children: Reac
     <p
       className={clsx(
         className,
-        "top-0 -left-[var(--gutter-width)] origin-bottom-right text-left font-mono text-sm font-semibold tracking-widest uppercase max-2xl:mb-4 max-2xl:px-2 max-sm:px-4 sm:text-xs 2xl:absolute 2xl:-translate-x-full 2xl:-translate-y-full 2xl:-rotate-90 2xl:text-right",
+        "top-0 -left-(--gutter-width) origin-bottom-right text-left font-mono text-sm font-semibold tracking-widest uppercase max-2xl:mb-4 max-2xl:px-2 max-sm:px-4 sm:text-xs 2xl:absolute 2xl:-translate-full 2xl:-rotate-90 2xl:text-right",
       )}
     >
       {children}

--- a/src/components/home/explainer-section.tsx
+++ b/src/components/home/explainer-section.tsx
@@ -200,7 +200,7 @@ function HtmlFile({ className }: { className?: string }) {
       aria-label="editor, readonly, html file"
       className={clsx(
         "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:rounded-lg *:px-3 *:py-2",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
         "**:[code]:pr-4",
         "**:[code]:w-full **:[pre]:w-full **:[pre]:whitespace-pre-wrap",
         "text-[0.8125rem]/[1.5rem]",
@@ -245,7 +245,7 @@ function Terminal() {
     <div
       className={clsx(
         "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:rounded-lg *:px-4 *:py-2",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
         "**:[code]:pr-4",
         "text-[0.8125rem]/[1.5rem]",
       )}
@@ -269,7 +269,7 @@ async function BuiltCss({ className, timeline }: { className?: string; timeline:
       className={clsx(
         "opacity-0 group-data-finished:opacity-100 group-data-running:opacity-100",
         "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:rounded-lg *:px-4 *:py-2",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
         "**:[code]:pr-4",
         "**:[code]:w-full **:[pre]:w-full **:[pre]:whitespace-pre-wrap",
         "text-[0.8125rem]/[1.5rem]",

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -106,7 +106,7 @@ const Hero: React.FC = () => {
               />
             </svg>
             Quick search
-            <kbd className="hidden font-sans text-xs/4 text-gray-500 dark:text-gray-400 [.os-macos_&]:block">
+            <kbd className="hidden font-sans text-xs/4 text-gray-500 in-[.os-macos]:block dark:text-gray-400">
               <span className="opacity-60">⌘</span>K
             </kbd>
             <kbd className="hidden font-sans text-xs/4 text-gray-500 not-[.os-macos_&]:block dark:text-gray-400">
@@ -122,7 +122,7 @@ const Hero: React.FC = () => {
               <div
                 className={clsx(
                   "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:overflow-auto *:rounded-lg *:bg-white/10! *:p-5 dark:*:bg-white/5!",
-                  "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+                  "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
                   "*:inset-ring *:inset-ring-white/10 dark:*:inset-ring-white/5",
                 )}
               >
@@ -353,7 +353,7 @@ const Hero: React.FC = () => {
               </div>
             </Editor>
           </div>
-          <div className="relative border-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 max-lg:h-66 max-lg:border-t lg:border-l dark:[--pattern-fg:var(--color-white)]/10">
+          <div className="relative border-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 max-lg:h-66 max-lg:border-t lg:border-l dark:[--pattern-fg:var(--color-white)]/10">
             <div className="absolute right-1/2 max-lg:bottom-8 max-md:translate-x-1/2 md:right-16 lg:top-1/2 lg:-translate-y-1/2 2xl:right-1/2 2xl:translate-x-[calc(50%-3rem)]">
               <Example step={step} />
             </div>
@@ -375,7 +375,7 @@ function Example({ step }: { step: number }) {
       transition={TRANSITION}
       className={clsx(
         "@container rounded-3xl bg-black/5 p-2 outline outline-white/15 backdrop-blur-md dark:bg-white/10",
-        step > 7 && step !== 11 ? "w-[584px]" : "w-[262px] xl:ml-[3rem]",
+        step > 7 && step !== 11 ? "w-[584px]" : "w-[262px] xl:ml-12",
       )}
     >
       <motion.div

--- a/src/components/home/tabs.tsx
+++ b/src/components/home/tabs.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 
 export function TabButtonContainer({ children }: { children: React.ReactNode }) {
   return (
-    <TabList className="grid grid-cols-[repeat(auto-fit,calc(var(--spacing)*42))] overflow-x-auto text-gray-950 dark:text-white">
+    <TabList className="grid grid-cols-[repeat(auto-fit,--spacing(42))] overflow-x-auto text-gray-950 dark:text-white">
       {children}
     </TabList>
   );

--- a/src/components/home/tailwind-ui-section.tsx
+++ b/src/components/home/tailwind-ui-section.tsx
@@ -107,7 +107,7 @@ export default function TailwindUiSection() {
       <TabGroup>
         <GridContainer className="mt-16">
           <div className="mt-16 grid w-full overflow-x-hidden">
-            <TabList className="grid grid-cols-[repeat(3,_minmax(125px,_1fr))] divide-x divide-gray-950/10 overflow-x-auto text-gray-950 dark:divide-white/10 dark:text-white">
+            <TabList className="grid grid-cols-[repeat(3,minmax(125px,1fr))] divide-x divide-gray-950/10 overflow-x-auto text-gray-950 dark:divide-white/10 dark:text-white">
               <TabButton className="data-selected:bg-pink-500/5 data-selected:text-pink-600 dark:data-selected:text-pink-500">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -369,7 +369,7 @@ export default function TailwindUiSection() {
           <TabPanels>
             <TabPanel className="bg-gray-950/5 p-2 dark:bg-white/10 dark:opacity-40">
               <BentoItem className="relative isolate h-148 w-full overflow-hidden bg-white/75! p-0! dark:bg-gray-950! dark:ring dark:ring-white/10">
-                <div className="absolute -left-[300%] h-150 w-380 min-[500px]:-left-[250%] sm:-left-[200%] md:-left-[150%] lg:-left-[100%] xl:-left-[80%] 2xl:-left-[65%]">
+                <div className="absolute left-[-300%] h-150 w-380 min-[500px]:left-[-250%] sm:left-[-200%] md:left-[-150%] lg:-left-full xl:left-[-80%] 2xl:left-[-65%]">
                   <div className="grid origin-top-left scale-120 rotate-x-55 rotate-y-0 -rotate-z-45 grid-cols-3 transform-3d">
                     <motion.img
                       initial={{ y: 700 }}
@@ -722,7 +722,7 @@ export default function TailwindUiSection() {
 
             <TabPanel className="bg-gray-950/5 p-2 dark:bg-white/5">
               <BentoItem className="relative isolate h-148 w-full overflow-hidden bg-white/75! p-0! dark:bg-gray-950!">
-                <div className="absolute -left-[300%] h-150 w-380 min-[500px]:-left-[250%] sm:-left-[200%] md:-left-[150%] lg:-left-[100%] xl:-left-[80%] 2xl:-left-[65%]">
+                <div className="absolute left-[-300%] h-150 w-380 min-[500px]:left-[-250%] sm:left-[-200%] md:left-[-150%] lg:-left-full xl:left-[-80%] 2xl:left-[-65%]">
                   <div className="flex origin-top-left scale-100 rotate-x-55 rotate-y-0 -rotate-z-45 grid-cols-3 flex-row gap-4 transform-3d dark:bg-white/5">
                     <motion.img
                       initial={{ y: 700 }}

--- a/src/components/home/transforms-3d.tsx
+++ b/src/components/home/transforms-3d.tsx
@@ -12,7 +12,7 @@ const INITIAL = {
 export function Transforms3d() {
   return (
     <div className="grid size-full place-content-center">
-      <div className="-translate-y-4 transition duration-300 perspective-[1200px] perspective-origin-top">
+      <div className="-translate-y-4 transition duration-300 perspective-distant perspective-origin-top">
         <motion.img
           initial={INITIAL}
           whileHover={INITIAL}

--- a/src/components/home/why-tailwind-css-section/dark-mode.tsx
+++ b/src/components/home/why-tailwind-css-section/dark-mode.tsx
@@ -53,7 +53,7 @@ export function DarkMode() {
           </motion.div>
         </div>
 
-        <div className="isolate flex h-full w-full items-center justify-center">
+        <div className="isolate flex size-full items-center justify-center">
           <div className="relative grid h-112 w-[375px] grid-cols-1 grid-rows-1 overflow-hidden rounded-t-4xl bg-gray-950/10 outline outline-gray-950/10 dark:outline-white/10">
             <div className="col-start-1 row-start-1">
               <motion.img

--- a/src/components/installation-steps.tsx
+++ b/src/components/installation-steps.tsx
@@ -18,7 +18,7 @@ export function Steps({ steps }: { steps: Step[] }) {
       {steps.map((step, stepIdx) => (
         <Fragment key={stepIdx}>
           <div data-tabs={step.tabs?.join(" ") ?? null}>
-            <div className="grid size-7 grid-cols-1 grid-rows-1 place-content-center border-1 border-gray-700/50 font-mono text-[10px]/7 font-medium text-gray-950 dark:border-white/50 dark:text-white">
+            <div className="grid size-7 grid-cols-1 grid-rows-1 place-content-center border border-gray-700/50 font-mono text-[10px]/7 font-medium text-gray-950 dark:border-white/50 dark:text-white">
               <div className="col-start-1 row-start-1 grid place-content-center">
                 <div className="h-7 w-5 bg-white dark:bg-gray-950" />
               </div>
@@ -29,12 +29,12 @@ export function Steps({ steps }: { steps: Step[] }) {
           </div>
 
           <div className="col-span-5 xl:col-span-2" data-tabs={step.tabs?.join(" ") ?? null}>
-            <h4 className="mb-2 text-sm leading-6 font-semibold text-slate-900 dark:text-slate-200">{step.title}</h4>
+            <h4 className="mb-2 text-sm/6 font-semibold text-slate-900 dark:text-slate-200">{step.title}</h4>
             <div className="prose">{step.body}</div>
           </div>
 
           <div
-            className="col-span-full mt-6 mb-16 sm:ml-13 xl:col-span-3 xl:m-0 xl:ml-0"
+            className="col-span-full mt-6 mb-16 sm:ml-13 xl:col-span-3 xl:m-0"
             data-tabs={step.tabs?.join(" ") ?? null}
           >
             <CodeExample

--- a/src/components/multi-cursor/example.tsx
+++ b/src/components/multi-cursor/example.tsx
@@ -27,7 +27,7 @@ export function MultiCursorCode() {
     <HighlightedCode
       className={clsx(
         "*:flex *:*:max-w-none *:*:shrink-0 *:*:grow *:overflow-auto *:rounded-lg *:bg-white/10! *:p-5 *:inset-ring *:inset-ring-white/10 dark:*:bg-white/5! dark:*:inset-ring-white/5",
-        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-[1lh]",
+        "**:[.line]:isolate **:[.line]:block **:[.line]:not-last:min-h-lh",
       )}
       example={code}
       transformers={[

--- a/src/components/nav-list.tsx
+++ b/src/components/nav-list.tsx
@@ -24,8 +24,8 @@ export function NavListItems({ children, nested = false }: React.PropsWithChildr
   return (
     <ul
       className={clsx(
-        "flex flex-col gap-2 border-l dark:border-[color-mix(in_oklab,_var(--color-gray-950),white_20%)]",
-        nested ? "border-transparent" : "border-[color-mix(in_oklab,_var(--color-gray-950),white_90%)]",
+        "flex flex-col gap-2 border-l dark:border-[color-mix(in_oklab,var(--color-gray-950),white_20%)]",
+        nested ? "border-transparent" : "border-[color-mix(in_oklab,var(--color-gray-950),white_90%)]",
       )}
     >
       {children}

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -11,7 +11,7 @@ export default function Pagination({ slug }: { slug: string }) {
   let next = position < flatIndex.length - 1 ? flatIndex[position + 1] : null;
 
   return (
-    <footer className="mt-16 text-sm leading-6">
+    <footer className="mt-16 text-sm/6">
       <div className="flex items-center justify-between gap-2 text-gray-700 dark:text-gray-200">
         {prev ? (
           <Link className="group flex items-center gap-2 hover:text-gray-900 dark:hover:text-white" href={prev[1]}>

--- a/src/components/promos.tsx
+++ b/src/components/promos.tsx
@@ -15,17 +15,17 @@ export function BookPromo() {
     <a href="https://www.refactoringui.com/?ref=sidebar" className="group">
       <div className="mt-12 flex flex-col items-center justify-center">
         <div className="relative origin-center -translate-x-3 rotate-6 p-6 duration-500 group-hover:rotate-0">
-          <div className="absolute top-4 left-0 h-px w-full bg-[linear-gradient(to_right,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
-          <div className="absolute top-0 left-4 h-full w-px bg-[linear-gradient(to_bottom,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-4 left-0 h-px w-full bg-[linear-gradient(to_right,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-0 left-4 h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
           <Image
             src={bookPromo}
             alt="Refactoring UI"
             width={128}
             height={171.2}
-            className="shadow-[-5px_10px_15px_-3px_var(--shadow-color),_-5px_4px_6px_-4px_var(--shadow-color)] duration-500 [--shadow-color:var(--color-black)]/10 dark:[--shadow-color:var(--color-black)]"
+            className="shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)] duration-500 [--shadow-color:var(--color-black)]/10 dark:[--shadow-color:var(--color-black)]"
           />
-          <div className="absolute top-0 right-4 h-full w-px bg-[linear-gradient(to_bottom,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
-          <div className="absolute bottom-4 left-0 h-px w-full bg-[linear-gradient(to_right,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-0 right-4 h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute bottom-4 left-0 h-px w-full bg-[linear-gradient(to_right,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
         </div>
       </div>
       <p className="text-[0.815rem]/6 font-semibold text-sky-500 dark:text-sky-400">
@@ -49,17 +49,17 @@ export function CoursePromo() {
     <div className="group relative">
       <div className="mt-12 flex flex-col items-center justify-center">
         <div className="relative origin-center -translate-x-3 rotate-6 p-6 duration-500 group-hover:rotate-0">
-          <div className="absolute top-4 left-0 h-px w-full bg-[linear-gradient(to_right,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
-          <div className="absolute top-0 left-4 h-full w-px bg-[linear-gradient(to_bottom,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-4 left-0 h-px w-full bg-[linear-gradient(to_right,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-0 left-4 h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
           <Image
             src={coursePromo}
             alt="Build UIs that don’t suck — 5-day mini-course"
             width={192}
             height={108}
-            className="shadow-[-5px_10px_15px_-3px_var(--shadow-color),_-5px_4px_6px_-4px_var(--shadow-color)] duration-500 [--shadow-color:var(--color-black)]/10 dark:[--shadow-color:var(--color-black)]"
+            className="shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)] duration-500 [--shadow-color:var(--color-black)]/10 dark:[--shadow-color:var(--color-black)]"
           />
-          <div className="absolute top-0 right-4 h-full w-px bg-[linear-gradient(to_bottom,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
-          <div className="absolute bottom-4 left-0 h-px w-full bg-[linear-gradient(to_right,_transparent_0%,_var(--gradient-bg)_9.27%,_var(--gradient-bg)_90.7%,_transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute top-0 right-4 h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
+          <div className="absolute bottom-4 left-0 h-px w-full bg-[linear-gradient(to_right,transparent_0%,var(--gradient-bg)_9.27%,var(--gradient-bg)_90.7%,transparent_100%)] [--gradient-bg:var(--color-black)]/15 dark:[--gradient-bg:var(--color-white)]/10"></div>
           <div className="absolute inset-6 flex items-center justify-center">
             <div className="flex size-10 items-center justify-center rounded-full bg-white/30 outline -outline-offset-6 outline-white">
               <svg className="size-3" viewBox="0 0 17 17" fill="none">

--- a/src/components/showcase-thumbnail.tsx
+++ b/src/components/showcase-thumbnail.tsx
@@ -67,7 +67,7 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
 
   return (
     <div
-      className="group dark:border-bg-white/10 relative isolate border-x border-gray-950/5 transition-colors hover:bg-gray-950/5 max-sm:border-0 sm:max-lg:nth-[2n]:border-r-transparent sm:max-lg:nth-[2n+1]:border-l-transparent lg:max-xl:nth-[3n]:border-r-transparent lg:max-xl:nth-[3n+1]:border-l-transparent xl:nth-[4n]:border-r-transparent xl:nth-[4n+1]:border-l-transparent dark:border-white/10 dark:hover:bg-white/2.5"
+      className="dark:border-bg-white/10 group relative isolate border-x border-gray-950/5 transition-colors hover:bg-gray-950/5 max-sm:border-0 sm:max-lg:nth-[2n]:border-r-transparent sm:max-lg:nth-[2n+1]:border-l-transparent lg:max-xl:nth-[3n]:border-r-transparent lg:max-xl:nth-[3n+1]:border-l-transparent xl:nth-[4n]:border-r-transparent xl:nth-[4n+1]:border-l-transparent dark:border-white/10 dark:hover:bg-white/2.5"
       onMouseEnter={() => {
         if (state.current === "idle") {
           state.current = "playing";
@@ -84,11 +84,11 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
     >
       <a href={showcase.url} target="_blank" rel="noopener noreferrer" className="absolute inset-0 z-10"></a>
       <GridContainer className={clsx("p-2", BEFORE_AND_AFTER_ONLY_IN_FIRST_COLUMN_OF_CURRENT_GRID)}>
-        <div className="relative aspect-[672/494] overflow-hidden rounded-xl outline outline-gray-950/5">
+        <div className="relative aspect-672/494 overflow-hidden rounded-xl outline outline-gray-950/5">
           <Image
             src={showcase.thumbnail}
             alt=""
-            className={clsx("absolute inset-0 h-full w-full", showcase.dark && "dark:hidden")}
+            className={clsx("absolute inset-0 size-full", showcase.dark && "dark:hidden")}
             priority={priority}
             unoptimized
           />
@@ -96,7 +96,7 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
             <Image
               src={showcase.dark.thumbnail}
               alt=""
-              className="absolute inset-0 hidden h-full w-full dark:block"
+              className="absolute inset-0 hidden size-full dark:block"
               priority={priority}
               unoptimized
             />
@@ -122,7 +122,7 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
               muted
               playsInline
               className={clsx(
-                "absolute inset-0 h-full w-full [mask-image:radial-gradient(white,black)]",
+                "absolute inset-0 size-full mask-[radial-gradient(white,black)]",
                 showcase.dark && "dark:hidden",
               )}
               onEnded={onEnded}
@@ -135,7 +135,7 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
                 preload="none"
                 muted
                 playsInline
-                className="absolute inset-0 hidden h-full w-full [mask-image:radial-gradient(white,black)] dark:block"
+                className="absolute inset-0 hidden size-full mask-[radial-gradient(white,black)] dark:block"
                 onEnded={onEnded}
               >
                 <source src={showcase.dark.video} type="video/mp4" />
@@ -150,7 +150,7 @@ export default function ShowcaseThumbnail({ showcase, priority = false }: { show
           {showcase.isTemplate && (
             <p
               aria-label="This site is a Tailwind Plus template"
-              className="ml-2 rounded-full border border-transparent bg-sky-100 px-1.5 text-[0.6875rem] leading-5 font-semibold text-sky-500 dark:bg-gray-600/50 dark:text-gray-200 dark:group-hover:bg-sky-500 dark:group-hover:text-white"
+              className="ml-2 rounded-full border border-transparent bg-sky-100 px-1.5 text-[0.6875rem]/5 font-semibold text-sky-500 dark:bg-gray-600/50 dark:text-gray-200 dark:group-hover:bg-sky-500 dark:group-hover:text-white"
             >
               Template
             </p>

--- a/src/components/stripes.tsx
+++ b/src/components/stripes.tsx
@@ -16,8 +16,8 @@ export function Stripes({
         border === "x" && "border-x",
         border === "y" && "border-y",
         noColor === false && "text-black/10 dark:text-white/12.5",
-        "bg-[size:8px_8px] bg-top-left",
-        "bg-[image:repeating-linear-gradient(315deg,currentColor_0,currentColor_1px,transparent_0,transparent_50%)]",
+        "bg-size-[8px_8px] bg-top-left",
+        "bg-[repeating-linear-gradient(315deg,currentColor_0,currentColor_1px,transparent_0,transparent_50%)]",
       )}
     >
       {children ? children : null}

--- a/src/docs/align-items.mdx
+++ b/src/docs/align-items.mdx
@@ -185,7 +185,7 @@ Use the `items-baseline-last` utility to align items along the container's cross
       <div className="grid grid-cols-[1fr_auto] items-baseline-last gap-x-4 px-4 py-6">
         <div className="grid grid-cols-[auto_1fr] gap-x-4 max-sm:grid-cols-1">
           <img
-            className="size-[2rem] rounded-full"
+            className="size-8 rounded-full"
             src="https://spotlight.tailwindui.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Favatar.51a13c67.jpg&w=128&q=80"
             alt=""
           />
@@ -202,7 +202,7 @@ Use the `items-baseline-last` utility to align items along the container's cross
       <div className="grid grid-cols-[1fr_auto] items-baseline-last gap-x-4 px-4 py-6">
         <div className="grid grid-cols-[auto_1fr] gap-x-4 max-sm:grid-cols-1">
           <img
-            className="size-[2rem] rounded-full"
+            className="size-8 rounded-full"
             src="https://images.unsplash.com/photo-1590895340509-793cb98788c9?q=80&w=256&h=256&&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             alt=""
           />

--- a/src/docs/align-self.mdx
+++ b/src/docs/align-self.mdx
@@ -239,7 +239,7 @@ Use the `self-baseline-last` utility to align an item along the container's cros
     <div className="mx-auto grid max-w-md divide-y divide-gray-100 border-x border-x-gray-200 text-gray-700 dark:divide-gray-800 dark:border-x-gray-800 dark:bg-gray-950/10 dark:text-gray-300">
       <div className="grid grid-cols-[auto_1fr_auto] gap-x-4 px-4 py-6">
         <img
-          className="size-[2rem] rounded-full"
+          className="size-8 rounded-full"
           src="https://spotlight.tailwindui.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Favatar.51a13c67.jpg&w=128&q=80"
           alt=""
         />
@@ -256,7 +256,7 @@ Use the `self-baseline-last` utility to align an item along the container's cros
       </div>
       <div className="grid grid-cols-[auto_1fr_auto] gap-x-4 px-4 py-6">
         <img
-          className="size-[2rem] rounded-full"
+          className="size-8 rounded-full"
           src="https://images.unsplash.com/photo-1590895340509-793cb98788c9?q=80&w=256&h=256&&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
           alt=""
         />

--- a/src/docs/background-attachment.mdx
+++ b/src/docs/background-attachment.mdx
@@ -24,7 +24,7 @@ Use the `bg-fixed` utility to fix the background image relative to the viewport:
 
 <Example padding={false}>
   {
-    <div className="mx-auto h-80 overflow-y-scroll border-x border-x-gray-200 bg-[url('https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&h=800&q=80')] bg-cover bg-[center_-100px] dark:border-gray-800">
+    <div className="mx-auto h-80 overflow-y-scroll border-x border-x-gray-200 bg-[url('https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&h=800&q=80')] bg-cover bg-position-[center_-100px] dark:border-gray-800">
       <div className="mt-45">
         <div className="border-x border-x-gray-200 bg-white p-4 text-gray-500 sm:p-8 dark:border-x-gray-800 dark:bg-gray-900 dark:text-gray-400">
           <div className="font-inter text-2xl font-extrabold tracking-tight text-black dark:text-white">

--- a/src/docs/background-image.mdx
+++ b/src/docs/background-image.mdx
@@ -172,7 +172,7 @@ Use utilities like `from-indigo-500`, `via-purple-500`, and `to-pink-500` to set
 <Example>
   {
     <div className="mx-5">
-      <div className="relative h-[3.625rem]">
+      <div className="relative h-14.5">
         <div className="absolute top-0 left-px -ml-4 flex h-12 flex-col items-center">
           <svg viewBox="0 0 32 34" className="w-8 flex-none fill-indigo-500 drop-shadow">
             <use href="#gradient-color-stop" />
@@ -213,7 +213,7 @@ Use utilities like `from-10%`, `via-30%`, and `to-90%` to set more precise posit
 <Example>
   {
     <div className="mx-5">
-      <div className="relative h-[3.625rem]">
+      <div className="relative h-14.5">
         <div className="absolute top-0 left-[10%] -ml-4 flex h-12 flex-col items-center">
           <svg viewBox="0 0 32 34" className="w-8 flex-none fill-indigo-500 drop-shadow">
             <use href="#gradient-color-stop" />

--- a/src/docs/background-position.mdx
+++ b/src/docs/background-position.mdx
@@ -39,7 +39,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-top-left
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top-left outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top-left outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute top-0 left-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -51,7 +51,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-top
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute top-0 -left-6 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -63,7 +63,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-top-right
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top-right outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top-right outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute top-0 right-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -75,7 +75,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-left
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-left outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-left outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-6 left-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -87,7 +87,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-center
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-center outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-center outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-6 -left-6 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -99,7 +99,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-right
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-right outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-right outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-6 right-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -111,7 +111,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-bottom-left
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom-left outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom-left outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-12 left-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -123,7 +123,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-bottom
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-12 -left-6 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -135,7 +135,7 @@ Use utilities like `bg-center`, `bg-right`, and `bg-top-left` to control the pos
             bg-bottom-right
           </p>
           <div className="group relative mx-auto h-20 w-20 rounded-lg">
-            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom-right outline -outline-offset-1 outline-black/10"></div>
+            <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom-right outline -outline-offset-1 outline-black/10"></div>
             <img
               className="absolute -top-12 right-0 h-32 w-32 max-w-none overflow-hidden rounded-md opacity-0 sm:group-hover:opacity-25"
               src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"

--- a/src/docs/box-decoration-break.mdx
+++ b/src/docs/box-decoration-break.mdx
@@ -28,7 +28,7 @@ Use the `box-decoration-slice` and `box-decoration-clone` utilities to control w
       <div className="flex flex-col">
         <p className="mb-3 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">box-decoration-slice</p>
         <div className="font-sans text-5xl leading-none font-extrabold tracking-tight">
-          <span className="bg-linear-to-r from-indigo-600 to-pink-500 box-decoration-slice px-2 leading-[3.5rem] text-white">
+          <span className="bg-linear-to-r from-indigo-600 to-pink-500 box-decoration-slice px-2 leading-14 text-white">
             Hello
             <br />
             World
@@ -38,7 +38,7 @@ Use the `box-decoration-slice` and `box-decoration-clone` utilities to control w
       <div className="flex flex-col">
         <p className="mb-3 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">box-decoration-clone</p>
         <div className="font-sans text-5xl leading-none font-extrabold tracking-tight">
-          <span className="bg-linear-to-r from-indigo-600 to-pink-500 box-decoration-clone px-2 leading-[3.5rem] text-white">
+          <span className="bg-linear-to-r from-indigo-600 to-pink-500 box-decoration-clone px-2 leading-14 text-white">
             Hello
             <br />
             World

--- a/src/docs/box-sizing.mdx
+++ b/src/docs/box-sizing.mdx
@@ -52,13 +52,13 @@ This means a 100px &times; 100px element with a 2px border and 4px of padding on
         {/* h-measure indicator */}
         <div className="absolute top-0 right-2 bottom-0 flex w-3">
           {/* Vertical line */}
-          <div className="absolute top-0 bottom-0 left-1/2 w-px -translate-x-[0.5px] bg-sky-400"></div>
+          <div className="absolute top-0 bottom-0 left-1/2 w-px translate-x-[-0.5px] bg-sky-400"></div>
           {/* Top chip */}
           <div className="w-full">
             <div className="absolute top-0 left-1/2 h-px w-2 -translate-x-1 -translate-y-px rounded-full bg-sky-400"></div>
           </div>
           {/* Badge */}
-          <div className="relative flex h-3 flex-auto -translate-x-[1.15rem] translate-y-14 -rotate-90 items-center justify-center bg-white px-1.5 font-mono text-xs leading-none font-bold text-sky-600 dark:bg-gray-900 dark:text-sky-400">
+          <div className="relative flex h-3 flex-auto translate-x-[-1.15rem] translate-y-14 -rotate-90 items-center justify-center bg-white px-1.5 font-mono text-xs leading-none font-bold text-sky-600 dark:bg-gray-900 dark:text-sky-400">
             128px
           </div>
           {/* Bottom chip */}
@@ -130,13 +130,13 @@ This means a 100px &times; 100px element with a 2px border and 4px of padding on
         {/* h-measure indicator */}
         <div className="absolute top-0 right-2 bottom-0 flex w-3 -translate-x-5">
           {/* Vertical line */}
-          <div className="absolute top-0 bottom-0 left-1/2 w-px -translate-x-[0.5px] bg-blue-400"></div>
+          <div className="absolute top-0 bottom-0 left-1/2 w-px translate-x-[-0.5px] bg-blue-400"></div>
           {/* Top chip */}
           <div className="w-full">
             <div className="absolute top-0 left-1/2 h-px w-2 -translate-x-1 -translate-y-px rounded-full bg-blue-400"></div>
           </div>
           {/* Badge */}
-          <div className="relative flex h-3 flex-auto -translate-x-[1.15rem] translate-y-14 -rotate-90 items-center justify-center bg-white px-1.5 font-mono text-xs leading-none font-bold text-blue-600 dark:bg-gray-900 dark:text-blue-400">
+          <div className="relative flex h-3 flex-auto translate-x-[-1.15rem] translate-y-14 -rotate-90 items-center justify-center bg-white px-1.5 font-mono text-xs leading-none font-bold text-blue-600 dark:bg-gray-900 dark:text-blue-400">
             128px
           </div>
           {/* Bottom chip */}

--- a/src/docs/clear.mdx
+++ b/src/docs/clear.mdx
@@ -29,7 +29,7 @@ Use the `clear-left` utility to position an element below any preceding left-flo
   {
     <>
       <img
-        className="float-left mr-6 mb-4 aspect-16/9 w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-left mr-6 mb-4 aspect-video w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <img
@@ -73,7 +73,7 @@ Use the `clear-right` utility to position an element below any preceding right-f
         src="https://images.unsplash.com/photo-1434394354979-a235cd36269d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <img
-        className="float-right mb-4 ml-6 aspect-16/9 w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-right mb-4 ml-6 aspect-video w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=formathttps://images.unsplash.com/photo-1454496522488-7a8e488e8606?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <p className="clear-right text-justify">
@@ -109,7 +109,7 @@ Use the `clear-both` utility to position an element below all preceding floated 
   {
     <>
       <img
-        className="float-left mr-6 mb-4 aspect-16/9 w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-left mr-6 mb-4 aspect-video w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=formathttps://images.unsplash.com/photo-1454496522488-7a8e488e8606?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <img
@@ -149,7 +149,7 @@ Use the `clear-start` and `clear-end` utilities, which use [logical properties](
   {
     <div dir="rtl">
       <img
-        className="float-left mr-6 mb-4 aspect-16/9 w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-left mr-6 mb-4 aspect-video w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <img
@@ -193,7 +193,7 @@ Use the `clear-none` utility to reset any clears that are applied to an element:
         src="https://images.unsplash.com/photo-1434394354979-a235cd36269d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <img
-        className="float-right ml-6 aspect-16/9 w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-right ml-6 aspect-video w-1/4 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=formathttps://images.unsplash.com/photo-1454496522488-7a8e488e8606?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <p className="text-justify">

--- a/src/docs/color-scheme.mdx
+++ b/src/docs/color-scheme.mdx
@@ -28,21 +28,21 @@ Use utilities like `scheme-light` and `scheme-light-dark` to control how element
 <Example>
   {
     <div className="flex justify-between gap-8 text-sm max-sm:flex-col">
-      <div className="flex flex-grow flex-col items-center gap-3 text-center scheme-light">
+      <div className="flex grow flex-col items-center gap-3 text-center scheme-light">
         <p className="font-mono font-medium text-gray-500 dark:text-gray-400">scheme-light</p>
         <input
           type="date"
           className="w-full rounded-lg border border-gray-950/10 bg-[Field] px-3 py-2 text-[FieldText] dark:border-white/10"
         />
       </div>
-      <div className="flex flex-grow flex-col items-center gap-3 text-center scheme-dark">
+      <div className="flex grow flex-col items-center gap-3 text-center scheme-dark">
         <p className="font-mono font-medium text-gray-500 dark:text-gray-400">scheme-dark</p>
         <input
           type="date"
           className="w-full rounded-lg border border-gray-950/10 bg-[Field] px-3 py-2 text-[FieldText] dark:border-white/10"
         />
       </div>
-      <div className="flex flex-grow flex-col items-center gap-3 text-center scheme-light-dark">
+      <div className="flex grow flex-col items-center gap-3 text-center scheme-light-dark">
         <p className="font-medium text-gray-500 dark:text-gray-400">scheme-light-dark</p>
         <input
           type="date"

--- a/src/docs/columns.mdx
+++ b/src/docs/columns.mdx
@@ -47,7 +47,7 @@ Use `columns-<number>` utilities like `columns-3` to set the number of columns t
         <Stripes border="x" />
         <Stripes border="x" />
       </div>
-      <div className="relative -mb-[5cqw] columns-3 gap-[5cqw] *:mb-[5cqw]">
+      <div className="relative mb-[-5cqw] columns-3 gap-[5cqw] *:mb-[5cqw]">
         <img
           className="aspect-3/2 rounded-lg bg-black/5 object-cover outline -outline-offset-1 outline-black/10 dark:outline-0"
           src="https://images.unsplash.com/photo-1454496522488-7a8e488e8606?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2952&q=80"

--- a/src/docs/float.mdx
+++ b/src/docs/float.mdx
@@ -28,7 +28,7 @@ Use the `float-right` utility to float an element to the right of its container:
   {
     <>
       <img
-        className="float-right ml-6 aspect-16/9 w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-right ml-6 aspect-video w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <p className="text-justify">
@@ -63,7 +63,7 @@ Use the `float-left` utility to float an element to the left of its container:
   {
     <>
       <img
-        className="float-left mr-6 aspect-16/9 w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="float-left mr-6 aspect-video w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <p className="text-justify">
@@ -101,7 +101,7 @@ Use the `float-start` and `float-end` utilities, which use [logical properties](
         <p className="mb-4 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">left-to-right</p>
         <div>
           <img
-            className="float-start me-6 aspect-16/9 w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+            className="float-start me-6 aspect-video w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
           />
           <p className="text-justify">
@@ -118,7 +118,7 @@ Use the `float-start` and `float-end` utilities, which use [logical properties](
         <p className="mb-4 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">right-to-left</p>
         <div>
           <img
-            className="float-start me-6 aspect-16/9 w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+            className="float-start me-6 aspect-video w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
           />
           <p className="text-justify">
@@ -160,7 +160,7 @@ Use the `float-none` utility to reset any floats that are applied to an element:
   {
     <>
       <img
-        className="mb-4 aspect-16/9 w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
+        className="mb-4 aspect-video w-2/5 rounded-lg object-cover outline -outline-offset-1 outline-black/10"
         src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
       />
       <p className="text-justify">

--- a/src/docs/hover-focus-and-other-states.mdx
+++ b/src/docs/hover-focus-and-other-states.mdx
@@ -806,7 +806,7 @@ When nesting groups, you can style something based on the state of a _specific_ 
       >
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 className="h-12 w-12 rounded-full"
                 src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
@@ -840,7 +840,7 @@ When nesting groups, you can style something based on the state of a _specific_ 
         </li>
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 className="h-12 w-12 rounded-full"
                 src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
@@ -874,7 +874,7 @@ When nesting groups, you can style something based on the state of a _specific_ 
         </li>
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 className="h-12 w-12 rounded-full"
                 src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
@@ -2051,7 +2051,7 @@ Use the `starting` variant to set the appearance of an element when it is first 
         <div
           popover="auto"
           id="my-popover"
-          className="relative inset-y-0 mx-auto my-auto transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left opacity-0 shadow-xl transition-all [transition-behavior:allow-discrete] duration-500 sm:w-full sm:max-w-96 sm:p-6 dark:bg-gray-800 [&:is([open],:popover-open)]:opacity-100 [@starting-style]:[&:is([open],:popover-open)]:opacity-0"
+          className="relative inset-y-0 mx-auto my-auto transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left opacity-0 shadow-xl transition-all transition-discrete duration-500 open:opacity-100 sm:w-full sm:max-w-96 sm:p-6 dark:bg-gray-800 starting:open:opacity-0"
         >
           <div>
             <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-600/10">
@@ -2785,7 +2785,7 @@ Like `*`, the `**` variant can be used to style children of an element. The main
       >
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 data-avatar
                 src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
@@ -2802,7 +2802,7 @@ Like `*`, the `**` variant can be used to style children of an element. The main
         </li>
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 data-avatar
                 src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
@@ -2819,7 +2819,7 @@ Like `*`, the `**` variant can be used to style children of an element. The main
         </li>
         <li className="group/item relative flex items-center justify-between rounded-xl p-4 hover:bg-gray-100 dark:hover:bg-white/5">
           <div className="flex gap-4">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <img
                 data-avatar
                 src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"

--- a/src/docs/list-style-position.mdx
+++ b/src/docs/list-style-position.mdx
@@ -34,7 +34,7 @@ Use utilities like `list-inside` and `list-outside` to control the position of t
         </ul>
       </div>
       <div className="relative">
-        <div className="absolute -top-0 -bottom-8 left-8 w-px bg-pink-400/40 sm:-top-8 dark:bg-pink-400/30"></div>
+        <div className="absolute top-0 -bottom-8 left-8 w-px bg-pink-400/40 sm:-top-8 dark:bg-pink-400/30"></div>
         <p className="mb-3 ml-8 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">list-outside</p>
         <ul className="list-outside list-disc rounded-xl p-4 pl-8 text-gray-900 dark:text-gray-200">
           <li>5 cups chopped Porcini mushrooms</li>

--- a/src/docs/mask-clip.mdx
+++ b/src/docs/mask-clip.mdx
@@ -32,19 +32,19 @@ Use utilities like `mask-clip-border`, `mask-clip-padding`, and `mask-clip-conte
       <div className="flex flex-col items-center">
         <p className="mb-3">mask-clip-border</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-border p-1.5"></div>
+          <div className="absolute inset-[-3px] bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-border p-1.5"></div>
         </div>
       </div>
       <div className="flex flex-col items-center">
         <p className="mb-3">mask-clip-padding</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-padding p-1.5"></div>
+          <div className="absolute inset-[-3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-padding p-1.5"></div>
         </div>
       </div>
       <div className="flex flex-col items-center">
         <p className="mb-3">mask-clip-content</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-content p-1.5"></div>
+          <div className="absolute inset-[-3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-clip-content p-1.5"></div>
         </div>
       </div>
     </div>

--- a/src/docs/mask-composite.mdx
+++ b/src/docs/mask-composite.mdx
@@ -27,28 +27,28 @@ Use utilities like `mask-add` and `mask-intersect` to control how an element's m
   {
     <div className="grid grid-cols-2 items-center justify-center justify-items-center gap-y-8 py-4 text-center font-mono text-xs font-medium text-gray-500 max-sm:grid-cols-1 dark:text-gray-400">
       <div className="relative grid justify-center">
-        <div className="absolute right-[calc(5%-2px)] -bottom-[2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
-        <div className="absolute -bottom-[2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute right-[calc(5%-2px)] bottom-[-2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute bottom-[-2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
         <p className="mb-3">mask-add</p>
-        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,_white_100%,transparent_100%),_radial-gradient(ellipse_25%_50%_at_70%_50%,_white_100%,transparent_100%)] bg-cover bg-center mask-add"></div>
+        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,white_100%,transparent_100%),radial-gradient(ellipse_25%_50%_at_70%_50%,white_100%,transparent_100%)] bg-cover bg-center mask-add"></div>
       </div>
       <div className="relative grid justify-center">
-        <div className="absolute right-[calc(5%-2px)] -bottom-[2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
-        <div className="absolute -bottom-[2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute right-[calc(5%-2px)] bottom-[-2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute bottom-[-2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
         <p className="mb-3 text-center">mask-subtract</p>
-        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,_white_100%,transparent_100%),_radial-gradient(ellipse_25%_50%_at_70%_50%,_white_100%,transparent_100%)] bg-cover bg-center mask-subtract"></div>
+        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,white_100%,transparent_100%),radial-gradient(ellipse_25%_50%_at_70%_50%,white_100%,transparent_100%)] bg-cover bg-center mask-subtract"></div>
       </div>
       <div className="relative grid justify-center">
-        <div className="absolute right-[calc(5%-2px)] -bottom-[2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
-        <div className="absolute -bottom-[2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute right-[calc(5%-2px)] bottom-[-2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute bottom-[-2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
         <p className="mb-3 text-center">mask-intersect</p>
-        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,_white_100%,transparent_100%),_radial-gradient(ellipse_25%_50%_at_70%_50%,_white_100%,transparent_100%)] bg-cover bg-center mask-intersect"></div>
+        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,white_100%,transparent_100%),radial-gradient(ellipse_25%_50%_at_70%_50%,white_100%,transparent_100%)] bg-cover bg-center mask-intersect"></div>
       </div>
       <div className="relative grid justify-center">
-        <div className="absolute right-[calc(5%-2px)] -bottom-[2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
-        <div className="absolute -bottom-[2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute right-[calc(5%-2px)] bottom-[-2px] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
+        <div className="absolute bottom-[-2px] left-[calc(5%-2px)] box-content size-24 rounded-full border-2 border-dashed border-black/10 dark:border-white/20" />
         <p className="mb-3 text-center">mask-exclude</p>
-        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,_white_100%,transparent_100%),_radial-gradient(ellipse_25%_50%_at_70%_50%,_white_100%,transparent_100%)] bg-cover bg-center mask-exclude"></div>
+        <div className="h-24 w-48 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-[radial-gradient(ellipse_25%_50%_at_30%_50%,white_100%,transparent_100%),radial-gradient(ellipse_25%_50%_at_70%_50%,white_100%,transparent_100%)] bg-cover bg-center mask-exclude"></div>
       </div>
     </div>
   }
@@ -57,10 +57,10 @@ Use utilities like `mask-add` and `mask-intersect` to control how an element's m
 {/* prettier-ignore */}
 ```html
 <!-- [!code classes:mask-add,mask-subtract,mask-intersect,mask-exclude] -->
-<div class="mask-add mask-[url(/img/circle.png),url(/img/circle.png)] mask-[position:30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
-<div class="mask-subtract mask-[url(/img/circle.png),url(/img/circle.png)] mask-[position:30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
-<div class="mask-intersect mask-[url(/img/circle.png),url(/img/circle.png)] mask-[position:30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
-<div class="mask-exclude mask-[url(/img/circle.png),url(/img/circle.png)] mask-[position:30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
+<div class="mask-add mask-[url(/img/circle.png),url(/img/circle.png)] mask-position-[30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
+<div class="mask-subtract mask-[url(/img/circle.png),url(/img/circle.png)] mask-position-[30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
+<div class="mask-intersect mask-[url(/img/circle.png),url(/img/circle.png)] mask-position-[30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
+<div class="mask-exclude mask-[url(/img/circle.png),url(/img/circle.png)] mask-position-[30%_50%,70%_50%] bg-[url(/img/mountains.jpg)]"></div>
 ```
 
 </Figure>

--- a/src/docs/mask-mode.mdx
+++ b/src/docs/mask-mode.mdx
@@ -53,7 +53,7 @@ Use the `mask-alpha`, `mask-luminance` and `mask-match` utilities to control the
   {
     <div className="mx-5 grid gap-10 text-center font-mono text-xs font-medium text-gray-500 dark:text-gray-400">
       <div>
-        <div className="relative h-[3.625rem]">
+        <div className="relative h-14.5">
           <div className="absolute top-0 left-[50%] -ml-3 flex h-12 flex-col items-center">
             <svg viewBox="0 0 32 34" className="w-7 flex-none text-black drop-shadow-sm dark:stroke-white/10">
               <use href="#gradient-color-stop" />
@@ -74,7 +74,7 @@ Use the `mask-alpha`, `mask-luminance` and `mask-match` utilities to control the
         <p className="mt-3">mask-alpha</p>
       </div>
       <div>
-        <div className="relative h-[3.625rem]">
+        <div className="relative h-14.5">
           <div className="absolute top-0 left-[50%] -ml-3 flex h-12 flex-col items-center">
             <svg viewBox="0 0 32 34" className="w-7 flex-none text-white drop-shadow-sm dark:stroke-white/10">
               <use href="#gradient-color-stop" />

--- a/src/docs/mask-origin.mdx
+++ b/src/docs/mask-origin.mdx
@@ -32,19 +32,19 @@ Use utilities like `mask-origin-border`, `mask-origin-padding`, and `mask-origin
       <div className="flex shrink-0 flex-col items-center">
         <p className="mb-3">mask-origin-border</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-border p-1.5"></div>
+          <div className="absolute inset-[-3px] bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-border p-1.5"></div>
         </div>
       </div>
       <div className="flex shrink-0 flex-col items-center">
         <p className="mb-3">mask-origin-padding</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-padding p-1.5"></div>
+          <div className="absolute inset-[-3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-padding p-1.5"></div>
         </div>
       </div>
       <div className="flex shrink-0 flex-col items-center">
         <p className="mb-3">mask-origin-content</p>
         <div className="relative size-24 rounded-lg border-3 border-dashed border-indigo-500/50 dark:border-indigo-400/75">
-          <div className="absolute -inset-[3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-content p-1.5"></div>
+          <div className="absolute inset-[-3px] rounded-lg border-3 bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=80)] mask-radial-[50%_50%] mask-radial-from-100% bg-cover bg-center mask-no-repeat mask-origin-content p-1.5"></div>
         </div>
       </div>
     </div>

--- a/src/docs/min-block-size.mdx
+++ b/src/docs/min-block-size.mdx
@@ -42,7 +42,7 @@ Use `min-block-<number>` utilities like `min-block-24` and `min-block-64` to set
   {
     <div className="mx-auto flex justify-center">
       <div className="relative flex items-end space-x-4 font-mono text-xs font-bold text-white">
-        <Stripes border className="absolute -inset-x-[5%] w-[110%] rounded-lg block-20" />
+        <Stripes border className="absolute inset-x-[-5%] w-[110%] rounded-lg block-20" />
         <div className="relative flex w-8 items-end justify-center rounded-lg bg-blue-500 block-96">
           <div className="mb-1 transform-[rotate(-90deg)_translate(50%)] text-left text-nowrap">min-block-96</div>
         </div>

--- a/src/docs/min-height.mdx
+++ b/src/docs/min-height.mdx
@@ -42,7 +42,7 @@ Use `min-h-<number>` utilities like `min-h-24` and `min-h-64` to set an element 
   {
     <div className="mx-auto flex justify-center">
       <div className="relative flex items-end space-x-4 font-mono text-xs font-bold text-white">
-        <Stripes border className="absolute -inset-x-[5%] h-20 w-[110%] rounded-lg" />
+        <Stripes border className="absolute inset-x-[-5%] h-20 w-[110%] rounded-lg" />
         <div className="relative flex h-96 w-8 items-end justify-center rounded-lg bg-blue-500">
           <div className="mb-8 -rotate-90 text-left text-nowrap">min-h-96</div>
         </div>

--- a/src/docs/object-position.mdx
+++ b/src/docs/object-position.mdx
@@ -39,7 +39,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-top-left
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top-left ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top-left ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute top-0 left-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -51,7 +51,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-top
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute top-0 -left-6 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -63,7 +63,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-top-right
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-top-right ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-top-right ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute top-0 right-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -75,7 +75,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-left
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-left ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-left ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-6 left-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -87,7 +87,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-center
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-center ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-center ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-6 -left-6 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -99,7 +99,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-right
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-right ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-right ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-6 right-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -111,7 +111,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-bottom-left
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom-left ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom-left ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-12 left-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -123,7 +123,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-bottom
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-12 -left-6 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"
@@ -135,7 +135,7 @@ Use utilities like `object-left` and `object-bottom-right` to specify how a repl
           object-bottom-right
         </p>
         <div className="group relative mx-auto size-20 rounded-lg">
-          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-[size:8rem] bg-bottom-right ring-1 ring-black/10 ring-inset"></div>
+          <div className="relative z-10 h-full w-full rounded-md bg-[url(https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90)] bg-size-[8rem] bg-bottom-right ring-1 ring-black/10 ring-inset"></div>
           <img
             className="absolute -top-12 right-0 size-32 max-w-none overflow-hidden rounded-md opacity-0 transition duration-100 sm:group-hover:opacity-25"
             src="https://images.unsplash.com/photo-1554629947-334ff61d85dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1000&h=1000&q=90"

--- a/src/docs/order.mdx
+++ b/src/docs/order.mdx
@@ -12,7 +12,6 @@ export const description = "Utilities for controlling the order of flex and grid
     ["-order-<number>", "order: calc(<number> * -1);"],
     ["order-first", "order: -9999;"],
     ["order-last", "order: 9999;"],
-    ["order-none", "order: 0;"],
     ["order-(<custom-property>)", "order: var(<custom-property>);"],
     ["order-[<value>]", "order: <value>;"],
   ]}

--- a/src/docs/place-content.mdx
+++ b/src/docs/place-content.mdx
@@ -130,7 +130,7 @@ Use `place-content-between` to distribute grid items along the inline and block 
   {
     <div className="grid grid-cols-1">
       <Stripes border className="col-start-1 row-start-1 rounded-lg" />
-      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] [place-content:space-between] gap-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
+      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] place-content-between gap-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-purple-500 p-4">01</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-purple-500 p-4">02</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-purple-500 p-4">03</div>
@@ -162,7 +162,7 @@ Use `place-content-around` to distribute grid items along the inline and block a
   {
     <div className="grid grid-cols-1">
       <Stripes border className="col-start-1 row-start-1 rounded-lg" />
-      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] [place-content:space-around] gap-x-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
+      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] place-content-around gap-x-4 rounded-lg font-mono text-sm leading-6 font-bold text-white">
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-cyan-500 p-4">01</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-cyan-500 p-4">02</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-cyan-500 p-4">03</div>
@@ -194,7 +194,7 @@ Use `place-content-evenly` to distribute grid items such that they are evenly sp
   {
     <div className="grid grid-cols-1">
       <Stripes border className="col-start-1 row-start-1 rounded-lg" />
-      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] [place-content:space-evenly] rounded-lg font-mono text-sm leading-6 font-bold text-white">
+      <div className="col-start-1 row-start-1 grid h-56 grid-cols-[repeat(2,56px)] place-content-evenly rounded-lg font-mono text-sm leading-6 font-bold text-white">
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-violet-500 p-4">01</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-violet-500 p-4">02</div>
         <div className="flex h-14 w-14 items-center justify-center rounded-lg bg-violet-500 p-4">03</div>

--- a/src/docs/scroll-margin.mdx
+++ b/src/docs/scroll-margin.mdx
@@ -125,35 +125,35 @@ Use the `scroll-ms-<number>` and `scroll-me-<number>` utilities to set the `scro
       <p className="mb-4 pt-8 pl-6 text-sm font-medium">Left-to-right</p>
       <div className="flex w-full snap-x gap-12 overflow-x-auto pb-10" dir="ltr">
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pr-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute start-0 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute inset-s-0 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1604999565976-8913ad2ddb7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pr-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1540206351-d6465b3ac5c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pr-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1622890806166-111d7f6c7c97?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pr-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1590523277543-a94d2e4eb00b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pr-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1575424909138-46b05e5919ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
@@ -163,35 +163,35 @@ Use the `scroll-ms-<number>` and `scroll-me-<number>` utilities to set the `scro
       <p className="mt-4 mb-4 pl-6 text-sm font-medium">Right-to-left</p>
       <div className="flex w-full snap-x gap-12 overflow-x-auto pb-10" dir="rtl">
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pl-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute start-0 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute inset-s-0 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1604999565976-8913ad2ddb7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pl-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1540206351-d6465b3ac5c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pl-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1622890806166-111d7f6c7c97?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pl-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1590523277543-a94d2e4eb00b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"
           />
         </div>
         <div className="relative shrink-0 snap-start scroll-ms-6 first:ps-6 last:pl-[calc(100%-21.5rem)]">
-          <Stripes border className="absolute -start-6 top-0 bottom-0 w-6" />
+          <Stripes border className="absolute -inset-s-6 top-0 bottom-0 w-6" />
           <img
             className="relative h-40 w-80 shrink-0 rounded-lg bg-white"
             src="https://images.unsplash.com/photo-1575424909138-46b05e5919ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=320&h=160&q=80"

--- a/src/docs/scroll-padding.mdx
+++ b/src/docs/scroll-padding.mdx
@@ -110,7 +110,7 @@ Use the `scroll-ps-<number>` and `scroll-pe-<number>` utilities to set the `scro
     <>
       <p className="mb-4 pt-8 pl-6 text-sm font-medium">Left-to-right</p>
       <div className="relative" dir="ltr">
-        <Stripes border className="absolute start-0 top-0 bottom-10 w-6" />
+        <Stripes border className="absolute inset-s-0 top-0 bottom-10 w-6" />
         <div className="flex w-full snap-x scroll-ps-6 gap-8 overflow-x-auto pb-10">
           <div className="shrink-0 snap-start first:ps-6 last:pe-[calc(100%-21.5rem)]">
             <img
@@ -146,7 +146,7 @@ Use the `scroll-ps-<number>` and `scroll-pe-<number>` utilities to set the `scro
       </div>
       <p className="mt-4 mb-4 pl-6 text-sm font-medium">Right-to-left</p>
       <div className="relative" dir="rtl">
-        <Stripes border className="absolute start-0 top-0 bottom-10 w-6" />
+        <Stripes border className="absolute inset-s-0 top-0 bottom-10 w-6" />
         <div className="flex w-full snap-x scroll-ps-6 gap-8 overflow-x-auto pb-10">
           <div className="shrink-0 snap-start first:ps-6 last:pe-[calc(100%-21.5rem)]">
             <img

--- a/src/docs/scroll-snap-align.mdx
+++ b/src/docs/scroll-snap-align.mdx
@@ -156,7 +156,7 @@ Use the `snap-start` utility to snap an element to its start when being scrolled
           />
         </div>
         <div className="shrink-0 snap-start scroll-mx-6">
-          <div className="h-40 w-3 shrink-0 sm:-ml-[2px] sm:w-96"></div>
+          <div className="h-40 w-3 shrink-0 sm:ml-[-2px] sm:w-96"></div>
         </div>
       </div>
     </div>
@@ -207,7 +207,7 @@ Use the `snap-end` utility to snap an element to its end when being scrolled ins
       </div>
       <div className="relative flex w-full snap-x snap-mandatory gap-6 overflow-x-auto pb-14">
         <div className="shrink-0 snap-end scroll-mx-6">
-          <div className="w-3 shrink-0 sm:-mr-[2px] sm:w-10"></div>
+          <div className="w-3 shrink-0 sm:mr-[-2px] sm:w-10"></div>
         </div>
         <div className="shrink-0 snap-end scroll-mx-6">
           <img

--- a/src/docs/scrollbar-gutter.mdx
+++ b/src/docs/scrollbar-gutter.mdx
@@ -41,7 +41,7 @@ Use the `scrollbar-gutter-stable` utility to reserve space for the scrollbar eve
             Hey everyone! It’s almost 2027 and we still don’t know if there are aliens living among us, or do we? Maybe
             the person writing this is an alien. You will never know.
           </p>
-          <div className="absolute top-0 right-0 bottom-0 w-4 rounded-r-lg border bg-[image:repeating-linear-gradient(315deg,currentColor_0,currentColor_1px,transparent_0,transparent_50%)] bg-[size:8px_8px] bg-top-left text-black/10 dark:text-white/12.5"></div>
+          <div className="absolute top-0 right-0 bottom-0 w-4 rounded-r-lg border bg-[repeating-linear-gradient(315deg,currentColor_0,currentColor_1px,transparent_0,transparent_50%)] bg-size-[8px_8px] bg-top-left text-black/10 dark:text-white/12.5"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR bumps Tailwind CSS to the latest version.

It also canonicalizes some of the classes to be up to date with the recommended way of writing these classes.

I did leave the `blog/` related pages alone since they often talk about new features or changes introduced in a version that is documented at that time.

This also removes `order-none` from the order docs because `order-0` is recommended instead. `order-none` still works as backwards compatibility.

This also improves some internal `line-*` related utilities to make sure that we use `@variant before` instead of repeating the `before` variant in the `line-*` utilities to get better output.

Before
```css
.line-t {
  position: relative;
  &::before {
    content: var(--tw-content);
    position: absolute;
  }
  &::before {
    content: var(--tw-content);
    top: 0px;
  }
  &::before {
    content: var(--tw-content);
    left: calc(100vw * -1);
  }
  &::before {
    content: var(--tw-content);
    height: 1px;
  }
  &::before {
    content: var(--tw-content);
    width: 200vw;
  }
  &::before {
    content: var(--tw-content);
    background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
    @supports (color: color-mix(in lab, red, red)) {
      background-color: color-mix(in oklab, var(--color-gray-950, oklch(13% 0.028 261.692)) 5%, transparent);
    }
  }
  &:where(.dark, .dark *) {
    &::before {
      content: var(--tw-content);
      background-color: color-mix(in srgb, #fff 10%, transparent);
      @supports (color: color-mix(in lab, red, red)) {
        background-color: color-mix(in oklab, var(--color-white, #fff) 10%, transparent);
      }
    }
  }
  @media (prefers-color-scheme: dark) {
    &:where(.system, .system *) {
      &::before {
        content: var(--tw-content);
        background-color: color-mix(in srgb, #fff 10%, transparent);
        @supports (color: color-mix(in lab, red, red)) {
          background-color: color-mix(in oklab, var(--color-white, #fff) 10%, transparent);
        }
      }
    }
  }
}
```

After:
```css
.line-t {
  position: relative;
  &::before {
    content: var(--tw-content);
    position: absolute;
    top: 0px;
    left: -100vw;
    height: 1px;
    width: 200vw;
    background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
    @supports (color: color-mix(in lab, red, red)) {
      background-color: color-mix(in oklab, var(--color-gray-950, oklch(13% 0.028 261.692)) 5%, transparent);
    }
  }
  &:where(.dark, .dark *) {
    &::before {
      content: var(--tw-content);
      background-color: color-mix(in srgb, #fff 10%, transparent);
      @supports (color: color-mix(in lab, red, red)) {
        background-color: color-mix(in oklab, var(--color-white, #fff) 10%, transparent);
      }
    }
  }
  @media (prefers-color-scheme: dark) {
    &:where(.system, .system *) {
      &::before {
        content: var(--tw-content);
        background-color: color-mix(in srgb, #fff 10%, transparent);
        @supports (color: color-mix(in lab, red, red)) {
          background-color: color-mix(in oklab, var(--color-white, #fff) 10%, transparent);
        }
      }
    }
  }
}
```

Closes: #2509
