### PR TITLE
Update default --font-sans stack to match v4.3.3

### DIFF
--- a/src/docs/font-family.mdx
+++ b/src/docs/font-family.mdx
@@ -10,7 +10,7 @@ export const description = "Utilities for controlling the font family of an elem
   rows={[
     [
       "font-sans",
-      "font-family: var(--font-sans); /* ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' */",
+      "font-family: var(--font-sans); /* -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' */",
     ],
     ["font-serif", "font-family: var(--font-serif); /* ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif */"],
     [

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -70,7 +70,7 @@ For example, theme variables defined in the `--font-*` namespace determine all o
 @theme {
   /* [!code highlight:4] */
   /* prettier-ignore */
-  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   /* prettier-ignore */
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -330,7 +330,7 @@ That `theme.css` file includes the default color palette, type scale, shadows, f
 /* [!code filename:node_modules/tailwindcss/theme.css] */
 @theme {
   /* prettier-ignore */
-  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
@@ -570,7 +570,7 @@ All of your theme variables are turned into regular CSS variables when you compi
 /* [!code filename:dist.css] */
 :root {
   /* prettier-ignore */
-  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
@@ -672,7 +672,7 @@ For reference, here's a complete list of the theme variables included by default
 /* [!code filename:tailwindcss/theme.css] */
 @theme {
   /* prettier-ignore */
-  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 


### PR DESCRIPTION
Tailwind CSS v4.3.3 changed the default `--font-sans` value to fix broken character rendering on Windows with CJK locales (tailwindlabs/tailwindcss#20318), but the docs still show the previous`ui-sans-serif, system-ui, sans-serif` stack.

Update the `font-family` quick reference and the four `theme.css`examples on the theme page to match the stack that actually ships (tailwindlabs/tailwindcss/packages/tailwindcss/theme.css).

Reported in tailwindlabs/tailwindcss#20348.