### PR TITLE
Fix path reference in nuxt.config.ts

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
@@ -91,8 +91,10 @@ export let steps: Step[] = [
     title: "Add the CSS file globally",
     body: (
       <p>
-        Add your newly-created <code>./app/assets/css/main.css</code> to the <code>css</code> array in your{" "}
-        <code>nuxt.config.ts</code> file.
+        Add <code>assets/css/main.css</code> to the <code>css</code> array in your{" "}
+        <code>nuxt.config.ts</code>. See{" "}
+        <a href="https://nuxt.com/docs/4.x/api/nuxt-config#alias">the documentation</a>{" "}
+        for more info on valid config paths.
       </p>
     ),
     code: {
@@ -104,8 +106,9 @@ export let steps: Step[] = [
         export default defineNuxtConfig({
           compatibilityDate: "2025-07-15",
           devtools: { enabled: true },
+          // \`assets\` is an alias to <rootDir>/app/assets
           // [!code highlight:2]
-          css: ['./app/assets/css/main.css'],
+          css: ['assets/css/main.css'],
           vite: {
             plugins: [
               tailwindcss(),


### PR DESCRIPTION
# Fix failing Nuxt configuration path reference

When installing Tailwind in Nuxt 4, the guide tells us to add `./app/assets/css/main.css` to the `nuxt.config.ts`. This, however, results in an error:

<img width="628" height="548" alt="image" src="https://github.com/user-attachments/assets/7b88c154-1229-45de-a8eb-fc28a636fb02" />
<img width="810" height="304" alt="image" src="https://github.com/user-attachments/assets/35f9e745-8a0e-4f69-9093-fa9b86942292" />
_(I apologize in advance for the light theme)_

## The fix

Did some tests and it seems `./` defaults to inside the `app/` directory. Changing to `./assets/css/main.css` (`app/` removed) fixed the problem. Using `~/assets/css/main.css` and `assets/css/main.css` also work, and it's actually a little more idiomatic:

<img width="831" height="540" alt="image" src="https://github.com/user-attachments/assets/c6ecd6a7-ada4-4de5-877c-d5d96f0acc14" />

See [official docs](https://nuxt.com/docs/4.x/api/nuxt-config#alias).

## Notes

I deliberately rephrased the instruction so I could fit a reference to the Nuxt docs + added a comment to the code snippet explaining that `assets` is an alias.

Please let me know whether you think that makes sense or if you want to request some changes.
