### PR TITLE
Document all @import options on functions and directives page

### DIFF
--- a/src/docs/functions-and-directives.mdx
+++ b/src/docs/functions-and-directives.mdx
@@ -27,7 +27,7 @@ When importing Tailwind (or its individual stylesheets), you can pass options af
 @import "tailwindcss" important;
 @import "tailwindcss" prefix(tw);
 @import "tailwindcss" source("../src");
-@import "tailwindcss" theme(reference);
+@import "tailwindcss/theme.css" theme(reference);
 @import "tailwindcss" reference;
 @import "tailwindcss/utilities.css" layer(utilities);
 ```

--- a/src/docs/functions-and-directives.mdx
+++ b/src/docs/functions-and-directives.mdx
@@ -18,6 +18,33 @@ Use the `@import` directive to inline import CSS files, including Tailwind itsel
 @import "tailwindcss";
 ```
 
+### `@import` options
+
+When importing Tailwind (or its individual stylesheets), you can pass options after the path:
+
+```css
+/* [!code filename:CSS] */
+@import "tailwindcss" important;
+@import "tailwindcss" prefix(tw);
+@import "tailwindcss" source("../src");
+@import "tailwindcss" theme(reference);
+@import "tailwindcss" reference;
+@import "tailwindcss/utilities.css" layer(utilities);
+```
+
+- Use `important` to mark all utilities as `!important`, or `prefix(…)` to namespace generated utilities and theme CSS variables — see [styling with utility classes](/docs/styling-with-utility-classes#using-the-important-flag).
+- Use `source(…)` to set the base path for automatic source detection, or `source(none)` to disable it — see [detecting classes in source files](/docs/detecting-classes-in-source-files#setting-your-base-path).
+- Use `theme(…)` to control how theme variables are emitted, for example `theme(reference)`, `theme(static)`, or `theme(inline)`.
+- Use `reference` to import styles for reference only without emitting CSS (same idea as [`@reference`](#reference-directive)).
+- Use `layer(…)` to place the imported styles in a [cascade layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@import#layer_name), which is especially useful when [importing Tailwind’s stylesheets individually](/docs/preflight#disabling-preflight).
+
+These options can also be combined on a single import when needed:
+
+```css
+/* [!code filename:CSS] */
+@import "tailwindcss" source(none) prefix(tw);
+```
+
 <h3 id="theme-directive">
   <a href="#theme-directive">@theme</a>
 </h3>


### PR DESCRIPTION
## Summary
- Document the full set of options that can be passed to `@import` (`important`, `prefix()`, `source()`, `theme()`, `reference`, and `layer()`) on the [functions and directives](https://tailwindcss.com/docs/functions-and-directives#import-directive) page.
- Link out to the existing deeper guides for important/prefix, source detection, and individual stylesheet imports so this page is the central reference without duplicating those docs.

Fixes #2514

## Test plan
- [ ] Preview the Functions and directives page and confirm the new `@import` options section renders correctly
- [ ] Click through the linked anchors (important flag, source base path, disabling Preflight, `@reference`)
- [ ] Spot-check that the example snippets match supported option syntax
