### PR TITLE
Add missing `gap-px` docs

### DIFF
--- a/src/docs/border-spacing.mdx
+++ b/src/docs/border-spacing.mdx
@@ -9,12 +9,15 @@ export const description = "Utilities for controlling the spacing between table 
 <ApiTable
   rows={[
     ["border-spacing-<number>", "border-spacing: calc(var(--spacing) * <number>);"],
+    ["border-spacing-px", "border-spacing: 1px;"],
     ["border-spacing-(<custom-property>)", "border-spacing: var(<custom-property>);"],
     ["border-spacing-[<value>]", "border-spacing: <value>;"],
     ["border-spacing-x-<number>", "border-spacing: calc(var(--spacing) * <number>) var(--tw-border-spacing-y);"],
+    ["border-spacing-x-px", "border-spacing: 1px var(--tw-border-spacing-y);"],
     ["border-spacing-x-(<custom-property>)", "border-spacing: var(<custom-property>) var(--tw-border-spacing-y);"],
     ["border-spacing-x-[<value>]", "border-spacing: <value> var(--tw-border-spacing-y);"],
     ["border-spacing-y-<number>", "border-spacing: var(--tw-border-spacing-x) calc(var(--spacing) * <number>);"],
+    ["border-spacing-y-px", "border-spacing: var(--tw-border-spacing-x) 1px;"],
     ["border-spacing-y-(<custom-property>)", "border-spacing: var(--tw-border-spacing-x) var(<custom-property>);"],
     ["border-spacing-y-[<value>]", "border-spacing: var(--tw-border-spacing-x) <value>;"],
   ]}

--- a/src/docs/flex-basis.mdx
+++ b/src/docs/flex-basis.mdx
@@ -12,6 +12,7 @@ export const description = "Utilities for controlling the initial size of flex i
     ["basis-<fraction>", "flex-basis: calc(<fraction> * 100%);"],
     ["basis-full", "flex-basis: 100%;"],
     ["basis-auto", "flex-basis: auto;"],
+    ["basis-px", "flex-basis: 1px;"],
     ["basis-3xs", "flex-basis: var(--container-3xs); /* 16rem (256px) */"],
     ["basis-2xs", "flex-basis: var(--container-2xs); /* 18rem (288px) */"],
     ["basis-xs", "flex-basis: var(--container-xs); /* 20rem (320px) */"],

--- a/src/docs/gap.mdx
+++ b/src/docs/gap.mdx
@@ -10,12 +10,15 @@ export const description = "Utilities for controlling gutters between grid and f
 <ApiTable
   rows={[
     ["gap-<number>", "gap: calc(var(--spacing) * <value>);"],
+    ["gap-px", "gap: 1px;"],
     ["gap-(<custom-property>)", "gap: var(<custom-property>);"],
     ["gap-[<value>]", "gap: <value>;"],
     ["gap-x-<number>", "column-gap: calc(var(--spacing) * <value>);"],
+    ["gap-x-px", "column-gap: 1px;"],
     ["gap-x-(<custom-property>)", "column-gap: var(<custom-property>);"],
     ["gap-x-[<value>]", "column-gap: <value>;"],
     ["gap-y-<number>", "row-gap: calc(var(--spacing) * <value>);"],
+    ["gap-y-px", "row-gap: 1px;"],
     ["gap-y-(<custom-property>)", "row-gap: var(<custom-property>);"],
     ["gap-y-[<value>]", "row-gap: <value>;"],
   ]}

--- a/src/docs/scroll-margin.mdx
+++ b/src/docs/scroll-margin.mdx
@@ -23,6 +23,8 @@ export const description = "Utilities for controlling the scroll offset around i
   ].flatMap(([prefix, property]) => [
     [`${prefix}-<number>`, `${property}: calc(var(--spacing) * <number>);`],
     [`-${prefix}-<number>`, `${property}: calc(var(--spacing) * -<number>);`],
+    [`${prefix}-px`, `${property}: 1px;`],
+    [`-${prefix}-px`, `${property}: -1px;`],
     [`${prefix}-(<custom-property>)`, `${property}: var(<custom-property>);`],
     [`${prefix}-[<value>]`, `${property}: <value>;`],
   ])}

--- a/src/docs/scroll-padding.mdx
+++ b/src/docs/scroll-padding.mdx
@@ -212,17 +212,6 @@ Use the `scroll-pbs-<number>` and `scroll-pbe-<number>` utilities to set the `sc
 </div>
 ```
 
-### Using negative values
-
-To use a negative scroll padding value, prefix the class name with a dash to convert it to a negative value:
-
-```html
-<!-- [!code classes:-scroll-ps-6] -->
-<div class="-scroll-ps-6 snap-x ...">
-  <!-- ... -->
-</div>
-```
-
 ### Using a custom value
 
 <UsingACustomValue

--- a/src/docs/scroll-padding.mdx
+++ b/src/docs/scroll-padding.mdx
@@ -22,7 +22,6 @@ export const description = "Utilities for controlling an element's scroll offset
     ["scroll-pl", "scroll-padding-left"],
   ].flatMap(([prefix, property]) => [
     [`${prefix}-<number>`, `${property}: calc(var(--spacing) * <number>);`],
-    [`-${prefix}-<number>`, `${property}: calc(var(--spacing) * -<number>);`],
     [`${prefix}-px`, `${property}: 1px;`],
     [`${prefix}-(<custom-property>)`, `${property}: var(<custom-property>);`],
     [`${prefix}-[<value>]`, `${property}: <value>;`],

--- a/src/docs/scroll-padding.mdx
+++ b/src/docs/scroll-padding.mdx
@@ -23,6 +23,7 @@ export const description = "Utilities for controlling an element's scroll offset
   ].flatMap(([prefix, property]) => [
     [`${prefix}-<number>`, `${property}: calc(var(--spacing) * <number>);`],
     [`-${prefix}-<number>`, `${property}: calc(var(--spacing) * -<number>);`],
+    [`${prefix}-px`, `${property}: 1px;`],
     [`${prefix}-(<custom-property>)`, `${property}: var(<custom-property>);`],
     [`${prefix}-[<value>]`, `${property}: <value>;`],
   ])}


### PR DESCRIPTION
This PR adds some missing docs for `*-px` related utilities:

- Add missing `gap-px`, `gap-x-px` and `gap-y-px`
- Add missing `border-spacing-px`, `border-spacing-x-px` and `border-spacing-y-px`
- Add missing `basis-px`
- Add missing `scroll-m-px` and `-scroll-m-px`
- Add missing `scroll-p-px`**

While looking at the `scroll-p-*` docs, also noticed that we had docs for `-scroll-p-*` but those utilities don't really exist, so let's get rid of them.

Fixes: #2516

