### PR TITLE
docs: use Nuxt alias ~/assets for Tailwind CSS

### DIFF
--- a/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
@@ -105,7 +105,7 @@ export let steps: Step[] = [
           compatibilityDate: "2025-07-15",
           devtools: { enabled: true },
           // [!code highlight:2]
-          css: ['./app/assets/css/main.css'],
+          css: ['~/app/assets/css/main.css'],
           vite: {
             plugins: [
               tailwindcss(),

--- a/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
+++ b/src/app/(docs)/docs/installation/framework-guides/nuxtjs.tsx
@@ -105,7 +105,7 @@ export let steps: Step[] = [
           compatibilityDate: "2025-07-15",
           devtools: { enabled: true },
           // [!code highlight:2]
-          css: ['~/app/assets/css/main.css'],
+          css: ['~/assets/css/main.css'],
           vite: {
             plugins: [
               tailwindcss(),


### PR DESCRIPTION
This resolves issue #2515, 

Modern versions of Nuxt use the `~` alias to refer to the application directory, and using relative paths like `./` is no longer supported for this configuration. 

This PR updates the setup instructions from:
```
css: ['./app/assets/css/main.css']
```
to
```
css: ['~/assets/css/main.css'],
```
